### PR TITLE
fix install script

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -305,7 +305,7 @@ ZINIT_COMMIT="${ZINIT_COMMIT:-}"  # no default value
 ZINIT_HOME="${ZINIT_HOME:-${XDG_DATA_HOME:-${HOME}/.local/share}/zinit}"
 ZINIT_REPO_DIR_NAME="${ZINIT_REPO_DIR_NAME:-zinit.git}"
 ZINIT_INSTALL_DIR=${ZINIT_INSTALL_DIR:-${ZINIT_HOME}/${ZINIT_REPO_DIR_NAME}}
-ZSHRC="${ZSHRC:-${ZDOTDIR:-${HOME}/.zshrc}}"
+ZSHRC="${ZSHRC:-${ZDOTDIR:-${HOME}}/.zshrc}"
 
 show_environment
 check_dependencies


### PR DESCRIPTION
Currently, the zinit installation script (`scripts/install.sh`) generates the path to zshrc with the following code.

https://github.com/zdharma-continuum/zinit/blob/7f456fdbd419ebdaf68a2aa5b53fd6bd3a4edb48/scripts/install.sh#L308

If `$ZDOTDIR` is set and `$ZSHRC` is not, the right hand side will be evaluated as `$ZDOTDIR`. However, it should be `$ZDOTDIR/.zshrc`.

This PR fixes #119