### PR TITLE
Announce zdharma-continuum in CHANGELOG

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,6 +9,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+* 06-11-2021
+  - 🚧 zinit has a new home: https://github.com/zdharma-continuum/zinit
+    - The migration from @zdharma, @Zsh-Packages and @zinit-zsh is still in
+progress. If you are interested in helping or want to let us know that a
+particular project is missing, please head to
+[I_WANT_TO_HELP](https://github.com/zdharma-continuum/I_WANT_TO_HELP/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc)
+
 * 21-01-2020
   - A few tips for the project rename following the field reports (the issues created
     by users):


### PR DESCRIPTION
Honk, honk.

As mentioned in #12 we really should be announcing our new home address in the changelog.
Let me know if you think this needs to be worded differently.