### PR TITLE
Shorten install url

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ read it to get the most out of Zinit.
 The easiest way to install Zinit is to execute:
 
 ```zsh
-sh -c "$(curl -fsSL https://raw.githubusercontent.com/zdharma-continuum/zinit/HEAD/scripts/install.sh)"
+sh -c "$(curl -fsSL https://git.io/zinit-install)"
 ```
 
 This will install Zinit in `~/.local/share/zinit/zinit.git`.

--- a/doc/zinit.1
+++ b/doc/zinit.1
@@ -203,7 +203,7 @@ The easiest way to install Zinit is to execute:
 .IP
 .nf
 \f[C]
-sh -c \[dq]$(curl -fsSL https://raw.githubusercontent.com/zdharma-continuum/zinit/HEAD/scripts/install.sh)\[dq]
+sh -c \[dq]$(curl -fsSL https://git.io/zinit-install)\[dq]
 \f[R]
 .fi
 .PP


### PR DESCRIPTION
The install instructions are now shorter!

```zsh
sh -c "$(curl -fsSL https://git.io/zinit-install)"
```