### PR TITLE
More robust handling of symlinks in the completions folder

### DIFF
--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -501,7 +501,7 @@ ZINIT[EXTENDED_GLOB]=""
     # This in effect works as: "if different, then readlink"
     [[ -n "$tmp" ]] && in_plugin_path="$tmp"
 
-    if [[ "$in_plugin_path" != "$cpath" ]]; then
+    if [[ "$in_plugin_path" != "$cpath" && -r "$in_plugin_path" ]]; then
         # Get the user---plugin part of path
         while [[ "$in_plugin_path" != ${ZINIT[PLUGINS_DIR]}/[^/]## && "$in_plugin_path" != "/" ]]; do
             in_plugin_path="${in_plugin_path:h}"

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -503,7 +503,7 @@ ZINIT[EXTENDED_GLOB]=""
 
     if [[ "$in_plugin_path" != "$cpath" && -r "$in_plugin_path" ]]; then
         # Get the user---plugin part of path
-        while [[ "$in_plugin_path" != ${ZINIT[PLUGINS_DIR]}/[^/]## && "$in_plugin_path" != "/" ]]; do
+        while [[ "$in_plugin_path" != ${ZINIT[PLUGINS_DIR]}/[^/]## && "$in_plugin_path" != "/" && "$in_plugin_path" != "." ]]; do
             in_plugin_path="${in_plugin_path:h}"
         done
         in_plugin_path="${in_plugin_path:t}"


### PR DESCRIPTION
zinit clist assumes that all symlinks in the completions directory are absolute symlinks that resolve to a file in a plugin directory. These two commits ensure:
1) That the symlink resolves to a readable file
2) That the code extracting the plugin ID from a relative symlink to a non-plugin path does not get stuck in an infinite loop.