### PR TITLE
`zinit pack`: Support alternative sources

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,6 +9,16 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+* 26-11-2021
+  - zinit packages can now be installed from local files or custom repositories.
+zinit uses [zhdarma-continuum/zinit-packages](https://github.com/p/zdharma-continuum/zinit-packages)
+by default. To use a custom repo you can set `ZINIT[PACKAGES_REPO]=github_org/repo`.
+To install from a specific branch: `ZINIT[PACKAGES_BRANCH]=feature-branch`. For
+repos that are not hosted on GitHub, you can instruct zinit to install packages
+from the local filesystem like so:
+`zinit pack"profile" for local/path/to/package.json` (the user needs to be set
+to `local` and the path to `package.json` must be absolute)
+
 * 22-11-2021
   - We updated zinit's main branch from `master` to `main`. `zinit self-update`
 will try to update the branch locally. If it fails please try to:

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -196,14 +196,13 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || { builtin print -P "${ZINIT
         # saved as "package.json" and then ziextract etc will fail to detect these
         # NOTE that the id-as also dictates who the downloaded snippet file will
         # be named
-        if [[ -n "$localpkg" ]] && [[ -z "${ICE[id-as]}" ]]
-        then
+        if [[ -n "$localpkg" ]] && [[ -z "${ICE[id-as]}" ]] {
             # First we'll try using the name field of the package.json
             # If that fails we default to:
             # zinit-pack---local---path---to---plugin---dir
             local pkgname=$(jq -r '.name // ""' <<< "$pkgjson" 2>/dev/null)
-            ICE[id-as]=${pkgname:-zinit-pack---local---${${pkg%%/package.json}//\//---}
-        fi
+            ICE[id-as]=${pkgname:-zinit-pack---local---${${pkg%%/package.json}//\//---}}
+        }
     } else {
         # Założenie: profil domyślny jest pierwszy w tablicy (patrz: inny kolor).
         +zinit-message "{u-warn}Error{b-warn}:{error} the profile {apo}\`{hi}$profile{apo}\`" \

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -72,11 +72,13 @@ aliases|countdown|light-mode|is-snippet|git|verbose|cloneopts|\
 pullopts|debug|null|binary|make|nocompile|notify|reset"
 
 # Can be customized.
-: ${ZINIT[MODULE_DIR]:=${ZINIT[HOME_DIR]}/module}
-: ${ZINIT[PLUGINS_DIR]:=${ZINIT[HOME_DIR]}/plugins}
 : ${ZINIT[COMPLETIONS_DIR]:=${ZINIT[HOME_DIR]}/completions}
-: ${ZINIT[SNIPPETS_DIR]:=${ZINIT[HOME_DIR]}/snippets}
+: ${ZINIT[MODULE_DIR]:=${ZINIT[HOME_DIR]}/module}
+: ${ZINIT[PACKAGES_REPO]:=zdharma-continuum/zinit-packages}
+: ${ZINIT[PACKAGES_BRANCH]:=HEAD}
+: ${ZINIT[PLUGINS_DIR]:=${ZINIT[HOME_DIR]}/plugins}
 : ${ZINIT[SERVICES_DIR]:=${ZINIT[HOME_DIR]}/services}
+: ${ZINIT[SNIPPETS_DIR]:=${ZINIT[HOME_DIR]}/snippets}
 typeset -g ZPFX
 : ${ZPFX:=${ZINIT[HOME_DIR]}/polaris}
 : ${ZINIT[ALIASES_OPT]::=${${options[aliases]:#off}:+1}}


### PR DESCRIPTION
- Allow installation from local packages.json files or other repositories
- 2 new env vars users can override: 
  - `ZINIT[PACKAGE_REPO]=zhdarma-continuum/zinit-packages`
  - `ZINIT[PACKAGE_BRANCH]=HEAD`

Installation of local packages: `zinit pack for local/path/to/my/package.json`

Refs:
- https://github.com/zdharma-continuum/zinit-packages/pull/2