### PR TITLE
Fix #125

### DIFF
--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -660,9 +660,10 @@ ____
  FUNCTION: ∞zinit-mv-hook [[[
 ____
 
-Has 27 line(s). Calls functions:
+Has 35 line(s). Calls functions:
 
  ∞zinit-mv-hook
+ |-- zinit.zsh/+zinit-message
  `-- zinit.zsh/@zinit-substitute
 
 Uses feature(s): _setopt_

--- a/doc/zsdoc/zinit.zsh.adoc
+++ b/doc/zsdoc/zinit.zsh.adoc
@@ -857,6 +857,7 @@ Called by:
  zinit-install.zsh/.zinit-get-package
  zinit-install.zsh/.zinit-install-completions
  zinit-install.zsh/.zinit-jq-check
+ zinit-install.zsh/∞zinit-mv-hook
  zinit-install.zsh/∞zinit-ps-on-update-hook
  zinit-install.zsh/∞zinit-reset-hook
  zinit-install.zsh/.zinit-setup-plugin-dir

--- a/tests/ices.zunit
+++ b/tests/ices.zunit
@@ -30,11 +30,11 @@
 }
 
 @test 'failing atclone ice' {
-  local zcall=$'zinit null atclone'\''echo "intentional failure"; return 69'\'' \
+  local z=$'zinit null atclone'\''echo "intentional failure"; return 69'\'' \
       for zdharma-continuum/null'
 
   run ./scripts/docker-run.sh --wrap --debug --zunit \
-    $zcall
+    $z
 
   assert $state not_equal_to 0
   assert $state equals 69
@@ -51,9 +51,32 @@
   run ./scripts/docker-run.sh --wrap --debug --zunit \
     $z
 
-  assert $state not_equal_to 0
   assert $state equals 69
   assert "$output" contains "intentional failure"
 }
 
+@test 'failing mv ice' {
+  local z=$'zinit as'\''command'\'' from'\''gh-r'\'' bpick'\''*musl*'\'' mv'\''DOES_NOT_EXIST* -> fd'\'' \
+      pick'\''fd/fd'\'' for @sharkdp/fd'
+
+  run ./scripts/docker-run.sh --wrap --debug --zunit $z
+
+  assert $state equals 1
+  assert "$output" contains "DOES_NOT_EXIST"
+  assert "$output" contains "didn't match any file"
+}
+
+@test 'mv ice' {
+  local z=$'zinit as'\''command'\'' from'\''gh-r'\'' bpick'\''*musl*'\'' mv'\''fd* -> fd'\'' \
+      pick'\''fd/fd'\'' for @sharkdp/fd'
+  run ./scripts/docker-run.sh --wrap --debug --zunit $z
+
+  assert $state equals 0
+  assert "$output" contains "Downloading"
+
+  local artifact="${PLUGINS_DIR}/sharkdp---fd/fd/fd"
+  assert "$artifact" is_file
+  assert "$artifact" is_readable
+  assert "$artifact" is_executable
+}
 # vim: set ft=zsh et ts=2 sw=2 : #

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -2217,7 +2217,7 @@ zimv() {
 # ]]]
 # FUNCTION: ∞zinit-mv-hook [[[
 ∞zinit-mv-hook() {
-    [[ -z $ICE[mv] ]] && return
+    [[ -z $ICE[mv] ]] && return 0
 
     [[ "$1" = plugin ]] && \
         local dir="${5#%}" hook="$6" subtype="$7" || \
@@ -2231,18 +2231,26 @@ zimv() {
 
     @zinit-substitute from to
 
+    local -a mv_args=("-f")
     local -a afr
-    ( () { setopt localoptions noautopushd; builtin cd -q "$dir"; } || return 1
-      afr=( ${~from}(DN) )
-      if (( ${#afr} )) {
-          if (( !OPTS[opt_-q,--quiet] )) {
-              command mv -vf "${afr[1]}" "$to"
-              command mv -vf "${afr[1]}".zwc "$to".zwc 2>/dev/null
-          } else {
-              command mv -f "${afr[1]}" "$to"
-              command mv -f "${afr[1]}".zwc "$to".zwc 2>/dev/null
-          }
-      }
+
+    (
+        () { setopt localoptions noautopushd; builtin cd -q "$dir"; } || return 1
+        afr=( ${~from}(DN) )
+
+        if (( ! ${#afr} )) {
+            +zinit-message "{warn}Warning: mv ice didn't match any file. [{error}$ICE[mv]{warn}]" \
+                           "{nl}{warn}Available files:{nl}{obj}$(ls -1)"
+            return 1
+        }
+        if (( !OPTS[opt_-q,--quiet] )) {
+            mv_args+=("-v")
+        }
+
+        command mv "${mv_args[@]}" "${afr[1]}" "$to"
+        local retval=$?
+        command mv "${mv_args[@]}" "${afr[1]}".zwc "$to".zwc 2>/dev/null
+        return $retval
     )
 }
 # ]]]


### PR DESCRIPTION
What do we have here?

- Fix a for #125
- two new zunit test cases for the `mv` ice (one that fails, one that succeeds)
- when the `mv` fails to match any file a new warning is logged that list the available file to that the user can adjust the ice value accordingly. No more `zinit cd MYPLUGIN`, then listing files and fixing a typo in the `mv ` ice ;)

```
Downloading sharkdp/fd…
(Requesting `fd-v8.3.0-x86_64-unknown-linux-musl.tar.gz'…)
######################################################################## 100.0%
ziextract: Unpacking the files from: `fd-v8.3.0-x86_64-unknown-linux-musl.tar.gz'…
ziextract: Successfully extracted and assigned +x chmod to the file: `fd-v8.3.0-x86_64-unknown-linux-musl/fd'.
Warning: mv ice didn't match any file. [DOES_NOT_EXIST* -> fd]
Available files:
fd-v8.3.0-x86_64-unknown-linux-musl
Warning: ∞zinit-mv-hook hook returned with 1
```