### PR TITLE
Fetch the annexes during the install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -264,6 +264,8 @@ EOF
 
   if [ "$reply" = y ] || [ "$reply" = Y ]; then
     command cat "$zshrc_annex_file" >> "$ZSHRC"
+    echo_info "Installing annexes"
+    zsh -ic "@zinit-scheduler burst"
     echo_success 'Done!'
   else
     echo_warning "Skipped the annexes."


### PR DESCRIPTION
This installs the annexes with `@zinit-scheduler burst` at install time, rather than when the user first starts zsh after the installation.
