### PR TITLE
🚚 module: Get rid of the zdmodules/ dir

### DIFF
--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -3305,8 +3305,7 @@ EOF
               builtin print -r "error-report at: https://github.com/zdharma-continuum/zinit-module/issues"
         else
             builtin print -r "To load the module, add following 2 lines to .zshrc, at top:"
-            # TODO: Update when we move the C code source to the main dir of the repo
-            builtin print -r "    module_path+=( \"${ZINIT[MODULE_DIR]}/zmodules/Src\" )"
+            builtin print -r "    module_path+=( \"${ZINIT[MODULE_DIR]}/Src\" )"
             builtin print -r "    zmodload zdharma_continuum/zinit"
             builtin print -r ""
             builtin print -r "After loading, use command \`zpmod' to communicate with the module."
@@ -3340,7 +3339,7 @@ EOF
             return 1
         }
     fi
-    ( builtin cd -q "${ZINIT[MODULE_DIR]}/zmodules"  # TODO: Move the source of the module to the root of the repo
+    ( builtin cd -q "${ZINIT[MODULE_DIR]}"
       +zinit-message "{pname}== Building module zdharma-continuum/zinit-module, running: make clean, then ./configure and then make =={rst}"
       +zinit-message "{pname}== The module sources are located at: "${ZINIT[MODULE_DIR]}" =={rst}"
       if [[ -f Makefile ]] {

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -3330,16 +3330,16 @@ EOF
 .zinit-build-module() {
     setopt localoptions localtraps
     trap 'return 1' INT TERM
-    if command git -C "${ZINIT[MODULE_DIR]}" rev-parse 2>/dev/null {
+    if command git -C "${ZINIT[MODULE_DIR]}" rev-parse 2>/dev/null; then
         command git -C "${ZINIT[MODULE_DIR]}" clean -d -f -f
         command git -C "${ZINIT[MODULE_DIR]}" reset --hard HEAD
         command git -C "${ZINIT[MODULE_DIR]}" pull
-    } || {
+    else
         command git clone "https://github.com/zdharma-continuum/zinit-module.git" "${ZINIT[MODULE_DIR]}" || {
             builtin print "${ZINIT[col-error]}Failed to clone module repo${ZINIT[col-rst]}"
             return 1
         }
-    }
+    fi
     ( builtin cd -q "${ZINIT[MODULE_DIR]}/zmodules"  # TODO: Move the source of the module to the root of the repo
       +zinit-message "{pname}== Building module zdharma-continuum/zinit-module, running: make clean, then ./configure and then make =={rst}"
       +zinit-message "{pname}== The module sources are located at: "${ZINIT[MODULE_DIR]}" =={rst}"

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -3330,9 +3330,15 @@ EOF
 .zinit-build-module() {
     setopt localoptions localtraps
     trap 'return 1' INT TERM
-    command git clone "https://github.com/zdharma-continuum/zinit-module.git" "${ZINIT[MODULE_DIR]}" || {
-        builtin print "${ZINIT[col-error]}Failed to clone module repo${ZINIT[col-rst]}"
-        return 1
+    if command git -C "${ZINIT[MODULE_DIR]}" rev-parse 2>/dev/null {
+        command git -C "${ZINIT[MODULE_DIR]}" clean -d -f -f
+        command git -C "${ZINIT[MODULE_DIR]}" reset --hard HEAD
+        command git -C "${ZINIT[MODULE_DIR]}" pull
+    } || {
+        command git clone "https://github.com/zdharma-continuum/zinit-module.git" "${ZINIT[MODULE_DIR]}" || {
+            builtin print "${ZINIT[col-error]}Failed to clone module repo${ZINIT[col-rst]}"
+            return 1
+        }
     }
     ( builtin cd -q "${ZINIT[MODULE_DIR]}/zmodules"  # TODO: Move the source of the module to the root of the repo
       +zinit-message "{pname}== Building module zdharma-continuum/zinit-module, running: make clean, then ./configure and then make =={rst}"
@@ -3351,7 +3357,7 @@ EOF
       CPPFLAGS=-I/usr/local/include CFLAGS="-g -Wall -O3" LDFLAGS=-L/usr/local/lib ./configure --disable-gdbm --without-tcsetpgrp && {
           noglob +zinit-message {p}-- make --{rst}
           if { make } {
-            [[ -f Src/zdharma-continuum/zinit.so ]] && cp -vf Src/zdharma-continuum/zinit.{so,bundle}
+            [[ -f Src/zdharma_continuum/zinit.so ]] && cp -vf Src/zdharma_continuum/zinit.{so,bundle}
             noglob +zinit-message "{info}Module has been built correctly.{rst}"
             .zinit-module info
           } else {


### PR DESCRIPTION
🚧 Do not merge yet!

This depends on both: 
- https://github.com/zdharma-continuum/zinit-module/pull/1 
- https://github.com/zdharma-continuum/zinit/pull/86

Changes introduced:

- 🚚 Update module path. I'm planning on moving to the root dir inside the zinit-module dir. This will shorten the module path by one level (no more `module/zmodules`, only `module`)