### PR TITLE
No more name calling

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,11 @@
 
 [![MIT License][mit-badge]][mit-link] [![][ver-badge]][ver-link] [![Join the chat at https://gitter.im/zdharma-continuum/zinit][gitter-badge]][gitter-link]
 
-> **Note**: [Sebastian Gniazdowski](https://github.com/psprint), the original `zinit` dev, deleted `zdharma` randomly. 
+> **Note**: [The original author](https://github.com/psprint) of zinit deleted the `zdharma` organization randomly.
+>
 > This is a reliable fork / place for the continuation of the project.
 >
-> 🚧 For migration instructions please refer [to this wiki entry](https://github.com/zdharma-continuum/zinit/wiki/Migration-to-zdharma-continuum) 
+> 🚧 For migration instructions please refer [to this wiki entry](https://github.com/zdharma-continuum/zinit/wiki/Migration-to-zdharma-continuum)
 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 


### PR DESCRIPTION
I don't think its fair to have psprint's real name hilighted so prominently in
the disclaimer.

Sure, we can link to his profile - if he decides to put his real name on there
that's his choice. Anyway, we shouldn't make this decision for him. We
aren't at war with the poor guy.
