### PR TITLE
🐳 Add annexes to container

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ ENV PUSERNAME=${PUSERNAME} PUID=${PUID} PGID=${PGID} \
      TERM=${TERM} ZINIT_ZSH_VERSION=${ZINIT_ZSH_VERSION}
 
 RUN apk --no-cache --virtual base add \
-        zsh curl git libuser sudo && \
+        zsh curl git libuser sudo rsync && \
     apk --no-cache --virtual build-tools add \
         build-base autoconf ncurses-dev bash go
 
@@ -19,8 +19,8 @@ RUN sed -ir 's#^(root:.+):/bin/ash#\1:/bin/zsh#' /etc/passwd && \
     adduser -D -s /bin/zsh -u "${PUID}" -h "/home/${PUSERNAME}" \
         "${PUSERNAME}" && \
     printf "${PUSERNAME} ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/user && \
-    mkdir -p /src /data && \
-    chown -R "${PUID}:${PGID}" /data && \
+    mkdir -p /src /data /data-static && \
+    chown -R "${PUID}:${PGID}" /data /data-static && \
     ln -sfv /src/docker/zshenv /home/${PUSERNAME}/.zshenv && \
     ln -sfv /src/docker/zshrc /home/${PUSERNAME}/.zshrc
 
@@ -33,8 +33,7 @@ USER ${PUSERNAME}
 
 # Fetch keys config and store it outside of ZINIT[HOME_DIR] since it might get
 # overridden at runtime (the /data volume)
-RUN zsh -ils -c -- '@zinit-scheduler burst' && \
-    cp -vf /data/snippets/OMZL::key-bindings.zsh/OMZL::key-bindings.zsh \
-        /home/${PUSERNAME}/OMZL::key-bindings.zsh
+RUN ZINIT_HOME_DIR=/data-static ZSH_NO_INIT=1 \
+    zsh -ils -c -- '@zinit-scheduler burst'
 
 CMD ["/bin/zsh"]

--- a/docker/init.zsh
+++ b/docker/init.zsh
@@ -1,0 +1,15 @@
+# Fix permissions on /data
+if [[ -z "$QUIET" ]]
+then
+  echo "Setting owner of /data to ${PUID}:${PGID}" >&2
+fi
+
+sudo chown "${PUID}:${PGID}" /data
+sudo chown -R "${PUID}:${PGID}" /data
+
+# sync files between /data-static and /data
+if [[ -z "$QUIET" ]]
+then
+  echo "Copying files from /data-static to /data" >&2
+fi
+rsync -raq /data-static/ /data

--- a/docker/init.zsh
+++ b/docker/init.zsh
@@ -8,8 +8,11 @@ sudo chown "${PUID}:${PGID}" /data
 sudo chown -R "${PUID}:${PGID}" /data
 
 # sync files between /data-static and /data
-if [[ -z "$QUIET" ]]
+if [[ -z "$NOTHING_FANCY" ]]
 then
-  echo "Copying files from /data-static to /data" >&2
+  if [[ -z "$QUIET" ]]
+  then
+    echo "Copying files from /data-static to /data" >&2
+  fi
+  rsync -raq /data-static/ /data
 fi
-rsync -raq /data-static/ /data

--- a/docker/utils.zsh
+++ b/docker/utils.zsh
@@ -5,14 +5,7 @@ zinit::setup() {
 }
 
 zinit::setup-keys() {
-  local file="${HOME}/OMZL::key-bindings.zsh"
-
-  if [[ -r "$file" ]]
-  then
-    source "$file"
-  else
-    zinit snippet OMZL::key-bindings.zsh
-  fi
+  zinit snippet OMZL::key-bindings.zsh
 }
 
 zinit::setup-annexes() {

--- a/docker/zshenv
+++ b/docker/zshenv
@@ -4,5 +4,7 @@
 export TERM=${TERM:-xterm-256color}
 typeset -Ag ZINIT
 
-export ZINIT[HOME_DIR]=/data
+# ZINIT_HOME_DIR is used at build time to force the installation of plugins
+# etc to /data-static
+export ZINIT[HOME_DIR]=${ZINIT_HOME_DIR:-/data}
 export ZINIT[BIN_DIR]=/src

--- a/docker/zshrc
+++ b/docker/zshrc
@@ -6,6 +6,8 @@ fi
 
 # load zinit
 source /src/zinit.zsh
+autoload -Uz _zinit
+(( ${+_comps} )) && _comps[zinit]=_zinit
 
 # load zinit setup utility functions
 source /src/docker/utils.zsh

--- a/docker/zshrc
+++ b/docker/zshrc
@@ -1,12 +1,7 @@
-# Fix permissions on /data (run only once, at startup)
-if [[ "$$" == 1 ]]
+# Initialization. Trigger stuff that only needs to be run once, at startup.
+if [[ "$$" == 1 ]] && [[ -z "$ZSH_NO_INIT" ]]
 then
-  if [[ -z "$QUIET" ]]
-  then
-    echo "Setting owner of /data to ${PUID}:${PGID}" >&2
-  fi
-  sudo chown /data
-  sudo chown -R "${PUID}:${PGID}" /data
+  source /src/docker/init.zsh
 fi
 
 # load zinit
@@ -14,6 +9,9 @@ source /src/zinit.zsh
 
 # load zinit setup utility functions
 source /src/docker/utils.zsh
+
+# Annexes
+zinit::setup-annexes
 
 # Add ZPFX/bin to PATH
 typeset -U path

--- a/docker/zshrc
+++ b/docker/zshrc
@@ -11,7 +11,7 @@ source /src/zinit.zsh
 source /src/docker/utils.zsh
 
 # Annexes
-zinit::setup-annexes
+[[ -z "$NOTHING_FANCY" ]] && zinit::setup-annexes
 
 # Add ZPFX/bin to PATH
 typeset -U path
@@ -31,6 +31,6 @@ then
 fi
 
 # Setup keys
-zinit::setup-keys
+[[ -z "$NOTHING_FANCY" ]] && zinit::setup-keys
 
 # vim: ft=zsh et ts=2 sw=2 :

--- a/scripts/docker-run.sh
+++ b/scripts/docker-run.sh
@@ -209,6 +209,7 @@ then
     )
     CONTAINER_ENV+=(
       "QUIET=1"
+      "NOTHING_FANCY=1"
     )
   fi
 


### PR DESCRIPTION
Here are a few updates to the docker container.

- annexes get installed by default
- zinit completion
- at container build time `@zinit-scheduler burst` now installs to `/data-static`
- at runtime `/data-static` gets copied over to `/data`. This is necessary because `/data` is meant to be backed via a volume (that's what we do in the zunit tests for instance to verify if we downloaded the files correctly)
- most of the custom stuff (keys setup, annexes, the /data-static to /data file-copy etc) can now be disabled with `NOTHING_FANCY=1` at runtime
