### PR TITLE
Add link ice for local-only snippets that uses symlink

### DIFF
--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -323,7 +323,7 @@ ____
  This is used to provide a layer of support for Oh-My-Zsh and Prezto.
 ____
 
-Has 357 line(s). Calls functions:
+Has 370 line(s). Calls functions:
 
  .zinit-download-snippet
  |-- zinit-side.zsh/.zinit-store-ices

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -2212,22 +2212,26 @@ ZINIT[EXTENDED_GLOB]=""
         fi
         [[ -z $EPOCHREALTIME ]] && attime="<no zsh/datetime module → no time data>"
 
+        local line="$time"
         if [[ "$opt" = *-[a-z]#m[a-z]#* ]]; then
-            time="$attime"
+            line="$attime"
+        elif [[ "$opt" = *-[a-z]#a[a-z]#* ]]; then
+            line="$attime $line"
         fi
+
+        line="$line - $REPLY"
 
         if [[ ${sice[as]} == "command" ]]; then
-            builtin print "$time" - "$REPLY (command)"
+            line="$line (command)"
         elif [[ -n ${sice[sbin]+abc} ]]; then
-            builtin print "$time" - "$REPLY (sbin command)"
+            line="$line (sbin command)"
         elif [[ -n ${sice[fbin]+abc} ]]; then
-            builtin print "$time" - "$REPLY (fbin command)"
+            line="$line (fbin command)"
         elif [[ ( ${sice[pick]} = /dev/null || ${sice[as]} = null ) && ${+sice[make]} = 1 ]]; then
-            builtin print "$time" - "$REPLY (/dev/null make plugin)"
-        else
-            builtin print "$time" - "$REPLY"
+            line="$line (/dev/null make plugin)"
         fi
 
+        builtin print "$line"
         (( sum += ZINIT[$entry] ))
     done
     builtin print "Total: $sum sec"

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1185,14 +1185,26 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                     "accessible (wrong permissions).{rst}"
                 retval=4
             }
-            if (( !OPTS[opt_-q,--quiet] )) && [[ $url != /dev/null ]] {
-                +zinit-message "{msg}Copying {file}$filename{msg}{…}{rst}"
-                command cp -vf "$url" "$local_dir/$dirname/$filename" || \
-                    { +zinit-message "{ehi}ERROR:{error} The file copying has been unsuccessful.{rst}"; retval=4; }
+            if ! (( ${+ICE[link]} )) {
+                if (( !OPTS[opt_-q,--quiet] )) && [[ $url != /dev/null ]] {
+                    +zinit-message "{msg}Copying {file}$filename{msg}{…}{rst}"
+                    command cp -vf "$url" "$local_dir/$dirname/$filename" || \
+                        { +zinit-message "{ehi}ERROR:{error} The file copying has been unsuccessful.{rst}"; retval=4; }
+                } else {
+                    command cp -f "$url" "$local_dir/$dirname/$filename" &>/dev/null || \
+                        { +zinit-message "{ehi}ERROR:{error} The copying of {file}$filename{error} has been unsuccessful"\
+    "${${(M)OPTS[opt_-q,--quiet]:#1}:+, skip the -q/--quiet option for more information}.{rst}"; retval=4; }
+                }
             } else {
-                command cp -f "$url" "$local_dir/$dirname/$filename" &>/dev/null || \
-                    { +zinit-message "{ehi}ERROR:{error} The copying of {file}$filename{error} has been unsuccessful"\
-"${${(M)OPTS[opt_-q,--quiet]:#1}:+, skip the -q/--quiet option for more information}.{rst}"; retval=4; }
+                if (( !OPTS[opt_-q,--quiet] )) && [[ $url != /dev/null ]] {
+                    +zinit-message "{msg}Linking {file}$filename{msg}{…}{rst}"
+                    command ln -svf "$url" "$local_dir/$dirname/$filename" || \
+                        { +zinit-message "{ehi}ERROR:{error} The file linking has been unsuccessful.{rst}"; retval=4; }
+                } else {
+                    command ln -sf "$url" "$local_dir/$dirname/$filename" &>/dev/null || \
+                        { +zinit-message "{ehi}ERROR:{error} The link of {file}$filename{error} has been unsuccessful"\
+    "${${(M)OPTS[opt_-q,--quiet]:#1}:+, skip the -q/--quiet option for more information}.{rst}"; retval=4; }
+                }
             }
         }
 

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -65,7 +65,7 @@ reset-prompt|wrap|reset|sh|\!sh|bash|\!bash|ksh|\!ksh|csh|\
 \!csh|aliases|countdown|ps-on-unload|ps-on-update|trigger-load|\
 light-mode|is-snippet|atdelete|pack|git|verbose|on-update-of|\
 subscribe|extract|param|opts|autoload|subst|install|pullopts|\
-debug|null|binary"
+debug|null|binary|link"
 ZINIT[nval-ice-list]="blockf|silent|lucid|trackbinds|cloneonly|nocd|run-atpull|\
 nocompletions|sh|\!sh|bash|\!bash|ksh|\!ksh|csh|\!csh|\
 aliases|countdown|light-mode|is-snippet|git|verbose|cloneopts|\


### PR DESCRIPTION
Has a narrow use case, but I added a new ice "link" for local snippets that uses symlinks instead of copying files into the cache.

For those of us that keep our entire dotfiles in a git repo (dotbare, et al), we often want to treat a lot of our own rc files as snippets that can be managed by zinit.  This is great for taking advantage of features such as `trigger-load`, `if`, or `has` ices.  I used to use local plugins for this, but noticed that the load times for plugins were significantly longer than snippets.

In migrating to snippets, I found that copying files from a source path into the ZINIT_SNIPPETS directory meant that I had to run `zinit update [snippet]` in order for any changes that I may make to my rc files to take effect.  This ice simply replaces the `cp` command with `ln`, thus changes were live instantly with a new shell.  I thought that snippets, in combination with symlinks, are an effective way to manage a lot of low-level rc file stuff that doesn't necessarily need to be in a separate git repository of its own.

I'm not fond of the ice name, as I think the word 'link' may be too general.  I also think that there may be some need for additional handling to ensure that this ice doesn't interfere with operation of normal URL-based snippets.  But, nonetheless, I thought I'd open this PR as a way to start discussing whether this could be worked to a point of merging into the mainline.

I am very new the zinit codebase, and I really had to flex my zsh to read through its code.   Please let me know if there are things that need to be adjusted in this PR.
