### PR TITLE
Move ZINIT[MAN_DIR] creation to .zinit-prepare-home

### DIFF
--- a/zinit.zsh
+++ b/zinit.zsh
@@ -93,9 +93,6 @@ export ZPFX=${~ZPFX} ZSH_CACHE_DIR="${ZSH_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.ca
 [[ ! -d $ZSH_CACHE_DIR ]] && command mkdir -p "$ZSH_CACHE_DIR"
 [[ -n ${ZINIT[ZCOMPDUMP_PATH]} ]] && ZINIT[ZCOMPDUMP_PATH]=${~ZINIT[ZCOMPDUMP_PATH]}
 
-# Create ZINIT[MAN_DIR]/man{1..9}
-[[ ! -d ${~ZINIT[MAN_DIR]} ]] && command mkdir -p ${~ZINIT[MAN_DIR]}/man{1..9}
-
 ZINIT[UPAR]=";:^[[A;:^[OA;:\\e[A;:\\eOA;:${termcap[ku]/$'\e'/^\[};:${terminfo[kcuu1]/$'\e'/^\[};:"
 ZINIT[DOWNAR]=";:^[[B;:^[OB;:\\e[B;:\\eOB;:${termcap[kd]/$'\e'/^\[};:${terminfo[kcud1]/$'\e'/^\[};:"
 ZINIT[RIGHTAR]=";:^[[C;:^[OC;:\\e[C;:\\eOC;:${termcap[kr]/$'\e'/^\[};:${terminfo[kcuf1]/$'\e'/^\[};:"
@@ -1244,6 +1241,10 @@ builtin setopt noaliases
 
         # Also set up */bin and ZPFX in general.
         command mkdir 2>/dev/null -p $ZPFX/bin
+    }
+    [[ ! -d ${~ZINIT[MAN_DIR]}/man9 ]] && {
+        # Create ZINIT[MAN_DIR]/man{1..9}
+        command mkdir 2>/dev/null -p ${~ZINIT[MAN_DIR]}/man{1..9}
     }
 } # ]]]
 # FUNCTION: .zinit-load-object. [[[


### PR DESCRIPTION
It makes more sense to have it there, since this is the function that is responsible for create all the other dirs.