### PR TITLE
fix: use [*] inside arbitrary strings.

### DIFF
--- a/share/deploy_doc.sh
+++ b/share/deploy_doc.sh
@@ -53,8 +53,8 @@ cd out
 
 # No changes?
 if git diff --quiet --exit-code && [[ "${#LIST_ORIGINAL}" -eq "${#LIST_NEW}" ]]; then
-    echo -- "<- ${LIST_ORIGINAL[@]}"
-    echo -- "-> ${LIST_NEW[@]}"
+    echo -- "<- ${LIST_ORIGINAL[*]}"
+    echo -- "-> ${LIST_NEW[*]}"
     echo "NO CHANGES, exiting"
     exit 0
 fi


### PR DESCRIPTION
Only use `[@]` as only content of a string. e.g., "${foo[@]}"

From z-shell/zinit#5