### PR TITLE
✂ Remove custom git config for new plugins

### DIFF
--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -3029,14 +3029,6 @@ autoload -Uz template-script
 # vim:ft=zsh:tw=80:sw=4:sts=4:et:foldmarker=[[[,]]]
 EOF
 
-    command cat >>! .git/config <<EOF
-
-[diff "zsh"]
-    xfuncname = "^((function[[:blank:]]+[^[:blank:]]+[[:blank:]]*(\\\\(\\\\)|))|([^[:blank:]]+[[:blank:]]*\\\\(\\\\)))[[:blank:]]*(\\\\{|)[[:blank:]]*$"
-[diff "markdown"]
-    xfuncname = "^#+[[:blank:]].*$"
-EOF
-
     builtin print -r -- "# $plugin" >! "README.md"
     command cp -vf "${ZINIT[BIN_DIR]}/LICENSE" LICENSE
     command cp -vf "${ZINIT[BIN_DIR]}/share/template-plugin/zsh.gitignore" .gitignore


### PR DESCRIPTION
Follow-up to https://github.com/zdharma-continuum/zinit/pull/82

Above PR removed the custom `.gitattributes`, this get rid of the related 
custom git config.

Refs:
- #36
