### PR TITLE
Fix pack ice

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -124,7 +124,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || { builtin print -P "${ZINIT
     local user=$1 pkg=$2 plugin=$2 id_as=$3 dir=$4 profile=$5 \
         local_path=${ZINIT[PLUGINS_DIR]}/${3//\//---} pkgjson \
         tmpfile=${$(mktemp):-${TMPDIR:-/tmp}/zsh.xYzAbc123} \
-        URL=https://raw.githubusercontent.com/zdharma-continum/zinit-package-$2/main/package.json
+        URL=https://raw.githubusercontent.com/zdharma-continuum/zinit-package-$2/main/package.json
 
     local pro_sep="{rst}, {profile}" epro_sep="{error}, {profile}" \
         tool_sep="{rst}, {cmd}" \

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -124,7 +124,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || { builtin print -P "${ZINIT
     local user=$1 pkg=$2 plugin=$2 id_as=$3 dir=$4 profile=$5 \
         local_path=${ZINIT[PLUGINS_DIR]}/${3//\//---} pkgjson \
         tmpfile=${$(mktemp):-${TMPDIR:-/tmp}/zsh.xYzAbc123} \
-        URL=https://raw.githubusercontent.com/Zsh-Packages/$2/master/package.json
+        URL=https://raw.githubusercontent.com/zdharma-continum/zinit-package-$2/main/package.json
 
     local pro_sep="{rst}, {profile}" epro_sep="{error}, {profile}" \
         tool_sep="{rst}, {cmd}" \


### PR DESCRIPTION
So, since Zsh-Packages no longer exists I suggest we host the packages under the zdharma-continuum org.
I created https://github.com/zdharma-continuum/zsh-package-zsh for example.

Here's what I changed in a nutshell:

- the `pack` ice will look for packages in `zdharma-continuum/zsh-package-${PACKAGE_NAME}`
- Also I updated the default branch for these packages to main (this is debatable but since there

Fixes #3 