### PR TITLE
Pedantic warning: Return != 0 when a hook fails

### DIFF
--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -9,6 +9,18 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+* 29-11-2021
+  - zinit calls no longer silently fail when ices such as `atclone`, 
+`atpull` or `compile` fail. Any hook returning with != 0 will log a warning to
+stdout at runtime:
+
+```zsh
+zinit null atclone'echo "intentional failure"; return 69' \
+  for zdharma-continuum/null
+echo $?
+69
+```
+
 * 28-11-2021
   - **‼️ BREAKING CHANGE** zinit now requires [jq](https://github.com/stedolan/jq)
 for JSON parsing. This only affects the `pack` ice. Users who do not have jq 

--- a/doc/zsdoc/zinit-autoload.zsh.adoc
+++ b/doc/zsdoc/zinit-autoload.zsh.adoc
@@ -1414,7 +1414,7 @@ ____
  $3 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 300 line(s). Calls functions:
+Has 325 line(s). Calls functions:
 
  .zinit-update-or-status
  |-- zinit-install.zsh/.zinit-get-latest-gh-r-url-part
@@ -1451,7 +1451,7 @@ ____
  User-action entry point.
 ____
 
-Has 124 line(s). Calls functions:
+Has 131 line(s). Calls functions:
 
  .zinit-update-or-status-all
  |-- zinit-install.zsh/.zinit-compinit

--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -127,7 +127,7 @@ ____
  FUNCTION: ∞zinit-atclone-hook [[[
 ____
 
-Has 8 line(s). Calls functions:
+Has 26 line(s). Calls functions:
 
  ∞zinit-atclone-hook
  |-- zinit-side.zsh/.zinit-countdown
@@ -146,7 +146,7 @@ ____
  FUNCTION: .zinit-at-eval [[[
 ____
 
-Has 5 line(s). Calls functions:
+Has 9 line(s). Calls functions:
 
  .zinit-at-eval
  `-- zinit.zsh/@zinit-substitute
@@ -167,7 +167,7 @@ ____
  FUNCTION: ∞zinit-atpull-e-hook [[[
 ____
 
-Has 5 line(s). Calls functions:
+Has 22 line(s). Calls functions:
 
  ∞zinit-atpull-e-hook
  `-- zinit-side.zsh/.zinit-countdown
@@ -185,7 +185,7 @@ ____
  FUNCTION: ∞zinit-atpull-hook [[[
 ____
 
-Has 5 line(s). Calls functions:
+Has 22 line(s). Calls functions:
 
  ∞zinit-atpull-hook
  `-- zinit-side.zsh/.zinit-countdown
@@ -323,7 +323,7 @@ ____
  This is used to provide a layer of support for Oh-My-Zsh and Prezto.
 ____
 
-Has 323 line(s). Calls functions:
+Has 357 line(s). Calls functions:
 
  .zinit-download-snippet
  |-- zinit-side.zsh/.zinit-store-ices
@@ -367,7 +367,7 @@ ____
  FUNCTION: ∞zinit-extract-hook [[[
 ____
 
-Has 8 line(s). Calls functions:
+Has 10 line(s). Calls functions:
 
  ∞zinit-extract-hook
  `-- zinit.zsh/@zinit-substitute
@@ -584,7 +584,7 @@ ____
  FUNCTION: ∞zinit-make-ee-hook [[[
 ____
 
-Has 9 line(s). Calls functions:
+Has 11 line(s). Calls functions:
 
  ∞zinit-make-ee-hook
  |-- zinit-side.zsh/.zinit-countdown
@@ -601,7 +601,7 @@ ____
  FUNCTION: ∞zinit-make-e-hook [[[
 ____
 
-Has 9 line(s). Calls functions:
+Has 11 line(s). Calls functions:
 
  ∞zinit-make-e-hook
  |-- zinit-side.zsh/.zinit-countdown
@@ -618,7 +618,7 @@ ____
  FUNCTION: ∞zinit-make-hook [[[
 ____
 
-Has 10 line(s). Calls functions:
+Has 11 line(s). Calls functions:
 
  ∞zinit-make-hook
  |-- zinit-side.zsh/.zinit-countdown
@@ -720,7 +720,7 @@ ____
  $2 - plugin
 ____
 
-Has 198 line(s). Calls functions:
+Has 209 line(s). Calls functions:
 
  .zinit-setup-plugin-dir
  |-- ziextract

--- a/doc/zsdoc/zinit.zsh.adoc
+++ b/doc/zsdoc/zinit.zsh.adoc
@@ -699,7 +699,7 @@ ____
  $2 - plugin name, if the third format is used
 ____
 
-Has 92 line(s). Calls functions:
+Has 94 line(s). Calls functions:
 
  .zinit-load
  |-- +zinit-deploy-message

--- a/docker/zshrc
+++ b/docker/zshrc
@@ -12,9 +12,9 @@ autoload -Uz _zinit
 # load zinit setup utility functions
 source /src/docker/utils.zsh
 
-# Add ZPFX/bin to PATH
+# Add ZPFX/bin and GOPATH/bin to PATH
 typeset -U path
-path=("${ZPFX:-${HOME}/.local/share/zinit/polaris}/bin" $path)
+path=("${ZPFX:-${HOME}/.local/share/zinit/polaris}/bin" "${HOME}/go/bin" $path)
 
 # Install custom zsh version
 if [[ -n "$ZINIT_ZSH_VERSION" ]]

--- a/tests/ices.zunit
+++ b/tests/ices.zunit
@@ -30,10 +30,15 @@
 }
 
 @test 'failing atclone ice' {
-  run ./scripts/docker-run.sh --wrap --debug --zunit \
-    zinit null atclone'return 69' for zdharma-continuum/null
+  local zcall=$'zinit null atclone'\''echo "intentional failure"; return 69'\'' \
+      for zdharma-continuum/null'
 
+  run ./scripts/docker-run.sh --wrap --debug --zunit \
+    $zcall
+
+  assert $state not_equal_to 0
   assert $state equals 69
+  assert "$output" contains "intentional failure"
 }
 
 # vim: set ft=zsh et ts=2 sw=2 : #

--- a/tests/ices.zunit
+++ b/tests/ices.zunit
@@ -29,4 +29,11 @@
   assert "$artifact" is_executable
 }
 
+@test 'failing atclone ice' {
+  run ./scripts/docker-run.sh --wrap --debug --zunit \
+    zinit null atclone'return 69' for zdharma-continuum/null
+
+  assert $state equals 69
+}
+
 # vim: set ft=zsh et ts=2 sw=2 : #

--- a/tests/ices.zunit
+++ b/tests/ices.zunit
@@ -41,4 +41,19 @@
   assert "$output" contains "intentional failure"
 }
 
+@test 'failing atpull ice' {
+  local z=$'zinit id-as'\''atpull-fail'\'' null \
+      atpull'\''echo "intentional failure"; return 69'\'' \
+      run-atpull \
+    for zdharma-continuum/null; \
+    zi update atpull-fail'
+
+  run ./scripts/docker-run.sh --wrap --debug --zunit \
+    $z
+
+  assert $state not_equal_to 0
+  assert $state equals 69
+  assert "$output" contains "intentional failure"
+}
+
 # vim: set ft=zsh et ts=2 sw=2 : #

--- a/tests/plugins.zunit
+++ b/tests/plugins.zunit
@@ -25,7 +25,9 @@
 
 @test 'zinit direnv installation' {
   run ./scripts/docker-run.sh --wrap --debug --zunit \
-    zinit light-mode as"program" make for @direnv/direnv
+    'zinit light-mode as"program" \
+      atclone"go install github.com/cpuguy83/go-md2man/v2@latest" \
+      make for @direnv/direnv'
 
   assert $state equals 0
   assert "$output" contains "Downloading"

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -1433,7 +1433,7 @@ ZINIT[EXTENDED_GLOB]=""
     .zinit-set-m-func set
     trap ".zinit-set-m-func unset" EXIT
 
-    integer retval was_snippet
+    integer retval hook_rc was_snippet
     .zinit-two-paths "$2${${2:#(%|/)*}:+${3:+/}}$3"
     if [[ -d ${reply[-4]} || -d ${reply[-2]} ]]; then
         .zinit-update-or-status-snippet "$1" "$2${${2:#(%|/)*}:+${3:+/}}$3"
@@ -1573,6 +1573,12 @@ ZINIT[EXTENDED_GLOB]=""
                 for key in "${reply[@]}"; do
                     arr=( "${(Q)${(z@)ZINIT_EXTS[$key]:-$ZINIT_EXTS2[$key]}[@]}" )
                     "${arr[5]}" plugin "$user" "$plugin" "$id_as" "$local_dir" "${${key##(zinit|z-annex) hook:}%% <->}" update:bin
+                    hook_rc=$?
+                    [[ "$hook_rc" -ne 0 ]] && {
+                        # note: this will effectively return the last != 0 rc
+                        retval="$hook_rc"
+                        builtin print -Pr -- "${ZINIT[col-warn]}Warning:%f%b ${ZINIT[col-obj]}${arr[5]}${ZINIT[col-warn]} hook returned with ${ZINIT[col-obj]}${hook_rc}${ZINIT[col-rst]}"
+                    }
                 done
 
                 if (( ZINIT[annex-multi-flag:pull-active] >= 2 )) {
@@ -1656,6 +1662,12 @@ ZINIT[EXTENDED_GLOB]=""
                   for key in "${reply[@]}"; do
                       arr=( "${(Q)${(z@)ZINIT_EXTS[$key]:-$ZINIT_EXTS2[$key]}[@]}" )
                       "${arr[5]}" plugin "$user" "$plugin" "$id_as" "$local_dir" "${${key##(zinit|z-annex) hook:}%% <->}" update:git
+                      hook_rc=$?
+                      [[ "$hook_rc" -ne 0 ]] && {
+                          # note: this will effectively return the last != 0 rc
+                          retval="$hook_rc"
+                          builtin print -Pr -- "${ZINIT[col-warn]}Warning:%f%b ${ZINIT[col-obj]}${arr[5]}${ZINIT[col-warn]} hook returned with ${ZINIT[col-obj]}${hook_rc}${ZINIT[col-rst]}"
+                      }
                   done
                   ICE=()
                   (( ZINIT[annex-multi-flag:pull-active] >= 2 )) && command git pull --no-stat ${=ice[pullopts]:---ff-only} origin ${ice[ver]:-$main_branch} |& command egrep -v '(FETCH_HEAD|up.to.date\.|From.*://)'
@@ -1697,6 +1709,12 @@ ZINIT[EXTENDED_GLOB]=""
             for key in "${reply[@]}"; do
                 arr=( "${(Q)${(z@)ZINIT_EXTS[$key]:-$ZINIT_EXTS2[$key]}[@]}" )
                 "${arr[5]}" plugin "$user" "$plugin" "$id_as" "$local_dir" "${${key##(zinit|z-annex) hook:}%% <->}" update
+                hook_rc="$?"
+                [[ "$hook_rc" -ne 0 ]] && {
+                    # note: this will effectively return the last != 0 rc
+                    retval="$hook_rc"
+                    builtin print -Pr -- "${ZINIT[col-warn]}Warning:%f%b ${ZINIT[col-obj]}${arr[5]}${ZINIT[col-warn]} hook returned with ${ZINIT[col-obj]}${hook_rc}${ZINIT[col-rst]}"
+                }
             done
 
             # Run annexes' atpull hooks (the after atpull-ice ones).
@@ -1709,6 +1727,12 @@ ZINIT[EXTENDED_GLOB]=""
             for key in "${reply[@]}"; do
                 arr=( "${(Q)${(z@)ZINIT_EXTS[$key]:-$ZINIT_EXTS2[$key]}[@]}" )
                 "${arr[5]}" plugin "$user" "$plugin" "$id_as" "$local_dir" "${${key##(zinit|z-annex) hook:}%% <->}" update
+                hook_rc="$?"
+                [[ "$hook_rc" -ne 0 ]] && {
+                    # note: this will effectively return the last != 0 rc
+                    retval="$hook_rc"
+                    builtin print -Pr -- "${ZINIT[col-warn]}Warning:%f%b ${ZINIT[col-obj]}${arr[5]}${ZINIT[col-warn]} hook returned with ${ZINIT[col-obj]}${hook_rc}${ZINIT[col-rst]}"
+                }
             done
             ICE=()
         }
@@ -1728,6 +1752,12 @@ ZINIT[EXTENDED_GLOB]=""
     for key in "${reply[@]}"; do
         arr=( "${(Q)${(z@)ZINIT_EXTS[$key]:-$ZINIT_EXTS2[$key]}[@]}" )
         "${arr[5]}" plugin "$user" "$plugin" "$id_as" "$local_dir" "${${key##(zinit|z-annex) hook:}%% <->}" update:$ZINIT[annex-multi-flag:pull-active]
+        hook_rc=$?
+        [[ "$hook_rc" -ne 0 ]] && {
+            # note: this will effectively return the last != 0 rc
+            retval="$hook_rc"
+            builtin print -Pr -- "${ZINIT[col-warn]}Warning:%f%b ${ZINIT[col-obj]}${arr[5]}${ZINIT[col-warn]} hook returned with ${ZINIT[col-obj]}${hook_rc}${ZINIT[col-rst]}"
+        }
     done
     ICE=()
 

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -1842,7 +1842,7 @@ ZINIT[EXTENDED_GLOB]=""
         +zinit-message "{msg2}Restarting the update with the new codebase loaded.{rst}"$'\n'
 
     local file
-    integer sum el
+    integer sum el update_rc
     for file ( "" -side -install -autoload ) {
         .zinit-get-mtime-into "${ZINIT[BIN_DIR]}/zinit$file.zsh" el; sum+=el
     }
@@ -1956,6 +1956,11 @@ ZINIT[EXTENDED_GLOB]=""
         else
             (( !OPTS[opt_-q,--quiet] )) && builtin print "Updating $REPLY" || builtin print -n .
             .zinit-update-or-status update "$user" "$plugin"
+            update_rc=$?
+            [[ $update_rc -ne 0 ]] && {
+                +zinit-message "🚧{warn}Warning: {pid}${user}/${plugin} {warn}update returned {obj}$update_rc"
+                retval=$?
+            }
         fi
     done
 
@@ -1963,6 +1968,8 @@ ZINIT[EXTENDED_GLOB]=""
     if (( !OPTS[opt_-q,--quiet] )) {
         +zinit-message "{msg2}The update took {obj}${SECONDS}{msg2} seconds{rst}"
     }
+
+    return "$retval"
 } # ]]]
 # FUNCTION: .zinit-update-in-parallel [[[
 .zinit-update-all-parallel() {

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -479,6 +479,11 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
             for key in "${reply[@]}"; do
                 arr=( "${(Q)${(z@)ZINIT_EXTS[$key]:-$ZINIT_EXTS2[$key]}[@]}" )
                 "${arr[5]}" plugin "$user" "$plugin" "$id_as" "$local_path" "${${key##(zinit|z-annex) hook:}%% <->}"
+                hook_rc=$?
+                [[ "$hook_rc" -ne 0 ]] && {
+                    rc="$hook_rc"
+                    builtin print -Pr -- "${ZINIT[col-warn]}Warning:%f%b ${ZINIT[col-obj]}${arr[5]}${ZINIT[col-warn]} hook returned with ${ZINIT[col-obj]}${hook_rc}${ZINIT[col-rst]}"
+                }
             done
         }
 

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -2167,7 +2167,7 @@ zimv() {
     local extract=${ICE[extract]}
     @zinit-substitute extract
 
-    (( ${+ICE[extract]} )) || return
+    (( ${+ICE[extract]} )) || return 0
 
     .zinit-extract plugin "$extract" "$dir"
 }

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -2085,12 +2085,13 @@ zimv() {
 
     local make=${ICE[make]}
     @zinit-substitute make
-    (( ${+ICE[make]} )) || return 0
+
+    (( ${+ICE[make]} )) || return
+    [[ $make = "!!"* ]] || return
 
     # Git-plugin make'' at download
-    [[ $make = "!!"* ]] && \
-        .zinit-countdown make && \
-            command make -C "$dir" ${(@s; ;)${make#\!\!}}
+    .zinit-countdown make && \
+        command make -C "$dir" ${(@s; ;)${make#\!\!}}
 }
 # ]]]
 # FUNCTION: ∞zinit-make-e-hook [[[
@@ -2101,12 +2102,13 @@ zimv() {
 
     local make=${ICE[make]}
     @zinit-substitute make
-    (( ${+ICE[make]} )) || return 0
+
+    (( ${+ICE[make]} )) || return
+    [[ $make = ("!"[^\!]*|"!") ]] || return
 
     # Git-plugin make'' at download
-    [[ $make = ("!"[^\!]*|"!") ]] && \
-        .zinit-countdown make && \
-            command make -C "$dir" ${(@s; ;)${make#\!}}
+    .zinit-countdown make && \
+        command make -C "$dir" ${(@s; ;)${make#\!}}
 }
 # ]]]
 # FUNCTION: ∞zinit-make-hook [[[
@@ -2117,12 +2119,13 @@ zimv() {
 
     local make=${ICE[make]}
     @zinit-substitute make
-    (( ${+ICE[make]} )) || return 0
+
+    (( ${+ICE[make]} )) || return
+    [[ $make != "!"* ]] || return
 
     # Git-plugin make'' at download
-    [[ $make != "!"* ]] &&
     .zinit-countdown make &&
-    command make -C "$dir" ${(@s; ;)make}
+        command make -C "$dir" ${(@s; ;)make}
 }
 # ]]]
 # FUNCTION: ∞zinit-atclone-hook [[[
@@ -2164,9 +2167,9 @@ zimv() {
     local extract=${ICE[extract]}
     @zinit-substitute extract
 
-    (( ${+ICE[extract]} )) && {
-        .zinit-extract plugin "$extract" "$dir"
-    } || return 0
+    (( ${+ICE[extract]} )) || return
+
+    .zinit-extract plugin "$extract" "$dir"
 }
 # ]]]
 # FUNCTION: ∞zinit-mv-hook [[[

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -2331,7 +2331,7 @@ zimv() {
 # ]]]
 # FUNCTION: ∞zinit-atpull-hook [[[
 ∞zinit-atpull-hook() {
-    (( ${+ICE[atpull]} )) || { echo 'EMPTY ATPULL' >&2; return 0; }
+    (( ${+ICE[atpull]} )) || return 0
     [[ -n ${ICE[atpull]} ]] || return 0
     # Exit early if atpull"!cmd" -> this is done by zinit-atpull-e-hook
     [[ $ICE[atpull] == "!"* ]] && return 0

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -2266,20 +2266,56 @@ zimv() {
 # ]]]
 # FUNCTION: ∞zinit-atpull-e-hook [[[
 ∞zinit-atpull-e-hook() {
+    (( ${+ICE[atpull]} )) || return 0
+    [[ -z ${ICE[atpull]} ]] || return 0
+    # Only process atpull"!cmd"
+    [[ $ICE[atpull] != "!"* ]] || return 0
+
     [[ "$1" = plugin ]] && \
         local dir="${5#%}" hook="$6" subtype="$7" || \
         local dir="${4#%}" hook="$5" subtype="$6"
 
-    [[ $ICE[atpull] = "!"* ]] && .zinit-countdown atpull && { local ___oldcd=$PWD; (( ${+ICE[nocd]} == 0 )) && { () { setopt localoptions noautopushd; builtin cd -q "$dir"; } && .zinit-at-eval "${ICE[atpull]#\!}" "$ICE[atclone]"; ((1)); } || .zinit-at-eval "${ICE[atpull]#\!}" "$ICE[atclone]"; () { setopt localoptions noautopushd; builtin cd -q "$___oldcd"; };}
+    local atpull=${ICE[atpull]#\!}
+    local rc=0
+
+    .zinit-countdown atpull && {
+        local ___oldcd=$PWD
+        (( ${+ICE[nocd]} == 0 )) && {
+            () { setopt localoptions noautopushd; builtin cd -q "$dir"; }
+        }
+        .zinit-at-eval "$atpull" "$ICE[atclone]"
+        rc="$?"
+        () { setopt localoptions noautopushd; builtin cd -q "$___oldcd"; };
+    }
+
+    return "$rc"
 }
 # ]]]
 # FUNCTION: ∞zinit-atpull-hook [[[
 ∞zinit-atpull-hook() {
-    [[ "$1" = plugin ]] && \
+    (( ${+ICE[atpull]} )) || return 0
+    [[ -z ${ICE[atpull]} ]] || return 0
+    # Exit early if atpull"!cmd" -> this is done by zinit-atpull-e-hook
+    [[ $ICE[atpull] == "!"* ]] || return 0
+
+    [[ "$1" == plugin ]] && \
         local dir="${5#%}" hook="$6" subtype="$7" || \
         local dir="${4#%}" hook="$5" subtype="$6"
 
-    [[ -n $ICE[atpull] && $ICE[atpull] != "!"* ]] && .zinit-countdown atpull && { local ___oldcd=$PWD; (( ${+ICE[nocd]} == 0 )) && { () { setopt localoptions noautopushd; builtin cd -q "$dir"; } && .zinit-at-eval "$ICE[atpull]" "$ICE[atclone]"; ((1)); } || .zinit-at-eval "${ICE[atpull]#!}" $ICE[atclone]; () { setopt localoptions noautopushd; builtin cd -q "$___oldcd"; };}
+    local atpull=${ICE[atpull]}
+    local rc=0
+
+    .zinit-countdown atpull && {
+        local ___oldcd=$PWD
+        (( ${+ICE[nocd]} == 0 )) && {
+            () { setopt localoptions noautopushd; builtin cd -q "$dir"; }
+        }
+        .zinit-at-eval "$atpull" $ICE[atclone]
+        rc="$?"
+        () { setopt localoptions noautopushd; builtin cd -q "$___oldcd"; };
+    }
+
+    return "$rc"
 }
 # ]]]
 # FUNCTION: ∞zinit-ps-on-update-hook [[[

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -2086,8 +2086,8 @@ zimv() {
     local make=${ICE[make]}
     @zinit-substitute make
 
-    (( ${+ICE[make]} )) || return
-    [[ $make = "!!"* ]] || return
+    (( ${+ICE[make]} )) || return 0
+    [[ $make = "!!"* ]] || return 0
 
     # Git-plugin make'' at download
     .zinit-countdown make && \
@@ -2103,8 +2103,8 @@ zimv() {
     local make=${ICE[make]}
     @zinit-substitute make
 
-    (( ${+ICE[make]} )) || return
-    [[ $make = ("!"[^\!]*|"!") ]] || return
+    (( ${+ICE[make]} )) || return 0
+    [[ $make = ("!"[^\!]*|"!") ]] || return 0
 
     # Git-plugin make'' at download
     .zinit-countdown make && \
@@ -2120,8 +2120,8 @@ zimv() {
     local make=${ICE[make]}
     @zinit-substitute make
 
-    (( ${+ICE[make]} )) || return
-    [[ $make != "!"* ]] || return
+    (( ${+ICE[make]} )) || return 0
+    [[ $make != "!"* ]] || return 0
 
     # Git-plugin make'' at download
     .zinit-countdown make &&
@@ -2240,19 +2240,20 @@ zimv() {
         local dir="${5#%}" hook="$6" subtype="$7" || \
         local dir="${4#%}" hook="$5" subtype="$6"
 
-    if [[ ( $hook = *\!at(clone|pull)* && ${+ICE[nocompile]} -eq 0 ) || \
-            ( $hook = at(clone|pull)* && $ICE[nocompile] = '!' )
-    ]] {
-        # Compile plugin
-        if [[ -z $ICE[(i)(\!|)(sh|bash|ksh|csh)] ]] {
-            () {
-                emulate -LR zsh
-                setopt extendedglob warncreateglobal
-                if [[ $tpe == snippet ]] {
-                    .zinit-compile-plugin "%$dir" ""
-                } else {
-                    .zinit-compile-plugin "$id_as" ""
-                }
+    if ! [[ ( $hook = *\!at(clone|pull)* && ${+ICE[nocompile]} -eq 0 ) || \
+            ( $hook = at(clone|pull)* && $ICE[nocompile] = '!' ) ]] {
+        return 0
+    }
+
+    # Compile plugin
+    if [[ -z $ICE[(i)(\!|)(sh|bash|ksh|csh)] ]] {
+        () {
+            emulate -LR zsh
+            setopt extendedglob warncreateglobal
+            if [[ $tpe == snippet ]] {
+                .zinit-compile-plugin "%$dir" ""
+            } else {
+                .zinit-compile-plugin "$id_as" ""
             }
         }
     }

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -2358,7 +2358,7 @@ zimv() {
 # ]]]
 # FUNCTION: ∞zinit-ps-on-update-hook [[[
 ∞zinit-ps-on-update-hook() {
-    if [[ -z $ICE[ps-on-update] ]] { return 1; }
+    [[ -z $ICE[ps-on-update] ]] && return 0
 
     [[ "$1" = plugin ]] && \
         local tpe="$1" dir="${5#%}" hook="$6" subtype="$7" || \

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -1584,9 +1584,11 @@ builtin setopt noaliases
             zle && { builtin print; zle .reset-prompt; }
             return 1
         }
-        if ! .zinit-setup-plugin-dir "$___user" "$___plugin" "$___id_as" "$REPLY"; then
+        .zinit-setup-plugin-dir "$___user" "$___plugin" "$___id_as" "$REPLY"
+        local rc="$?"
+        if [[ "$rc" -ne 0 ]]; then
             zle && { builtin print; zle .reset-prompt; }
-            return 1
+            return "$rc"
         fi
         zle && ___rst=1
     }


### PR DESCRIPTION
Fixes #111

This also logs an explicit warning when a hook fails:

```
Warning: ∞zinit-compile-plugin-hook hook returned with 1
```
