### PR TITLE
fix: read without -r is generally bad.

### DIFF
--- a/doc/install.sh
+++ b/doc/install.sh
@@ -106,7 +106,7 @@ echo "[38;5;219m▓▒░[0m Would you like to add 4 useful plugins" \
     "It will be the following snippet:"
     command cat "$file"
     echo -n "[38;5;219m▓▒░[0m Enter y/n and press Return: "
-    read input
+    read -r input
     if [ "$input" = y ] || [ "$input" = Y ]; then
         command cat "$file" >> "$THE_ZDOTDIR"/.zshrc
         echo


### PR DESCRIPTION
The yes/no prompt doesn't need backslash escaped characters.

From z-shell/zinit#3