### PR TITLE
XDG compliance: `ZINIT[HOME_DIR]` no longer defaults to `HOME/.zinit` but to `XDG_DATA_HOME/zinit`

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,6 +9,17 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+* 20-11-2021
+  - zinit is now [XDG compliant](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html).
+This means that the default value of `ZINIT[HOME_DIR]` is now
+`XDG_DATA_HOME/zinit`, ie `HOME/.local/share/zinit`, we won't clutter your
+`HOME` anymore! Fear not though: if you update zinit without moving your
+config to the new default location it will still fall back to `HOME/.zinit` if
+this directory exists. In the same spirit, if you overrode `ZINIT[HOME_DIR]`
+yourself in your `zshrc` we will use that value instead.
+NOTE: Since its rewrite the installer has been installing zinit's repo to
+`XDG_DATA_HOME/zinit/zinit.git` (see 16-11-2021 entry)
+
 * 18-11-2021
   - The packages (`zinit pack`) have all been migrated to
 [a new repository](https://github.com/zdharma-continuum/zinit-packages). Nothing
@@ -19,7 +30,7 @@ For more information, please refer to
 [this issue](https://github.com/zdharma-continuum/zinit/issues/69) and/or to
 [the corresponding PR](https://github.com/zdharma-continuum/zinit/pull/75)
 
-  - The zinit module has been relocated to 
+  - The zinit module has been relocated to
 [its own repository](https://github.com/zdharma-continuum/zinit-module)
 
 * 17-11-2021

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -41,8 +41,10 @@ fi
 
 # User can override ZINIT[HOME_DIR].
 if [[ -z ${ZINIT[HOME_DIR]} ]]; then
-    # Ignore ZDOTDIR if user manually put Zinit to $HOME.
-    if [[ -d $HOME/.zinit ]]; then
+    # Search for zinit home in the usual locations
+    if [[ -d ${XDG_DATA_HOME:-${HOME}/.local/share}/zinit ]]; then
+        ZINIT[HOME_DIR]="${XDG_DATA_HOME:-${HOME}/.local/share}/zinit"
+    elif [[ -d $HOME/.zinit ]]; then
         ZINIT[HOME_DIR]="$HOME/.zinit"
     elif [[ -d ${ZDOTDIR:-$HOME}/.zinit ]]; then
         ZINIT[HOME_DIR]="${ZDOTDIR:-$HOME}/.zinit"

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -53,7 +53,7 @@ if [[ -z ${ZINIT[HOME_DIR]} ]]; then
     elif [[ -d ${ZDOTDIR:-$HOME}/.zplugin ]]; then
         ZINIT[HOME_DIR]="${ZDOTDIR:-$HOME}/.zplugin"
     else
-        ZINIT[HOME_DIR]="${ZDOTDIR:-$HOME}/.zinit"
+        ZINIT[HOME_DIR]="${XDG_DATA_HOME:-${HOME}/.local/share}/zinit"
     fi
 fi
 


### PR DESCRIPTION
We updated the installer to install to `XDG_DATA_HOME/zinit`, but never updated zinit itself to actually look for its home dir in there.

Note that this also updates the default value `ZINIT[HOME_DIR]` if none of these paths exists to `XDG_DATA_HOME/zinit` (instead of `HOME/.zinit`).
Epic victory royale for the XDG gang.

Refs:
- #61 