### PR TITLE
(bugfix): zinit self-update uses current branch

### DIFF
--- a/doc/zsdoc/zinit-autoload.zsh.adoc
+++ b/doc/zsdoc/zinit-autoload.zsh.adoc
@@ -1068,7 +1068,7 @@ ____
  User-action entry point.
 ____
 
-Has 45 line(s). Calls functions:
+Has 42 line(s). Calls functions:
 
  .zinit-self-update
  |-- zinit.zsh/+zinit-message

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -711,14 +711,14 @@ ZINIT[EXTENDED_GLOB]=""
     emulate -LR zsh
     setopt extendedglob typesetsilent warncreateglobal
 
-    [[ $1 = -q ]] && +zinit-message "{info2}Updating Zinit{…}{rst}"
+    [[ $1 = -q ]] && +zinit-message -n "{info2}[self-update]{info2}{msg2} Updating Zinit repository{msg2}" \
 
     local nl=$'\n' escape=$'\x1b['
     local current_branch=$(builtin pushd $ZINIT[BIN_DIR] > /dev/null && git branch --show-current && popd > /dev/null)
     local -a lines
     (
         builtin cd -q "$ZINIT[BIN_DIR]" \
-        && +zinit-message -n "{pre}[self-update]{msg2} fetching changes for {msg2}$current_branch$nl{cmd}" \
+        && +zinit-message -n "{pre}[self-update]{msg2} fetching latest changes from {msg2}$current_branch$nl{cmd}" \
         && command git fetch --quiet \
         && lines=( ${(f)"$(command git log --color --date=short --pretty=format:'%Cgreen%cd %h %Creset%s %Cred%d%Creset || %b' ..FETCH_HEAD)"} )
         if (( ${#lines} > 0 )); then
@@ -743,14 +743,14 @@ ZINIT[EXTENDED_GLOB]=""
         }
     )
     if [[ $1 != -q ]] {
-        +zinit-message "Compiling Zinit (zcompile){…}"
+        +zinit-message -n "{pre}[self-update]{msg2} compiling zinit (zinit){msg2}"
     }
     command rm -f $ZINIT[BIN_DIR]/*.zwc(DN)
     zcompile -U $ZINIT[BIN_DIR]/zinit.zsh
     zcompile -U $ZINIT[BIN_DIR]/zinit-{'side','install','autoload','additional'}.zsh
     zcompile -U $ZINIT[BIN_DIR]/share/git-process-output.zsh
     # Load for the current session
-    [[ $1 != -q ]] && +zinit-message "Reloading Zinit for the current session{…}"
+    [[ $1 != -q ]] && +zinit-message -n "{pre}[self-update]{msg2} Reloading Zinit for the current session{msg2}"
     source $ZINIT[BIN_DIR]/zinit.zsh
     zcompile -U $ZINIT[BIN_DIR]/zinit-{'side','install','autoload'}.zsh
     # Read and remember the new modification timestamps

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -711,7 +711,7 @@ ZINIT[EXTENDED_GLOB]=""
     emulate -LR zsh
     setopt extendedglob typesetsilent warncreateglobal
 
-    [[ $1 = -q ]] && +zinit-message -n "{info2}[self-update]{info2}{msg2} Updating Zinit repository{msg2}" \
+    [[ $1 = -q ]] && +zinit-message -n "{pre}[self-update]{msg2} Updating Zinit repository{msg2}" \
 
     local nl=$'\n' escape=$'\x1b['
     local current_branch=$(builtin pushd $ZINIT[BIN_DIR] > /dev/null && git branch --show-current && popd > /dev/null)
@@ -743,7 +743,7 @@ ZINIT[EXTENDED_GLOB]=""
         }
     )
     if [[ $1 != -q ]] {
-        +zinit-message -n "{pre}[self-update]{msg2} compiling zinit (zinit){msg2}"
+        +zinit-message -n "{pre}[self-update]{msg2} compiling zinit via {msg2}zcompile{cmd}"
     }
     command rm -f $ZINIT[BIN_DIR]/*.zwc(DN)
     zcompile -U $ZINIT[BIN_DIR]/zinit.zsh


### PR DESCRIPTION
fixes bug where zinit self-update was hard-coded to use main, even if it was on a different branch.

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>