### PR TITLE
Enable alternate 'tree' commands for zinit ls

### DIFF
--- a/doc/zsdoc/zinit-autoload.zsh.adoc
+++ b/doc/zsdoc/zinit-autoload.zsh.adoc
@@ -25,8 +25,8 @@ FUNCTIONS
  .zinit-check-which-completions-are-installed
  .zinit-clear-completions
  .zinit-clear-report-for
- .zinit-compiled
  .zinit-compile-uncompile-all
+ .zinit-compiled
  .zinit-confirm
  .zinit-create
  .zinit-delete
@@ -350,29 +350,6 @@ Called by:
 
  .zinit-unload
 
-.zinit-compiled
-~~~~~~~~~~~~~~~
-
-____
- 
- FUNCTION: .zinit-compiled [[[
- Displays list of plugins that are compiled.
- 
- User-action entry point.
-____
-
-Has 26 line(s). Calls functions:
-
- .zinit-compiled
- |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- `-- zinit.zsh/.zinit-any-to-user-plugin
-
-Uses feature(s): _setopt_
-
-Called by:
-
- zinit.zsh/zinit
-
 .zinit-compile-uncompile-all
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -388,6 +365,29 @@ Has 23 line(s). Calls functions:
 
  .zinit-compile-uncompile-all
  |-- zinit-install.zsh/.zinit-compile-plugin
+ |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+ `-- zinit.zsh/.zinit-any-to-user-plugin
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ zinit.zsh/zinit
+
+.zinit-compiled
+~~~~~~~~~~~~~~~
+
+____
+ 
+ FUNCTION: .zinit-compiled [[[
+ Displays list of plugins that are compiled.
+ 
+ User-action entry point.
+____
+
+Has 26 line(s). Calls functions:
+
+ .zinit-compiled
  |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
  `-- zinit.zsh/.zinit-any-to-user-plugin
 
@@ -462,9 +462,9 @@ Has 99 line(s). Calls functions:
 
  .zinit-delete
  |-- zinit-side.zsh/.zinit-compute-ice
+ |-- zinit.zsh/+zinit-prehelp-usage-message
  |-- zinit.zsh/.zinit-any-to-user-plugin
- |-- zinit.zsh/.zinit-parse-opts
- `-- zinit.zsh/+zinit-prehelp-usage-message
+ `-- zinit.zsh/.zinit-parse-opts
 
 Uses feature(s): _setopt_
 
@@ -865,7 +865,7 @@ ____
  FUNCTION: .zinit-ls [[[
 ____
 
-Has 19 line(s). Doesn't call other functions.
+Has 20 line(s). Doesn't call other functions.
 
 Uses feature(s): _setopt_
 
@@ -1071,8 +1071,8 @@ ____
 Has 45 line(s). Calls functions:
 
  .zinit-self-update
- |-- zinit.zsh/.zinit-get-mtime-into
- `-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/.zinit-get-mtime-into
 
 Uses feature(s): _setopt_, _source_, _zcompile_
 
@@ -1390,8 +1390,8 @@ Has 84 line(s). Calls functions:
 
  .zinit-update-all-parallel
  |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- |-- zinit.zsh/.zinit-any-to-user-plugin
- `-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/.zinit-any-to-user-plugin
 
 Uses feature(s): _setopt_
 
@@ -1425,8 +1425,8 @@ Has 325 line(s). Calls functions:
  |-- zinit-side.zsh/.zinit-exists-physically-message
  |-- zinit-side.zsh/.zinit-store-ices
  |-- zinit-side.zsh/.zinit-two-paths
- |-- zinit.zsh/.zinit-any-to-user-plugin
  |-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/.zinit-any-to-user-plugin
  `-- zinit.zsh/.zinit-set-m-func
 
 Uses feature(s): _kill_, _read_, _setopt_, _source_, _trap_, _wait_
@@ -1456,9 +1456,9 @@ Has 131 line(s). Calls functions:
  .zinit-update-or-status-all
  |-- zinit-install.zsh/.zinit-compinit
  |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+ |-- zinit.zsh/+zinit-message
  |-- zinit.zsh/.zinit-any-to-user-plugin
- |-- zinit.zsh/.zinit-get-mtime-into
- `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/.zinit-get-mtime-into
 
 Uses feature(s): _setopt_, _source_
 

--- a/doc/zsdoc/zinit-autoload.zsh.adoc
+++ b/doc/zsdoc/zinit-autoload.zsh.adoc
@@ -85,6 +85,8 @@ Script Body
 
 Has 5 line(s). No functions are called (may set up e.g. a hook, a Zle widget bound to a key, etc.).
 
+Uses feature(s): _source_
+
 .zinit-any-to-uspl2
 ~~~~~~~~~~~~~~~~~~~
 
@@ -100,9 +102,13 @@ ____
 
 Has 2 line(s). Calls functions:
 
- 
+ .zinit-any-to-uspl2
+ `-- zinit.zsh/.zinit-any-to-user-plugin
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ .zinit-clear-report-for
+ .zinit-exists-message
 
 .zinit-at-eval
 ~~~~~~~~~~~~~~
@@ -112,7 +118,12 @@ ____
  FUNCTION: .zinit-at-eval [[[
 ____
 
-Has 5 line(s). Doesn't call other functions.
+Has 5 line(s). Calls functions:
+
+ .zinit-at-eval
+ `-- zinit.zsh/@zinit-substitute
+
+Uses feature(s): _eval_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -127,9 +138,16 @@ ____
  how to load the module in .zshrc.
 ____
 
-Has 39 line(s). Doesn't call other functions.
+Has 39 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-build-module
+ `-- zinit.zsh/+zinit-message
+
+Uses feature(s): _setopt_, _trap_
+
+Called by:
+
+ .zinit-module
 
 .zinit-cd
 ~~~~~~~~~
@@ -145,7 +163,12 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 15 line(s). Doesn't call other functions.
+Has 15 line(s). Calls functions:
+
+ .zinit-cd
+ `-- zinit.zsh/+zinit-message
+
+Uses feature(s): _setopt_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -162,9 +185,13 @@ ____
  $1 - e.g. "_mkdir" or "mkdir"
 ____
 
-Has 30 line(s). Doesn't call other functions.
+Has 30 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-cdisable
+
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-cenable
 ~~~~~~~~~~~~~~
@@ -179,9 +206,13 @@ ____
  $1 - e.g. "_mkdir" or "mkdir"
 ____
 
-Has 31 line(s). Doesn't call other functions.
+Has 31 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-cenable
+
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-changes
 ~~~~~~~~~~~~~~
@@ -198,7 +229,11 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 9 line(s). Doesn't call other functions.
+Has 9 line(s). Calls functions:
+
+ .zinit-changes
+ |-- zinit-side.zsh/.zinit-exists-physically-message
+ `-- zinit.zsh/.zinit-any-to-user-plugin
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -220,7 +255,10 @@ ____
 
 Has 11 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ .zinit-cdisable
+ .zinit-cenable
 
 .zinit-check-which-completions-are-enabled
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -241,7 +279,9 @@ ____
 
 Has 11 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ .zinit-show-report
 
 .zinit-check-which-completions-are-installed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -259,7 +299,9 @@ ____
 
 Has 12 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ .zinit-show-report
 
 .zinit-clear-completions
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -275,9 +317,17 @@ ____
  User-action entry point.
 ____
 
-Has 37 line(s). Doesn't call other functions.
+Has 37 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-clear-completions
+ `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ zinit.zsh/.zinit-prepare-home
+ zinit.zsh/zinit
 
 .zinit-clear-report-for
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -292,9 +342,13 @@ ____
  $2 - (optional) plugin (only when $1 - i.e. user - given)
 ____
 
-Has 23 line(s). Doesn't call other functions.
+Has 23 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-clear-report-for
+
+Called by:
+
+ .zinit-unload
 
 .zinit-compile-uncompile-all
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -307,9 +361,18 @@ ____
  User-action entry point.
 ____
 
-Has 23 line(s). Doesn't call other functions.
+Has 23 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-compile-uncompile-all
+ |-- zinit-install.zsh/.zinit-compile-plugin
+ |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+ `-- zinit.zsh/.zinit-any-to-user-plugin
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-compiled
 ~~~~~~~~~~~~~~~
@@ -322,9 +385,17 @@ ____
  User-action entry point.
 ____
 
-Has 26 line(s). Doesn't call other functions.
+Has 26 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-compiled
+ |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+ `-- zinit.zsh/.zinit-any-to-user-plugin
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-confirm
 ~~~~~~~~~~~~~~
@@ -341,7 +412,11 @@ ____
 
 Has 22 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _eval_, _read_
+
+Called by:
+
+ .zinit-delete
 
 .zinit-create
 ~~~~~~~~~~~~~
@@ -357,7 +432,14 @@ ____
  $2 - (optional) plugin (only when $1 - i.e. user - given)
 ____
 
-Has 103 line(s). Doesn't call other functions.
+Has 103 line(s). Calls functions:
+
+ .zinit-create
+ |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+ |-- zinit-side.zsh/.zinit-exists-physically
+ `-- zinit.zsh/.zinit-any-to-user-plugin
+
+Uses feature(s): _autoload_, _setopt_, _vared_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -376,7 +458,15 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 99 line(s). Doesn't call other functions.
+Has 99 line(s). Calls functions:
+
+ .zinit-delete
+ |-- zinit-side.zsh/.zinit-compute-ice
+ |-- zinit.zsh/+zinit-prehelp-usage-message
+ |-- zinit.zsh/.zinit-any-to-user-plugin
+ `-- zinit.zsh/.zinit-parse-opts
+
+Uses feature(s): _setopt_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -394,7 +484,12 @@ ____
 
 Has 30 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-show-report
+ .zinit-unload
 
 .zinit-diff-functions-compute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -410,7 +505,12 @@ ____
 
 Has 19 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-show-report
+ .zinit-unload
 
 .zinit-diff-options-compute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -426,7 +526,12 @@ ____
 
 Has 17 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-show-report
+ .zinit-unload
 
 .zinit-diff-parameter-compute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -443,7 +548,12 @@ ____
 
 Has 28 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-show-report
+ .zinit-unload
 
 .zinit-edit
 ~~~~~~~~~~~
@@ -460,7 +570,10 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 22 line(s). Doesn't call other functions.
+Has 22 line(s). Calls functions:
+
+ .zinit-edit
+ `-- zinit-side.zsh/.zinit-compute-ice
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -477,9 +590,15 @@ ____
  $2 - (optional) plugin (only when $1 - i.e. user - given)
 ____
 
-Has 7 line(s). Doesn't call other functions.
+Has 7 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-exists-message
+ `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+
+Called by:
+
+ .zinit-show-report
+ .zinit-unload
 
 .zinit-find-completions-of-plugin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -494,9 +613,16 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 6 line(s). Doesn't call other functions.
+Has 6 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-find-completions-of-plugin
+ `-- zinit.zsh/.zinit-any-to-user-plugin
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-show-report
 
 .zinit-format-env
 ~~~~~~~~~~~~~~~~~
@@ -513,7 +639,9 @@ ____
 
 Has 16 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ .zinit-show-report
 
 .zinit-format-functions
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -529,7 +657,9 @@ ____
 
 Has 36 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ .zinit-show-report
 
 .zinit-format-options
 ~~~~~~~~~~~~~~~~~~~~~
@@ -543,9 +673,13 @@ ____
  $1 - user/plugin (i.e. uspl2 format of plugin-spec)
 ____
 
-Has 21 line(s). Doesn't call other functions.
+Has 21 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-format-options
+
+Called by:
+
+ .zinit-show-report
 
 .zinit-format-parameter
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -561,7 +695,11 @@ ____
 
 Has 35 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-show-report
 
 .zinit-get-completion-owner
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -585,7 +723,13 @@ ____
 
 Has 22 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-clear-completions
+ .zinit-get-completion-owner-uspl2col
+ .zinit-show-completions
 
 .zinit-get-completion-owner-uspl2col
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -600,9 +744,15 @@ ____
  $2 - readlink command (":" or "readlink")
 ____
 
-Has 2 line(s). Doesn't call other functions.
+Has 2 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-get-completion-owner-uspl2col
+ `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+
+Called by:
+
+ .zinit-cdisable
+ .zinit-cenable
 
 .zinit-get-path
 ~~~~~~~~~~~~~~~
@@ -617,9 +767,17 @@ ____
  nickname (i.e. id-as'' ice-mod), or a snippet nickname.
 ____
 
-Has 8 line(s). Doesn't call other functions.
+Has 8 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-get-path
+ `-- zinit.zsh/.zinit-get-object-path
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-cd
+ .zinit-uninstall-completions
 
 .zinit-glance
 ~~~~~~~~~~~~~
@@ -636,7 +794,12 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 39 line(s). Doesn't call other functions.
+Has 39 line(s). Calls functions:
+
+ .zinit-glance
+ |-- zinit-side.zsh/.zinit-exists-physically-message
+ |-- zinit-side.zsh/.zinit-first
+ `-- zinit.zsh/.zinit-any-to-user-plugin
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -653,7 +816,9 @@ ____
 
 Has 67 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-list-bindkeys
 ~~~~~~~~~~~~~~~~~~~~
@@ -664,9 +829,14 @@ ____
  FUNCTION: .zinit-list-bindkeys [[[
 ____
 
-Has 44 line(s). Doesn't call other functions.
+Has 44 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-list-bindkeys
+ `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-list-compdef-replay
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -683,7 +853,9 @@ ____
 
 Has 5 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-ls
 ~~~~~~~~~
@@ -695,7 +867,11 @@ ____
 
 Has 20 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _setopt_
+
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-module
 ~~~~~~~~~~~~~
@@ -709,9 +885,15 @@ ____
  defined in zinit.zsh, to not make this file longer than it's needed.
 ____
 
-Has 24 line(s). Doesn't call other functions.
+Has 24 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-module
+
+Called by:
+
+ .zinit-build-module
+ zinit.zsh/Script-Body
+ zinit.zsh/zinit
 
 .zinit-pager
 ~~~~~~~~~~~~
@@ -724,7 +906,13 @@ ____
 
 Has 14 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-glance
+ .zinit-self-update
+ .zinit-update-or-status
 
 .zinit-prepare-readlink
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -739,7 +927,14 @@ ____
 
 Has 4 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _type_
+
+Called by:
+
+ .zinit-cdisable
+ .zinit-cenable
+ .zinit-clear-completions
+ .zinit-show-completions
 
 .zinit-recall
 ~~~~~~~~~~~~~
@@ -750,7 +945,13 @@ ____
  FUNCTION: .zinit-recall [[[
 ____
 
-Has 38 line(s). Doesn't call other functions.
+Has 38 line(s). Calls functions:
+
+ .zinit-recall
+ |-- zinit-side.zsh/.zinit-compute-ice
+ `-- zinit.zsh/+zinit-deploy-message
+
+Uses feature(s): _setopt_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -767,9 +968,16 @@ ____
  $1 - time spec, e.g. "1 week"
 ____
 
-Has 28 line(s). Doesn't call other functions.
+Has 28 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-recently
+ `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-restore-extendedglob
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -782,7 +990,12 @@ ____
 
 Has 1 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-format-options
+ .zinit-unload
 
 .zinit-run-delete-hooks
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -792,7 +1005,12 @@ ____
  FUNCTION: .zinit-run-delete-hooks [[[
 ____
 
-Has 17 line(s). Doesn't call other functions.
+Has 17 line(s). Calls functions:
+
+ .zinit-run-delete-hooks
+ `-- zinit-side.zsh/.zinit-countdown
+
+Uses feature(s): _eval_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -808,7 +1026,12 @@ ____
 
 Has 2 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-format-options
+ .zinit-unload
 
 .zinit-search-completions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -823,9 +1046,16 @@ ____
  User-action entry point.
 ____
 
-Has 43 line(s). Doesn't call other functions.
+Has 43 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-search-completions
+ `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-self-update
 ~~~~~~~~~~~~~~~~~~
@@ -838,9 +1068,18 @@ ____
  User-action entry point.
 ____
 
-Has 45 line(s). Doesn't call other functions.
+Has 45 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-self-update
+ |-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/.zinit-get-mtime-into
+
+Uses feature(s): _setopt_, _source_, _zcompile_
+
+Called by:
+
+ .zinit-update-or-status-all
+ zinit.zsh/zinit
 
 .zinit-show-all-reports
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -853,9 +1092,13 @@ ____
  User-action entry point.
 ____
 
-Has 5 line(s). Doesn't call other functions.
+Has 5 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-show-all-reports
+
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-show-completions
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -872,9 +1115,16 @@ ____
  User-action entry point.
 ____
 
-Has 72 line(s). Doesn't call other functions.
+Has 72 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-show-completions
+ `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-show-debug-report
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -887,9 +1137,13 @@ ____
  User-action entry point.
 ____
 
-Has 1 line(s). Doesn't call other functions.
+Has 1 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-show-debug-report
+
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-show-registered-plugins
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -902,9 +1156,16 @@ ____
  User-action entry point.
 ____
 
-Has 22 line(s). Doesn't call other functions.
+Has 22 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-show-registered-plugins
+ `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-show-report
 ~~~~~~~~~~~~~~~~~~
@@ -920,9 +1181,18 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 71 line(s). Doesn't call other functions.
+Has 71 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-show-report
+ `-- zinit.zsh/.zinit-any-to-user-plugin
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-show-all-reports
+ .zinit-show-debug-report
+ zinit.zsh/zinit
 
 .zinit-show-times
 ~~~~~~~~~~~~~~~~~
@@ -935,9 +1205,16 @@ ____
  User-action entry point.
 ____
 
-Has 60 line(s). Doesn't call other functions.
+Has 60 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-show-times
+ `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-show-zstatus
 ~~~~~~~~~~~~~~~~~~~
@@ -952,9 +1229,16 @@ ____
  User-action entry point.
 ____
 
-Has 47 line(s). Doesn't call other functions.
+Has 47 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-show-zstatus
+ `-- zinit.zsh/+zinit-message
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-stress
 ~~~~~~~~~~~~~
@@ -974,7 +1258,14 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 38 line(s). Doesn't call other functions.
+Has 38 line(s). Calls functions:
+
+ .zinit-stress
+ |-- zinit-side.zsh/.zinit-exists-physically-message
+ |-- zinit-side.zsh/.zinit-first
+ `-- zinit.zsh/.zinit-any-to-user-plugin
+
+Uses feature(s): _setopt_, _zcompile_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -992,9 +1283,18 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 22 line(s). Doesn't call other functions.
+Has 22 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-uncompile-plugin
+ |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+ `-- zinit.zsh/.zinit-any-to-user-plugin
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-compile-uncompile-all
+ zinit.zsh/zinit
 
 .zinit-uninstall-completions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1009,9 +1309,18 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 46 line(s). Doesn't call other functions.
+Has 46 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-uninstall-completions
+ |-- zinit-install.zsh/.zinit-compinit
+ |-- zinit-install.zsh/.zinit-forget-completion
+ `-- zinit.zsh/+zinit-message
+
+Uses feature(s): _setopt_, _source_
+
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-unload
 ~~~~~~~~~~~~~
@@ -1037,9 +1346,18 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 394 line(s). Doesn't call other functions.
+Has 394 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-unload
+ |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+ `-- zinit.zsh/.zinit-any-to-user-plugin
+
+Uses feature(s): _alias_, _bindkey_, _eval_, _setopt_, _unalias_, _unfunction_, _zle_, _zstyle_
+
+Called by:
+
+ zinit.zsh/.zinit-run-task
+ zinit.zsh/zinit
 
 .zinit-unregister-plugin
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1051,9 +1369,14 @@ ____
  zsh_loaded_plugins array (managed according to the plugin standard)
 ____
 
-Has 6 line(s). Doesn't call other functions.
+Has 6 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-unregister-plugin
+ `-- zinit.zsh/.zinit-any-to-user-plugin
+
+Called by:
+
+ .zinit-unload
 
 .zinit-update-all-parallel
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1063,9 +1386,18 @@ ____
  FUNCTION: .zinit-update-in-parallel [[[
 ____
 
-Has 84 line(s). Doesn't call other functions.
+Has 84 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-update-all-parallel
+ |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+ |-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/.zinit-any-to-user-plugin
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-update-or-status-all
 
 .zinit-update-or-status
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -1082,9 +1414,28 @@ ____
  $3 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 325 line(s). Doesn't call other functions.
+Has 325 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-update-or-status
+ |-- zinit-install.zsh/.zinit-get-latest-gh-r-url-part
+ |-- zinit-install.zsh/.zinit-setup-plugin-dir
+ |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+ |-- zinit-side.zsh/.zinit-compute-ice
+ |-- zinit-side.zsh/.zinit-exists-physically
+ |-- zinit-side.zsh/.zinit-exists-physically-message
+ |-- zinit-side.zsh/.zinit-store-ices
+ |-- zinit-side.zsh/.zinit-two-paths
+ |-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/.zinit-any-to-user-plugin
+ `-- zinit.zsh/.zinit-set-m-func
+
+Uses feature(s): _kill_, _read_, _setopt_, _source_, _trap_, _wait_
+
+Called by:
+
+ .zinit-update-all-parallel
+ .zinit-update-or-status-all
+ zinit.zsh/zinit
 
 .zinit-update-or-status-all
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1100,9 +1451,20 @@ ____
  User-action entry point.
 ____
 
-Has 133 line(s). Doesn't call other functions.
+Has 133 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-update-or-status-all
+ |-- zinit-install.zsh/.zinit-compinit
+ |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+ |-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/.zinit-any-to-user-plugin
+ `-- zinit.zsh/.zinit-get-mtime-into
+
+Uses feature(s): _setopt_, _source_
+
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-update-or-status-snippet
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1117,9 +1479,19 @@ ____
  $2 - snippet URL
 ____
 
-Has 34 line(s). Doesn't call other functions.
+Has 34 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-update-or-status-snippet
+ |-- zinit-install.zsh/.zinit-update-snippet
+ `-- zinit-side.zsh/.zinit-compute-ice
+
+Uses feature(s): _source_
+
+Called by:
+
+ .zinit-update-all-parallel
+ .zinit-update-or-status-all
+ .zinit-update-or-status
 
 .zinit-wait-for-update-jobs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1130,7 +1502,14 @@ ____
  FUNCTION: .zinit-wait-for-update-jobs [[[
 ____
 
-Has 18 line(s). Doesn't call other functions.
+Has 18 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-wait-for-update-jobs
+ `-- zinit.zsh/+zinit-message
+
+Uses feature(s): _wait_
+
+Called by:
+
+ .zinit-update-all-parallel
 

--- a/doc/zsdoc/zinit-autoload.zsh.adoc
+++ b/doc/zsdoc/zinit-autoload.zsh.adoc
@@ -85,8 +85,6 @@ Script Body
 
 Has 5 line(s). No functions are called (may set up e.g. a hook, a Zle widget bound to a key, etc.).
 
-Uses feature(s): _source_
-
 .zinit-any-to-uspl2
 ~~~~~~~~~~~~~~~~~~~
 
@@ -102,13 +100,9 @@ ____
 
 Has 2 line(s). Calls functions:
 
- .zinit-any-to-uspl2
- `-- zinit.zsh/.zinit-any-to-user-plugin
+ 
 
-Called by:
-
- .zinit-clear-report-for
- .zinit-exists-message
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-at-eval
 ~~~~~~~~~~~~~~
@@ -118,12 +112,7 @@ ____
  FUNCTION: .zinit-at-eval [[[
 ____
 
-Has 5 line(s). Calls functions:
-
- .zinit-at-eval
- `-- zinit.zsh/@zinit-substitute
-
-Uses feature(s): _eval_
+Has 5 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -138,16 +127,9 @@ ____
  how to load the module in .zshrc.
 ____
 
-Has 39 line(s). Calls functions:
+Has 39 line(s). Doesn't call other functions.
 
- .zinit-build-module
- `-- zinit.zsh/+zinit-message
-
-Uses feature(s): _setopt_, _trap_
-
-Called by:
-
- .zinit-module
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-cd
 ~~~~~~~~~
@@ -163,12 +145,7 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 15 line(s). Calls functions:
-
- .zinit-cd
- `-- zinit.zsh/+zinit-message
-
-Uses feature(s): _setopt_
+Has 15 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -185,13 +162,9 @@ ____
  $1 - e.g. "_mkdir" or "mkdir"
 ____
 
-Has 30 line(s). Calls functions:
+Has 30 line(s). Doesn't call other functions.
 
- .zinit-cdisable
-
-Called by:
-
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-cenable
 ~~~~~~~~~~~~~~
@@ -206,13 +179,9 @@ ____
  $1 - e.g. "_mkdir" or "mkdir"
 ____
 
-Has 31 line(s). Calls functions:
+Has 31 line(s). Doesn't call other functions.
 
- .zinit-cenable
-
-Called by:
-
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-changes
 ~~~~~~~~~~~~~~
@@ -229,11 +198,7 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 9 line(s). Calls functions:
-
- .zinit-changes
- |-- zinit-side.zsh/.zinit-exists-physically-message
- `-- zinit.zsh/.zinit-any-to-user-plugin
+Has 9 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -255,10 +220,7 @@ ____
 
 Has 11 line(s). Doesn't call other functions.
 
-Called by:
-
- .zinit-cdisable
- .zinit-cenable
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-check-which-completions-are-enabled
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -279,9 +241,7 @@ ____
 
 Has 11 line(s). Doesn't call other functions.
 
-Called by:
-
- .zinit-show-report
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-check-which-completions-are-installed
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -299,9 +259,7 @@ ____
 
 Has 12 line(s). Doesn't call other functions.
 
-Called by:
-
- .zinit-show-report
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-clear-completions
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -317,17 +275,9 @@ ____
  User-action entry point.
 ____
 
-Has 37 line(s). Calls functions:
+Has 37 line(s). Doesn't call other functions.
 
- .zinit-clear-completions
- `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
-
-Uses feature(s): _setopt_
-
-Called by:
-
- zinit.zsh/.zinit-prepare-home
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-clear-report-for
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -342,13 +292,9 @@ ____
  $2 - (optional) plugin (only when $1 - i.e. user - given)
 ____
 
-Has 23 line(s). Calls functions:
+Has 23 line(s). Doesn't call other functions.
 
- .zinit-clear-report-for
-
-Called by:
-
- .zinit-unload
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-compile-uncompile-all
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -361,18 +307,9 @@ ____
  User-action entry point.
 ____
 
-Has 23 line(s). Calls functions:
+Has 23 line(s). Doesn't call other functions.
 
- .zinit-compile-uncompile-all
- |-- zinit-install.zsh/.zinit-compile-plugin
- |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- `-- zinit.zsh/.zinit-any-to-user-plugin
-
-Uses feature(s): _setopt_
-
-Called by:
-
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-compiled
 ~~~~~~~~~~~~~~~
@@ -385,17 +322,9 @@ ____
  User-action entry point.
 ____
 
-Has 26 line(s). Calls functions:
+Has 26 line(s). Doesn't call other functions.
 
- .zinit-compiled
- |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- `-- zinit.zsh/.zinit-any-to-user-plugin
-
-Uses feature(s): _setopt_
-
-Called by:
-
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-confirm
 ~~~~~~~~~~~~~~
@@ -412,11 +341,7 @@ ____
 
 Has 22 line(s). Doesn't call other functions.
 
-Uses feature(s): _eval_, _read_
-
-Called by:
-
- .zinit-delete
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-create
 ~~~~~~~~~~~~~
@@ -432,14 +357,7 @@ ____
  $2 - (optional) plugin (only when $1 - i.e. user - given)
 ____
 
-Has 103 line(s). Calls functions:
-
- .zinit-create
- |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- |-- zinit-side.zsh/.zinit-exists-physically
- `-- zinit.zsh/.zinit-any-to-user-plugin
-
-Uses feature(s): _autoload_, _setopt_, _vared_
+Has 103 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -458,15 +376,7 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 99 line(s). Calls functions:
-
- .zinit-delete
- |-- zinit-side.zsh/.zinit-compute-ice
- |-- zinit.zsh/+zinit-prehelp-usage-message
- |-- zinit.zsh/.zinit-any-to-user-plugin
- `-- zinit.zsh/.zinit-parse-opts
-
-Uses feature(s): _setopt_
+Has 99 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -484,12 +394,7 @@ ____
 
 Has 30 line(s). Doesn't call other functions.
 
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-show-report
- .zinit-unload
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-diff-functions-compute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -505,12 +410,7 @@ ____
 
 Has 19 line(s). Doesn't call other functions.
 
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-show-report
- .zinit-unload
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-diff-options-compute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -526,12 +426,7 @@ ____
 
 Has 17 line(s). Doesn't call other functions.
 
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-show-report
- .zinit-unload
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-diff-parameter-compute
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -548,12 +443,7 @@ ____
 
 Has 28 line(s). Doesn't call other functions.
 
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-show-report
- .zinit-unload
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-edit
 ~~~~~~~~~~~
@@ -570,10 +460,7 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 22 line(s). Calls functions:
-
- .zinit-edit
- `-- zinit-side.zsh/.zinit-compute-ice
+Has 22 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -590,15 +477,9 @@ ____
  $2 - (optional) plugin (only when $1 - i.e. user - given)
 ____
 
-Has 7 line(s). Calls functions:
+Has 7 line(s). Doesn't call other functions.
 
- .zinit-exists-message
- `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
-
-Called by:
-
- .zinit-show-report
- .zinit-unload
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-find-completions-of-plugin
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -613,16 +494,9 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 6 line(s). Calls functions:
+Has 6 line(s). Doesn't call other functions.
 
- .zinit-find-completions-of-plugin
- `-- zinit.zsh/.zinit-any-to-user-plugin
-
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-show-report
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-format-env
 ~~~~~~~~~~~~~~~~~
@@ -639,9 +513,7 @@ ____
 
 Has 16 line(s). Doesn't call other functions.
 
-Called by:
-
- .zinit-show-report
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-format-functions
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -657,9 +529,7 @@ ____
 
 Has 36 line(s). Doesn't call other functions.
 
-Called by:
-
- .zinit-show-report
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-format-options
 ~~~~~~~~~~~~~~~~~~~~~
@@ -673,13 +543,9 @@ ____
  $1 - user/plugin (i.e. uspl2 format of plugin-spec)
 ____
 
-Has 21 line(s). Calls functions:
+Has 21 line(s). Doesn't call other functions.
 
- .zinit-format-options
-
-Called by:
-
- .zinit-show-report
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-format-parameter
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -695,11 +561,7 @@ ____
 
 Has 35 line(s). Doesn't call other functions.
 
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-show-report
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-get-completion-owner
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -723,13 +585,7 @@ ____
 
 Has 22 line(s). Doesn't call other functions.
 
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-clear-completions
- .zinit-get-completion-owner-uspl2col
- .zinit-show-completions
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-get-completion-owner-uspl2col
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -744,15 +600,9 @@ ____
  $2 - readlink command (":" or "readlink")
 ____
 
-Has 2 line(s). Calls functions:
+Has 2 line(s). Doesn't call other functions.
 
- .zinit-get-completion-owner-uspl2col
- `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
-
-Called by:
-
- .zinit-cdisable
- .zinit-cenable
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-get-path
 ~~~~~~~~~~~~~~~
@@ -767,17 +617,9 @@ ____
  nickname (i.e. id-as'' ice-mod), or a snippet nickname.
 ____
 
-Has 8 line(s). Calls functions:
+Has 8 line(s). Doesn't call other functions.
 
- .zinit-get-path
- `-- zinit.zsh/.zinit-get-object-path
-
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-cd
- .zinit-uninstall-completions
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-glance
 ~~~~~~~~~~~~~
@@ -794,12 +636,7 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 39 line(s). Calls functions:
-
- .zinit-glance
- |-- zinit-side.zsh/.zinit-exists-physically-message
- |-- zinit-side.zsh/.zinit-first
- `-- zinit.zsh/.zinit-any-to-user-plugin
+Has 39 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -816,9 +653,7 @@ ____
 
 Has 67 line(s). Doesn't call other functions.
 
-Called by:
-
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-list-bindkeys
 ~~~~~~~~~~~~~~~~~~~~
@@ -829,14 +664,9 @@ ____
  FUNCTION: .zinit-list-bindkeys [[[
 ____
 
-Has 44 line(s). Calls functions:
+Has 44 line(s). Doesn't call other functions.
 
- .zinit-list-bindkeys
- `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
-
-Called by:
-
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-list-compdef-replay
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -853,9 +683,7 @@ ____
 
 Has 5 line(s). Doesn't call other functions.
 
-Called by:
-
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-ls
 ~~~~~~~~~
@@ -867,11 +695,7 @@ ____
 
 Has 20 line(s). Doesn't call other functions.
 
-Uses feature(s): _setopt_
-
-Called by:
-
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-module
 ~~~~~~~~~~~~~
@@ -885,15 +709,9 @@ ____
  defined in zinit.zsh, to not make this file longer than it's needed.
 ____
 
-Has 24 line(s). Calls functions:
+Has 24 line(s). Doesn't call other functions.
 
- .zinit-module
-
-Called by:
-
- .zinit-build-module
- zinit.zsh/Script-Body
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-pager
 ~~~~~~~~~~~~
@@ -906,13 +724,7 @@ ____
 
 Has 14 line(s). Doesn't call other functions.
 
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-glance
- .zinit-self-update
- .zinit-update-or-status
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-prepare-readlink
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -927,14 +739,7 @@ ____
 
 Has 4 line(s). Doesn't call other functions.
 
-Uses feature(s): _type_
-
-Called by:
-
- .zinit-cdisable
- .zinit-cenable
- .zinit-clear-completions
- .zinit-show-completions
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-recall
 ~~~~~~~~~~~~~
@@ -945,13 +750,7 @@ ____
  FUNCTION: .zinit-recall [[[
 ____
 
-Has 38 line(s). Calls functions:
-
- .zinit-recall
- |-- zinit-side.zsh/.zinit-compute-ice
- `-- zinit.zsh/+zinit-deploy-message
-
-Uses feature(s): _setopt_
+Has 38 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -968,16 +767,9 @@ ____
  $1 - time spec, e.g. "1 week"
 ____
 
-Has 28 line(s). Calls functions:
+Has 28 line(s). Doesn't call other functions.
 
- .zinit-recently
- `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
-
-Uses feature(s): _setopt_
-
-Called by:
-
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-restore-extendedglob
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -990,12 +782,7 @@ ____
 
 Has 1 line(s). Doesn't call other functions.
 
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-format-options
- .zinit-unload
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-run-delete-hooks
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -1005,12 +792,7 @@ ____
  FUNCTION: .zinit-run-delete-hooks [[[
 ____
 
-Has 17 line(s). Calls functions:
-
- .zinit-run-delete-hooks
- `-- zinit-side.zsh/.zinit-countdown
-
-Uses feature(s): _eval_
+Has 17 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1026,12 +808,7 @@ ____
 
 Has 2 line(s). Doesn't call other functions.
 
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-format-options
- .zinit-unload
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-search-completions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1046,16 +823,9 @@ ____
  User-action entry point.
 ____
 
-Has 43 line(s). Calls functions:
+Has 43 line(s). Doesn't call other functions.
 
- .zinit-search-completions
- `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
-
-Uses feature(s): _setopt_
-
-Called by:
-
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-self-update
 ~~~~~~~~~~~~~~~~~~
@@ -1068,18 +838,9 @@ ____
  User-action entry point.
 ____
 
-Has 45 line(s). Calls functions:
+Has 45 line(s). Doesn't call other functions.
 
- .zinit-self-update
- |-- zinit.zsh/+zinit-message
- `-- zinit.zsh/.zinit-get-mtime-into
-
-Uses feature(s): _setopt_, _source_, _zcompile_
-
-Called by:
-
- .zinit-update-or-status-all
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-show-all-reports
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -1092,13 +853,9 @@ ____
  User-action entry point.
 ____
 
-Has 5 line(s). Calls functions:
+Has 5 line(s). Doesn't call other functions.
 
- .zinit-show-all-reports
-
-Called by:
-
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-show-completions
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -1115,16 +872,9 @@ ____
  User-action entry point.
 ____
 
-Has 72 line(s). Calls functions:
+Has 72 line(s). Doesn't call other functions.
 
- .zinit-show-completions
- `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
-
-Uses feature(s): _setopt_
-
-Called by:
-
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-show-debug-report
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1137,13 +887,9 @@ ____
  User-action entry point.
 ____
 
-Has 1 line(s). Calls functions:
+Has 1 line(s). Doesn't call other functions.
 
- .zinit-show-debug-report
-
-Called by:
-
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-show-registered-plugins
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1156,16 +902,9 @@ ____
  User-action entry point.
 ____
 
-Has 22 line(s). Calls functions:
+Has 22 line(s). Doesn't call other functions.
 
- .zinit-show-registered-plugins
- `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
-
-Uses feature(s): _setopt_
-
-Called by:
-
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-show-report
 ~~~~~~~~~~~~~~~~~~
@@ -1181,18 +920,9 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 71 line(s). Calls functions:
+Has 71 line(s). Doesn't call other functions.
 
- .zinit-show-report
- `-- zinit.zsh/.zinit-any-to-user-plugin
-
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-show-all-reports
- .zinit-show-debug-report
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-show-times
 ~~~~~~~~~~~~~~~~~
@@ -1205,16 +935,9 @@ ____
  User-action entry point.
 ____
 
-Has 60 line(s). Calls functions:
+Has 60 line(s). Doesn't call other functions.
 
- .zinit-show-times
- `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
-
-Uses feature(s): _setopt_
-
-Called by:
-
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-show-zstatus
 ~~~~~~~~~~~~~~~~~~~
@@ -1229,16 +952,9 @@ ____
  User-action entry point.
 ____
 
-Has 47 line(s). Calls functions:
+Has 47 line(s). Doesn't call other functions.
 
- .zinit-show-zstatus
- `-- zinit.zsh/+zinit-message
-
-Uses feature(s): _setopt_
-
-Called by:
-
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-stress
 ~~~~~~~~~~~~~
@@ -1258,14 +974,7 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 38 line(s). Calls functions:
-
- .zinit-stress
- |-- zinit-side.zsh/.zinit-exists-physically-message
- |-- zinit-side.zsh/.zinit-first
- `-- zinit.zsh/.zinit-any-to-user-plugin
-
-Uses feature(s): _setopt_, _zcompile_
+Has 38 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1283,18 +992,9 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 22 line(s). Calls functions:
+Has 22 line(s). Doesn't call other functions.
 
- .zinit-uncompile-plugin
- |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- `-- zinit.zsh/.zinit-any-to-user-plugin
-
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-compile-uncompile-all
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-uninstall-completions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1309,18 +1009,9 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 46 line(s). Calls functions:
+Has 46 line(s). Doesn't call other functions.
 
- .zinit-uninstall-completions
- |-- zinit-install.zsh/.zinit-compinit
- |-- zinit-install.zsh/.zinit-forget-completion
- `-- zinit.zsh/+zinit-message
-
-Uses feature(s): _setopt_, _source_
-
-Called by:
-
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-unload
 ~~~~~~~~~~~~~
@@ -1346,18 +1037,9 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 394 line(s). Calls functions:
+Has 394 line(s). Doesn't call other functions.
 
- .zinit-unload
- |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- `-- zinit.zsh/.zinit-any-to-user-plugin
-
-Uses feature(s): _alias_, _bindkey_, _eval_, _setopt_, _unalias_, _unfunction_, _zle_, _zstyle_
-
-Called by:
-
- zinit.zsh/.zinit-run-task
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-unregister-plugin
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1369,14 +1051,9 @@ ____
  zsh_loaded_plugins array (managed according to the plugin standard)
 ____
 
-Has 6 line(s). Calls functions:
+Has 6 line(s). Doesn't call other functions.
 
- .zinit-unregister-plugin
- `-- zinit.zsh/.zinit-any-to-user-plugin
-
-Called by:
-
- .zinit-unload
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-update-all-parallel
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1386,18 +1063,9 @@ ____
  FUNCTION: .zinit-update-in-parallel [[[
 ____
 
-Has 84 line(s). Calls functions:
+Has 84 line(s). Doesn't call other functions.
 
- .zinit-update-all-parallel
- |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- |-- zinit.zsh/+zinit-message
- `-- zinit.zsh/.zinit-any-to-user-plugin
-
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-update-or-status-all
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-update-or-status
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -1414,28 +1082,9 @@ ____
  $3 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 325 line(s). Calls functions:
+Has 325 line(s). Doesn't call other functions.
 
- .zinit-update-or-status
- |-- zinit-install.zsh/.zinit-get-latest-gh-r-url-part
- |-- zinit-install.zsh/.zinit-setup-plugin-dir
- |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- |-- zinit-side.zsh/.zinit-compute-ice
- |-- zinit-side.zsh/.zinit-exists-physically
- |-- zinit-side.zsh/.zinit-exists-physically-message
- |-- zinit-side.zsh/.zinit-store-ices
- |-- zinit-side.zsh/.zinit-two-paths
- |-- zinit.zsh/+zinit-message
- |-- zinit.zsh/.zinit-any-to-user-plugin
- `-- zinit.zsh/.zinit-set-m-func
-
-Uses feature(s): _kill_, _read_, _setopt_, _source_, _trap_, _wait_
-
-Called by:
-
- .zinit-update-all-parallel
- .zinit-update-or-status-all
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-update-or-status-all
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1451,20 +1100,9 @@ ____
  User-action entry point.
 ____
 
-Has 133 line(s). Calls functions:
+Has 133 line(s). Doesn't call other functions.
 
- .zinit-update-or-status-all
- |-- zinit-install.zsh/.zinit-compinit
- |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- |-- zinit.zsh/+zinit-message
- |-- zinit.zsh/.zinit-any-to-user-plugin
- `-- zinit.zsh/.zinit-get-mtime-into
-
-Uses feature(s): _setopt_, _source_
-
-Called by:
-
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-update-or-status-snippet
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1479,19 +1117,9 @@ ____
  $2 - snippet URL
 ____
 
-Has 34 line(s). Calls functions:
+Has 34 line(s). Doesn't call other functions.
 
- .zinit-update-or-status-snippet
- |-- zinit-install.zsh/.zinit-update-snippet
- `-- zinit-side.zsh/.zinit-compute-ice
-
-Uses feature(s): _source_
-
-Called by:
-
- .zinit-update-all-parallel
- .zinit-update-or-status-all
- .zinit-update-or-status
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-wait-for-update-jobs
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1502,14 +1130,7 @@ ____
  FUNCTION: .zinit-wait-for-update-jobs [[[
 ____
 
-Has 18 line(s). Calls functions:
+Has 18 line(s). Doesn't call other functions.
 
- .zinit-wait-for-update-jobs
- `-- zinit.zsh/+zinit-message
-
-Uses feature(s): _wait_
-
-Called by:
-
- .zinit-update-all-parallel
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 

--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -57,8 +57,6 @@ Script Body
 
 Has 6 line(s). No functions are called (may set up e.g. a hook, a Zle widget bound to a key, etc.).
 
-Uses feature(s): _source_
-
 .zinit-at-eval
 ~~~~~~~~~~~~~~
 
@@ -68,17 +66,9 @@ ____
  FUNCTION: .zinit-at-eval [[[
 ____
 
-Has 9 line(s). Calls functions:
+Has 9 line(s). Doesn't call other functions.
 
- .zinit-at-eval
- `-- zinit.zsh/@zinit-substitute
-
-Uses feature(s): _eval_
-
-Called by:
-
- ∞zinit-atpull-e-hook
- ∞zinit-atpull-hook
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-compile-plugin
 ~~~~~~~~~~~~~~~~~~~~~
@@ -93,20 +83,9 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 87 line(s). Calls functions:
+Has 87 line(s). Doesn't call other functions.
 
- .zinit-compile-plugin
- |-- zinit-side.zsh/.zinit-compute-ice
- |-- zinit-side.zsh/.zinit-first
- `-- zinit.zsh/+zinit-message
-
-Uses feature(s): _eval_, _setopt_, _zcompile_
-
-Called by:
-
- ∞zinit-compile-plugin-hook
- zinit-autoload.zsh/.zinit-compile-uncompile-all
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-compinit
 ~~~~~~~~~~~~~~~
@@ -122,21 +101,9 @@ ____
  No arguments.
 ____
 
-Has 26 line(s). Calls functions:
+Has 26 line(s). Doesn't call other functions.
 
- .zinit-compinit
- |-- compinit
- `-- zinit.zsh/+zinit-message
-
-Uses feature(s): _autoload_, _compinit_, _setopt_, _unfunction_
-
-Called by:
-
- .zinit-install-completions
- zinit-autoload.zsh/.zinit-uninstall-completions
- zinit-autoload.zsh/.zinit-update-or-status-all
- zinit.zsh/.zinit-prepare-home
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-download-file-stdout
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -148,19 +115,9 @@ ____
  curl, wget, lftp, lynx. Used by snippet loading.
 ____
 
-Has 53 line(s). Calls functions:
+Has 53 line(s). Doesn't call other functions.
 
- .zinit-download-file-stdout
- `-- zinit.zsh/+zinit-message
-
-Uses feature(s): _setopt_, _trap_, _type_
-
-Called by:
-
- .zinit-download-snippet
- .zinit-get-cygwin-package
- .zinit-get-package
- .zinit-setup-plugin-dir
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-download-snippet
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -174,18 +131,9 @@ ____
  This is used to provide a layer of support for Oh-My-Zsh and Prezto.
 ____
 
-Has 357 line(s). Calls functions:
+Has 357 line(s). Doesn't call other functions.
 
- .zinit-download-snippet
- |-- zinit-side.zsh/.zinit-store-ices
- `-- zinit.zsh/+zinit-message
-
-Uses feature(s): _setopt_, _trap_, _zcompile_
-
-Called by:
-
- .zinit-update-snippet
- zinit.zsh/.zinit-load-snippet
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-extract
 ~~~~~~~~~~~~~~
@@ -196,18 +144,9 @@ ____
  FUNCTION: .zinit-extract() [[[
 ____
 
-Has 30 line(s). Calls functions:
+Has 30 line(s). Doesn't call other functions.
 
- .zinit-extract
- |-- ziextract
- |   `-- zinit.zsh/+zinit-message
- `-- zinit.zsh/+zinit-message
-
-Uses feature(s): _setopt_
-
-Called by:
-
- ∞zinit-extract-hook
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-forget-completion
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -224,14 +163,7 @@ ____
 
 Has 20 line(s). Doesn't call other functions.
 
-Uses feature(s): _setopt_, _unfunction_
-
-Called by:
-
- .zinit-compinit
- .zinit-install-completions
- zinit-autoload.zsh/.zinit-uninstall-completions
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-get-cygwin-package
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -242,16 +174,9 @@ ____
  FUNCTION: .zinit-get-cygwin-package [[[
 ____
 
-Has 70 line(s). Calls functions:
+Has 70 line(s). Doesn't call other functions.
 
- .zinit-get-cygwin-package
- `-- zinit.zsh/+zinit-message
-
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-setup-plugin-dir
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-get-latest-gh-r-url-part
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -264,17 +189,9 @@ ____
  package. Connects to Github releases page.
 ____
 
-Has 103 line(s). Calls functions:
+Has 103 line(s). Doesn't call other functions.
 
- .zinit-get-latest-gh-r-url-part
- `-- zinit.zsh/+zinit-message
-
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-setup-plugin-dir
- zinit-autoload.zsh/.zinit-update-or-status
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-get-package
 ~~~~~~~~~~~~~~~~~~
@@ -284,21 +201,9 @@ ____
  FUNCTION: .zinit-get-package [[[
 ____
 
-Has 194 line(s). Calls functions:
+Has 194 line(s). Doesn't call other functions.
 
- .zinit-get-package
- |-- ziextract
- |   `-- zinit.zsh/+zinit-message
- |-- zinit.zsh/+zinit-message
- `-- zinit.zsh/@zinit-substitute
-
-Uses feature(s): _eval_, _setopt_, _trap_
-
-Called by:
-
- zinit.zsh/.zinit-load
-
-_Environment variables used:_ zinit.zsh -> ZPFX
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-get-url-mtime
 ~~~~~~~~~~~~~~~~~~~~
@@ -312,11 +217,7 @@ ____
 
 Has 35 line(s). Doesn't call other functions.
 
-Uses feature(s): _read_, _setopt_, _trap_, _type_
-
-Called by:
-
- .zinit-download-snippet
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-install-completions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -334,21 +235,9 @@ ____
  $3 - if 1, then reinstall, otherwise only install completions that aren't there
 ____
 
-Has 61 line(s). Calls functions:
+Has 61 line(s). Doesn't call other functions.
 
- .zinit-install-completions
- |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- |-- zinit-side.zsh/.zinit-exists-physically-message
- |-- zinit.zsh/+zinit-message
- `-- zinit.zsh/.zinit-any-to-user-plugin
-
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-download-snippet
- .zinit-setup-plugin-dir
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-jq-check
 ~~~~~~~~~~~~~~~
@@ -360,15 +249,9 @@ ____
  that's not the case
 ____
 
-Has 8 line(s). Calls functions:
+Has 8 line(s). Doesn't call other functions.
 
- .zinit-jq-check
- `-- zinit.zsh/+zinit-message
-
-Called by:
-
- .zinit-json-get-value
- .zinit-json-to-array
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-json-get-value
 ~~~~~~~~~~~~~~~~~~~~~
@@ -381,9 +264,7 @@ ____
  $2: jq path
 ____
 
-Has 4 line(s). Calls functions:
-
- .zinit-json-get-value
+Has 4 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -400,15 +281,9 @@ ____
  $3: name of the associative array to store the key/value pairs in
 ____
 
-Has 13 line(s). Calls functions:
+Has 13 line(s). Doesn't call other functions.
 
- .zinit-json-to-array
-
-Uses feature(s): _eval_, _setopt_
-
-Called by:
-
- .zinit-get-package
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-mirror-using-svn
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -429,11 +304,7 @@ ____
 
 Has 29 line(s). Doesn't call other functions.
 
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-download-snippet
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-setup-plugin-dir
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -450,22 +321,9 @@ ____
  $2 - plugin
 ____
 
-Has 209 line(s). Calls functions:
+Has 209 line(s). Doesn't call other functions.
 
- .zinit-setup-plugin-dir
- |-- ziextract
- |   `-- zinit.zsh/+zinit-message
- |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- |-- zinit-side.zsh/.zinit-store-ices
- |-- zinit.zsh/+zinit-message
- `-- zinit.zsh/.zinit-get-object-path
-
-Uses feature(s): _setopt_, _trap_
-
-Called by:
-
- zinit-autoload.zsh/.zinit-update-or-status
- zinit.zsh/.zinit-load
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-update-snippet
 ~~~~~~~~~~~~~~~~~~~~~
@@ -476,18 +334,9 @@ ____
  FUNCTION: .zinit-update-snippet [[[
 ____
 
-Has 76 line(s). Calls functions:
+Has 76 line(s). Doesn't call other functions.
 
- .zinit-update-snippet
- |-- zinit.zsh/+zinit-message
- |-- zinit.zsh/.zinit-get-object-path
- `-- zinit.zsh/.zinit-pack-ice
-
-Uses feature(s): _eval_, _setopt_
-
-Called by:
-
- zinit-autoload.zsh/.zinit-update-or-status-snippet
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 zicp
 ~~~~
@@ -500,13 +349,7 @@ ____
 
 Has 30 line(s). Doesn't call other functions.
 
-Uses feature(s): _setopt_
-
-Called by:
-
- zimv
-
-_Environment variables used:_ zinit.zsh -> ZPFX
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ziextract
 ~~~~~~~~~
@@ -524,27 +367,14 @@ ____
  $2 - file
 ____
 
-Has 297 line(s). Calls functions:
+Has 297 line(s). Doesn't call other functions.
 
- ziextract
- `-- zinit.zsh/+zinit-message
-
-Uses feature(s): _setopt_, _unfunction_, _zparseopts_
-
-Called by:
-
- .zinit-extract
- .zinit-get-package
- .zinit-setup-plugin-dir
- zpextract
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 zimv
 ~~~~
 
-Has 3 line(s). Calls functions:
-
- zimv
- `-- zicp
+Has 3 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -557,16 +387,12 @@ ____
  FUNCTION: zpextract [[[
 ____
 
-Has 1 line(s). Calls functions:
-
- zpextract
- `-- ziextract
-     `-- zinit.zsh/+zinit-message
+Has 1 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ∞zinit-atclone-hook
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 ____
  
@@ -574,18 +400,12 @@ ____
  FUNCTION: ∞zinit-atclone-hook [[[
 ____
 
-Has 26 line(s). Calls functions:
-
- ∞zinit-atclone-hook
- |-- zinit-side.zsh/.zinit-countdown
- `-- zinit.zsh/@zinit-substitute
-
-Uses feature(s): _eval_, _setopt_
+Has 26 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ∞zinit-atpull-e-hook
-~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~
 
 ____
  
@@ -593,17 +413,12 @@ ____
  FUNCTION: ∞zinit-atpull-e-hook [[[
 ____
 
-Has 22 line(s). Calls functions:
-
- ∞zinit-atpull-e-hook
- `-- zinit-side.zsh/.zinit-countdown
-
-Uses feature(s): _setopt_
+Has 22 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ∞zinit-atpull-hook
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 ____
  
@@ -611,17 +426,12 @@ ____
  FUNCTION: ∞zinit-atpull-hook [[[
 ____
 
-Has 22 line(s). Calls functions:
-
- ∞zinit-atpull-hook
- `-- zinit-side.zsh/.zinit-countdown
-
-Uses feature(s): _setopt_
+Has 22 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ∞zinit-compile-plugin-hook
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ____
  
@@ -629,16 +439,12 @@ ____
  FUNCTION: ∞zinit-compile-plugin-hook [[[
 ____
 
-Has 19 line(s). Calls functions:
-
- ∞zinit-compile-plugin-hook
-
-Uses feature(s): _setopt_
+Has 19 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ∞zinit-cp-hook
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 ____
  
@@ -646,17 +452,12 @@ ____
  FUNCTION: ∞zinit-cp-hook [[[
 ____
 
-Has 27 line(s). Calls functions:
-
- ∞zinit-cp-hook
- `-- zinit.zsh/@zinit-substitute
-
-Uses feature(s): _setopt_
+Has 27 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ∞zinit-extract-hook
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 ____
  
@@ -664,15 +465,12 @@ ____
  FUNCTION: ∞zinit-extract-hook [[[
 ____
 
-Has 10 line(s). Calls functions:
-
- ∞zinit-extract-hook
- `-- zinit.zsh/@zinit-substitute
+Has 10 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ∞zinit-make-e-hook
-~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~
 
 ____
  
@@ -680,16 +478,12 @@ ____
  FUNCTION: ∞zinit-make-e-hook [[[
 ____
 
-Has 11 line(s). Calls functions:
-
- ∞zinit-make-e-hook
- |-- zinit-side.zsh/.zinit-countdown
- `-- zinit.zsh/@zinit-substitute
+Has 11 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ∞zinit-make-ee-hook
-~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~
 
 ____
  
@@ -697,16 +491,12 @@ ____
  FUNCTION: ∞zinit-make-ee-hook [[[
 ____
 
-Has 11 line(s). Calls functions:
-
- ∞zinit-make-ee-hook
- |-- zinit-side.zsh/.zinit-countdown
- `-- zinit.zsh/@zinit-substitute
+Has 11 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ∞zinit-make-hook
-~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~
 
 ____
  
@@ -714,16 +504,12 @@ ____
  FUNCTION: ∞zinit-make-hook [[[
 ____
 
-Has 11 line(s). Calls functions:
-
- ∞zinit-make-hook
- |-- zinit-side.zsh/.zinit-countdown
- `-- zinit.zsh/@zinit-substitute
+Has 11 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ∞zinit-mv-hook
-~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~
 
 ____
  
@@ -731,18 +517,12 @@ ____
  FUNCTION: ∞zinit-mv-hook [[[
 ____
 
-Has 35 line(s). Calls functions:
-
- ∞zinit-mv-hook
- |-- zinit.zsh/+zinit-message
- `-- zinit.zsh/@zinit-substitute
-
-Uses feature(s): _setopt_
+Has 35 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ∞zinit-ps-on-update-hook
-~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 ____
  
@@ -750,17 +530,12 @@ ____
  FUNCTION: ∞zinit-ps-on-update-hook [[[
 ____
 
-Has 18 line(s). Calls functions:
-
- ∞zinit-ps-on-update-hook
- `-- zinit.zsh/+zinit-message
-
-Uses feature(s): _eval_
+Has 18 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ∞zinit-reset-hook
-~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~
 
 ____
  
@@ -768,12 +543,7 @@ ____
  FUNCTION: ∞zinit-reset-opt-hook [[[
 ____
 
-Has 79 line(s). Calls functions:
-
- ∞zinit-reset-hook
- `-- zinit.zsh/+zinit-message
-
-Uses feature(s): _eval_
+Has 79 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -796,9 +566,5 @@ ____
 
 Has 549 line(s). Doesn't call other functions.
 
-Uses feature(s): _autoload_, _bindkey_, _compdef_, _compdump_, _eval_, _read_, _setopt_, _unfunction_, _zle_, _zstyle_
-
-Called by:
-
- .zinit-compinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 

--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -13,21 +13,12 @@ Documentation automatically generated with `zshelldoc'
 FUNCTIONS
 ---------
 
- zicp
- ziextract
- zimv
- ∞zinit-atclone-hook
  .zinit-at-eval
- ∞zinit-atpull-e-hook
- ∞zinit-atpull-hook
  .zinit-compile-plugin
- ∞zinit-compile-plugin-hook
  .zinit-compinit
- ∞zinit-cp-hook
  .zinit-download-file-stdout
  .zinit-download-snippet
  .zinit-extract
- ∞zinit-extract-hook
  .zinit-forget-completion
  .zinit-get-cygwin-package
  .zinit-get-latest-gh-r-url-part
@@ -37,16 +28,25 @@ FUNCTIONS
  .zinit-jq-check
  .zinit-json-get-value
  .zinit-json-to-array
- ∞zinit-make-ee-hook
- ∞zinit-make-e-hook
- ∞zinit-make-hook
  .zinit-mirror-using-svn
+ .zinit-setup-plugin-dir
+ .zinit-update-snippet
+ zicp
+ ziextract
+ zimv
+ zpextract
+ ∞zinit-atclone-hook
+ ∞zinit-atpull-e-hook
+ ∞zinit-atpull-hook
+ ∞zinit-compile-plugin-hook
+ ∞zinit-cp-hook
+ ∞zinit-extract-hook
+ ∞zinit-make-e-hook
+ ∞zinit-make-ee-hook
+ ∞zinit-make-hook
  ∞zinit-mv-hook
  ∞zinit-ps-on-update-hook
  ∞zinit-reset-hook
- .zinit-setup-plugin-dir
- .zinit-update-snippet
- zpextract
 AUTOLOAD compinit
 
 DETAILS
@@ -58,84 +58,6 @@ Script Body
 Has 6 line(s). No functions are called (may set up e.g. a hook, a Zle widget bound to a key, etc.).
 
 Uses feature(s): _source_
-
-zicp
-~~~~
-
-____
- 
- ]]]
- FUNCTION zicp [[[
-____
-
-Has 30 line(s). Doesn't call other functions.
-
-Uses feature(s): _setopt_
-
-Called by:
-
- zimv
-
-_Environment variables used:_ zinit.zsh -> ZPFX
-
-ziextract
-~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: ziextract [[[
- If the file is an archive, it is extracted by this function.
- Next stage is scanning of files with the common utility `file',
- to detect executables. They are given +x mode. There are also
- messages to the user on performed actions.
- 
- $1 - url
- $2 - file
-____
-
-Has 297 line(s). Calls functions:
-
- ziextract
- `-- zinit.zsh/+zinit-message
-
-Uses feature(s): _setopt_, _unfunction_, _zparseopts_
-
-Called by:
-
- .zinit-extract
- .zinit-get-package
- .zinit-setup-plugin-dir
- zpextract
-
-zimv
-~~~~
-
-Has 3 line(s). Calls functions:
-
- zimv
- `-- zicp
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
-
-∞zinit-atclone-hook
-~~~~~~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: ∞zinit-atclone-hook [[[
-____
-
-Has 26 line(s). Calls functions:
-
- ∞zinit-atclone-hook
- |-- zinit-side.zsh/.zinit-countdown
- `-- zinit.zsh/@zinit-substitute
-
-Uses feature(s): _eval_, _setopt_
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-at-eval
 ~~~~~~~~~~~~~~
@@ -157,42 +79,6 @@ Called by:
 
  ∞zinit-atpull-e-hook
  ∞zinit-atpull-hook
-
-∞zinit-atpull-e-hook
-~~~~~~~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: ∞zinit-atpull-e-hook [[[
-____
-
-Has 22 line(s). Calls functions:
-
- ∞zinit-atpull-e-hook
- `-- zinit-side.zsh/.zinit-countdown
-
-Uses feature(s): _setopt_
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
-
-∞zinit-atpull-hook
-~~~~~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: ∞zinit-atpull-hook [[[
-____
-
-Has 22 line(s). Calls functions:
-
- ∞zinit-atpull-hook
- `-- zinit-side.zsh/.zinit-countdown
-
-Uses feature(s): _setopt_
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-compile-plugin
 ~~~~~~~~~~~~~~~~~~~~~
@@ -221,23 +107,6 @@ Called by:
  ∞zinit-compile-plugin-hook
  zinit-autoload.zsh/.zinit-compile-uncompile-all
  zinit.zsh/zinit
-
-∞zinit-compile-plugin-hook
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: ∞zinit-compile-plugin-hook [[[
-____
-
-Has 19 line(s). Calls functions:
-
- ∞zinit-compile-plugin-hook
-
-Uses feature(s): _setopt_
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-compinit
 ~~~~~~~~~~~~~~~
@@ -268,24 +137,6 @@ Called by:
  zinit-autoload.zsh/.zinit-update-or-status-all
  zinit.zsh/.zinit-prepare-home
  zinit.zsh/zinit
-
-∞zinit-cp-hook
-~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: ∞zinit-cp-hook [[[
-____
-
-Has 27 line(s). Calls functions:
-
- ∞zinit-cp-hook
- `-- zinit.zsh/@zinit-substitute
-
-Uses feature(s): _setopt_
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-download-file-stdout
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -357,22 +208,6 @@ Uses feature(s): _setopt_
 Called by:
 
  ∞zinit-extract-hook
-
-∞zinit-extract-hook
-~~~~~~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: ∞zinit-extract-hook [[[
-____
-
-Has 10 line(s). Calls functions:
-
- ∞zinit-extract-hook
- `-- zinit.zsh/@zinit-substitute
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-forget-completion
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -504,8 +339,8 @@ Has 61 line(s). Calls functions:
  .zinit-install-completions
  |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
  |-- zinit-side.zsh/.zinit-exists-physically-message
- |-- zinit.zsh/.zinit-any-to-user-plugin
- `-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/.zinit-any-to-user-plugin
 
 Uses feature(s): _setopt_
 
@@ -575,57 +410,6 @@ Called by:
 
  .zinit-get-package
 
-∞zinit-make-ee-hook
-~~~~~~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: ∞zinit-make-ee-hook [[[
-____
-
-Has 11 line(s). Calls functions:
-
- ∞zinit-make-ee-hook
- |-- zinit-side.zsh/.zinit-countdown
- `-- zinit.zsh/@zinit-substitute
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
-
-∞zinit-make-e-hook
-~~~~~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: ∞zinit-make-e-hook [[[
-____
-
-Has 11 line(s). Calls functions:
-
- ∞zinit-make-e-hook
- |-- zinit-side.zsh/.zinit-countdown
- `-- zinit.zsh/@zinit-substitute
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
-
-∞zinit-make-hook
-~~~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: ∞zinit-make-hook [[[
-____
-
-Has 11 line(s). Calls functions:
-
- ∞zinit-make-hook
- |-- zinit-side.zsh/.zinit-countdown
- `-- zinit.zsh/@zinit-substitute
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
-
 .zinit-mirror-using-svn
 ~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -650,6 +434,293 @@ Uses feature(s): _setopt_
 Called by:
 
  .zinit-download-snippet
+
+.zinit-setup-plugin-dir
+~~~~~~~~~~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: .zinit-setup-plugin-dir [[[
+ Clones given plugin into PLUGIN_DIR. Supports multiple
+ sites (respecting `from' and `proto' ice modifiers).
+ Invokes compilation of plugin's main file.
+ 
+ $1 - user
+ $2 - plugin
+____
+
+Has 209 line(s). Calls functions:
+
+ .zinit-setup-plugin-dir
+ |-- ziextract
+ |   `-- zinit.zsh/+zinit-message
+ |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+ |-- zinit-side.zsh/.zinit-store-ices
+ |-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/.zinit-get-object-path
+
+Uses feature(s): _setopt_, _trap_
+
+Called by:
+
+ zinit-autoload.zsh/.zinit-update-or-status
+ zinit.zsh/.zinit-load
+
+.zinit-update-snippet
+~~~~~~~~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: .zinit-update-snippet [[[
+____
+
+Has 76 line(s). Calls functions:
+
+ .zinit-update-snippet
+ |-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/.zinit-get-object-path
+ `-- zinit.zsh/.zinit-pack-ice
+
+Uses feature(s): _eval_, _setopt_
+
+Called by:
+
+ zinit-autoload.zsh/.zinit-update-or-status-snippet
+
+zicp
+~~~~
+
+____
+ 
+ ]]]
+ FUNCTION zicp [[[
+____
+
+Has 30 line(s). Doesn't call other functions.
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ zimv
+
+_Environment variables used:_ zinit.zsh -> ZPFX
+
+ziextract
+~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: ziextract [[[
+ If the file is an archive, it is extracted by this function.
+ Next stage is scanning of files with the common utility `file',
+ to detect executables. They are given +x mode. There are also
+ messages to the user on performed actions.
+ 
+ $1 - url
+ $2 - file
+____
+
+Has 297 line(s). Calls functions:
+
+ ziextract
+ `-- zinit.zsh/+zinit-message
+
+Uses feature(s): _setopt_, _unfunction_, _zparseopts_
+
+Called by:
+
+ .zinit-extract
+ .zinit-get-package
+ .zinit-setup-plugin-dir
+ zpextract
+
+zimv
+~~~~
+
+Has 3 line(s). Calls functions:
+
+ zimv
+ `-- zicp
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+zpextract
+~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: zpextract [[[
+____
+
+Has 1 line(s). Calls functions:
+
+ zpextract
+ `-- ziextract
+     `-- zinit.zsh/+zinit-message
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+∞zinit-atclone-hook
+~~~~~~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: ∞zinit-atclone-hook [[[
+____
+
+Has 26 line(s). Calls functions:
+
+ ∞zinit-atclone-hook
+ |-- zinit-side.zsh/.zinit-countdown
+ `-- zinit.zsh/@zinit-substitute
+
+Uses feature(s): _eval_, _setopt_
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+∞zinit-atpull-e-hook
+~~~~~~~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: ∞zinit-atpull-e-hook [[[
+____
+
+Has 22 line(s). Calls functions:
+
+ ∞zinit-atpull-e-hook
+ `-- zinit-side.zsh/.zinit-countdown
+
+Uses feature(s): _setopt_
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+∞zinit-atpull-hook
+~~~~~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: ∞zinit-atpull-hook [[[
+____
+
+Has 22 line(s). Calls functions:
+
+ ∞zinit-atpull-hook
+ `-- zinit-side.zsh/.zinit-countdown
+
+Uses feature(s): _setopt_
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+∞zinit-compile-plugin-hook
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: ∞zinit-compile-plugin-hook [[[
+____
+
+Has 19 line(s). Calls functions:
+
+ ∞zinit-compile-plugin-hook
+
+Uses feature(s): _setopt_
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+∞zinit-cp-hook
+~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: ∞zinit-cp-hook [[[
+____
+
+Has 27 line(s). Calls functions:
+
+ ∞zinit-cp-hook
+ `-- zinit.zsh/@zinit-substitute
+
+Uses feature(s): _setopt_
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+∞zinit-extract-hook
+~~~~~~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: ∞zinit-extract-hook [[[
+____
+
+Has 10 line(s). Calls functions:
+
+ ∞zinit-extract-hook
+ `-- zinit.zsh/@zinit-substitute
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+∞zinit-make-e-hook
+~~~~~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: ∞zinit-make-e-hook [[[
+____
+
+Has 11 line(s). Calls functions:
+
+ ∞zinit-make-e-hook
+ |-- zinit-side.zsh/.zinit-countdown
+ `-- zinit.zsh/@zinit-substitute
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+∞zinit-make-ee-hook
+~~~~~~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: ∞zinit-make-ee-hook [[[
+____
+
+Has 11 line(s). Calls functions:
+
+ ∞zinit-make-ee-hook
+ |-- zinit-side.zsh/.zinit-countdown
+ `-- zinit.zsh/@zinit-substitute
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+∞zinit-make-hook
+~~~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: ∞zinit-make-hook [[[
+____
+
+Has 11 line(s). Calls functions:
+
+ ∞zinit-make-hook
+ |-- zinit-side.zsh/.zinit-countdown
+ `-- zinit.zsh/@zinit-substitute
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ∞zinit-mv-hook
 ~~~~~~~~~~~~~~
@@ -703,77 +774,6 @@ Has 79 line(s). Calls functions:
  `-- zinit.zsh/+zinit-message
 
 Uses feature(s): _eval_
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
-
-.zinit-setup-plugin-dir
-~~~~~~~~~~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: .zinit-setup-plugin-dir [[[
- Clones given plugin into PLUGIN_DIR. Supports multiple
- sites (respecting `from' and `proto' ice modifiers).
- Invokes compilation of plugin's main file.
- 
- $1 - user
- $2 - plugin
-____
-
-Has 209 line(s). Calls functions:
-
- .zinit-setup-plugin-dir
- |-- ziextract
- |   `-- zinit.zsh/+zinit-message
- |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- |-- zinit-side.zsh/.zinit-store-ices
- |-- zinit.zsh/.zinit-get-object-path
- `-- zinit.zsh/+zinit-message
-
-Uses feature(s): _setopt_, _trap_
-
-Called by:
-
- zinit-autoload.zsh/.zinit-update-or-status
- zinit.zsh/.zinit-load
-
-.zinit-update-snippet
-~~~~~~~~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: .zinit-update-snippet [[[
-____
-
-Has 76 line(s). Calls functions:
-
- .zinit-update-snippet
- |-- zinit.zsh/.zinit-get-object-path
- |-- zinit.zsh/+zinit-message
- `-- zinit.zsh/.zinit-pack-ice
-
-Uses feature(s): _eval_, _setopt_
-
-Called by:
-
- zinit-autoload.zsh/.zinit-update-or-status-snippet
-
-zpextract
-~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: zpextract [[[
-____
-
-Has 1 line(s). Calls functions:
-
- zpextract
- `-- ziextract
-     `-- zinit.zsh/+zinit-message
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 

--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -57,6 +57,8 @@ Script Body
 
 Has 6 line(s). No functions are called (may set up e.g. a hook, a Zle widget bound to a key, etc.).
 
+Uses feature(s): _source_
+
 .zinit-at-eval
 ~~~~~~~~~~~~~~
 
@@ -66,9 +68,17 @@ ____
  FUNCTION: .zinit-at-eval [[[
 ____
 
-Has 9 line(s). Doesn't call other functions.
+Has 9 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-at-eval
+ `-- zinit.zsh/@zinit-substitute
+
+Uses feature(s): _eval_
+
+Called by:
+
+ $'\342'$'\210'$'\236'zinit-atpull-e-hook
+ $'\342'$'\210'$'\236'zinit-atpull-hook
 
 .zinit-compile-plugin
 ~~~~~~~~~~~~~~~~~~~~~
@@ -83,9 +93,20 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 87 line(s). Doesn't call other functions.
+Has 87 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-compile-plugin
+ |-- zinit-side.zsh/.zinit-compute-ice
+ |-- zinit-side.zsh/.zinit-first
+ `-- zinit.zsh/+zinit-message
+
+Uses feature(s): _eval_, _setopt_, _zcompile_
+
+Called by:
+
+ $'\342'$'\210'$'\236'zinit-compile-plugin-hook
+ zinit-autoload.zsh/.zinit-compile-uncompile-all
+ zinit.zsh/zinit
 
 .zinit-compinit
 ~~~~~~~~~~~~~~~
@@ -101,9 +122,21 @@ ____
  No arguments.
 ____
 
-Has 26 line(s). Doesn't call other functions.
+Has 26 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-compinit
+ |-- compinit
+ `-- zinit.zsh/+zinit-message
+
+Uses feature(s): _autoload_, _compinit_, _setopt_, _unfunction_
+
+Called by:
+
+ .zinit-install-completions
+ zinit-autoload.zsh/.zinit-uninstall-completions
+ zinit-autoload.zsh/.zinit-update-or-status-all
+ zinit.zsh/.zinit-prepare-home
+ zinit.zsh/zinit
 
 .zinit-download-file-stdout
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -115,9 +148,19 @@ ____
  curl, wget, lftp, lynx. Used by snippet loading.
 ____
 
-Has 53 line(s). Doesn't call other functions.
+Has 53 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-download-file-stdout
+ `-- zinit.zsh/+zinit-message
+
+Uses feature(s): _setopt_, _trap_, _type_
+
+Called by:
+
+ .zinit-download-snippet
+ .zinit-get-cygwin-package
+ .zinit-get-package
+ .zinit-setup-plugin-dir
 
 .zinit-download-snippet
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -131,9 +174,18 @@ ____
  This is used to provide a layer of support for Oh-My-Zsh and Prezto.
 ____
 
-Has 357 line(s). Doesn't call other functions.
+Has 357 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-download-snippet
+ |-- zinit-side.zsh/.zinit-store-ices
+ `-- zinit.zsh/+zinit-message
+
+Uses feature(s): _setopt_, _trap_, _zcompile_
+
+Called by:
+
+ .zinit-update-snippet
+ zinit.zsh/.zinit-load-snippet
 
 .zinit-extract
 ~~~~~~~~~~~~~~
@@ -144,9 +196,18 @@ ____
  FUNCTION: .zinit-extract() [[[
 ____
 
-Has 30 line(s). Doesn't call other functions.
+Has 30 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-extract
+ |-- ziextract
+ |   `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/+zinit-message
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ $'\342'$'\210'$'\236'zinit-extract-hook
 
 .zinit-forget-completion
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -163,7 +224,14 @@ ____
 
 Has 20 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _setopt_, _unfunction_
+
+Called by:
+
+ .zinit-compinit
+ .zinit-install-completions
+ zinit-autoload.zsh/.zinit-uninstall-completions
+ zinit.zsh/zinit
 
 .zinit-get-cygwin-package
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -174,9 +242,16 @@ ____
  FUNCTION: .zinit-get-cygwin-package [[[
 ____
 
-Has 70 line(s). Doesn't call other functions.
+Has 70 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-get-cygwin-package
+ `-- zinit.zsh/+zinit-message
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-setup-plugin-dir
 
 .zinit-get-latest-gh-r-url-part
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -189,9 +264,17 @@ ____
  package. Connects to Github releases page.
 ____
 
-Has 103 line(s). Doesn't call other functions.
+Has 103 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-get-latest-gh-r-url-part
+ `-- zinit.zsh/+zinit-message
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-setup-plugin-dir
+ zinit-autoload.zsh/.zinit-update-or-status
 
 .zinit-get-package
 ~~~~~~~~~~~~~~~~~~
@@ -201,9 +284,21 @@ ____
  FUNCTION: .zinit-get-package [[[
 ____
 
-Has 194 line(s). Doesn't call other functions.
+Has 194 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-get-package
+ |-- ziextract
+ |   `-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/@zinit-substitute
+
+Uses feature(s): _eval_, _setopt_, _trap_
+
+Called by:
+
+ zinit.zsh/.zinit-load
+
+_Environment variables used:_ zinit.zsh -> ZPFX
 
 .zinit-get-url-mtime
 ~~~~~~~~~~~~~~~~~~~~
@@ -217,7 +312,11 @@ ____
 
 Has 35 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _read_, _setopt_, _trap_, _type_
+
+Called by:
+
+ .zinit-download-snippet
 
 .zinit-install-completions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -235,9 +334,21 @@ ____
  $3 - if 1, then reinstall, otherwise only install completions that aren't there
 ____
 
-Has 61 line(s). Doesn't call other functions.
+Has 61 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-install-completions
+ |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+ |-- zinit-side.zsh/.zinit-exists-physically-message
+ |-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/.zinit-any-to-user-plugin
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-download-snippet
+ .zinit-setup-plugin-dir
+ zinit.zsh/zinit
 
 .zinit-jq-check
 ~~~~~~~~~~~~~~~
@@ -249,9 +360,15 @@ ____
  that's not the case
 ____
 
-Has 8 line(s). Doesn't call other functions.
+Has 8 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-jq-check
+ `-- zinit.zsh/+zinit-message
+
+Called by:
+
+ .zinit-json-get-value
+ .zinit-json-to-array
 
 .zinit-json-get-value
 ~~~~~~~~~~~~~~~~~~~~~
@@ -264,7 +381,9 @@ ____
  $2: jq path
 ____
 
-Has 4 line(s). Doesn't call other functions.
+Has 4 line(s). Calls functions:
+
+ .zinit-json-get-value
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -281,9 +400,15 @@ ____
  $3: name of the associative array to store the key/value pairs in
 ____
 
-Has 13 line(s). Doesn't call other functions.
+Has 13 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-json-to-array
+
+Uses feature(s): _eval_, _setopt_
+
+Called by:
+
+ .zinit-get-package
 
 .zinit-mirror-using-svn
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -304,7 +429,11 @@ ____
 
 Has 29 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-download-snippet
 
 .zinit-setup-plugin-dir
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -321,9 +450,22 @@ ____
  $2 - plugin
 ____
 
-Has 209 line(s). Doesn't call other functions.
+Has 209 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-setup-plugin-dir
+ |-- ziextract
+ |   `-- zinit.zsh/+zinit-message
+ |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+ |-- zinit-side.zsh/.zinit-store-ices
+ |-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/.zinit-get-object-path
+
+Uses feature(s): _setopt_, _trap_
+
+Called by:
+
+ zinit-autoload.zsh/.zinit-update-or-status
+ zinit.zsh/.zinit-load
 
 .zinit-update-snippet
 ~~~~~~~~~~~~~~~~~~~~~
@@ -334,9 +476,18 @@ ____
  FUNCTION: .zinit-update-snippet [[[
 ____
 
-Has 76 line(s). Doesn't call other functions.
+Has 76 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-update-snippet
+ |-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/.zinit-get-object-path
+ `-- zinit.zsh/.zinit-pack-ice
+
+Uses feature(s): _eval_, _setopt_
+
+Called by:
+
+ zinit-autoload.zsh/.zinit-update-or-status-snippet
 
 zicp
 ~~~~
@@ -349,7 +500,13 @@ ____
 
 Has 30 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _setopt_
+
+Called by:
+
+ zimv
+
+_Environment variables used:_ zinit.zsh -> ZPFX
 
 ziextract
 ~~~~~~~~~
@@ -367,14 +524,27 @@ ____
  $2 - file
 ____
 
-Has 297 line(s). Doesn't call other functions.
+Has 297 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ ziextract
+ `-- zinit.zsh/+zinit-message
+
+Uses feature(s): _setopt_, _unfunction_, _zparseopts_
+
+Called by:
+
+ .zinit-extract
+ .zinit-get-package
+ .zinit-setup-plugin-dir
+ zpextract
 
 zimv
 ~~~~
 
-Has 3 line(s). Doesn't call other functions.
+Has 3 line(s). Calls functions:
+
+ zimv
+ `-- zicp
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -387,7 +557,11 @@ ____
  FUNCTION: zpextract [[[
 ____
 
-Has 1 line(s). Doesn't call other functions.
+Has 1 line(s). Calls functions:
+
+ zpextract
+ `-- ziextract
+     `-- zinit.zsh/+zinit-message
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -402,6 +576,8 @@ ____
 
 Has 26 line(s). Doesn't call other functions.
 
+Uses feature(s): _eval_, _setopt_
+
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ∞zinit-atpull-e-hook
@@ -414,6 +590,8 @@ ____
 ____
 
 Has 22 line(s). Doesn't call other functions.
+
+Uses feature(s): _setopt_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -428,6 +606,8 @@ ____
 
 Has 22 line(s). Doesn't call other functions.
 
+Uses feature(s): _setopt_
+
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ∞zinit-compile-plugin-hook
@@ -441,6 +621,8 @@ ____
 
 Has 19 line(s). Doesn't call other functions.
 
+Uses feature(s): _setopt_
+
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ∞zinit-cp-hook
@@ -453,6 +635,8 @@ ____
 ____
 
 Has 27 line(s). Doesn't call other functions.
+
+Uses feature(s): _setopt_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -519,6 +703,8 @@ ____
 
 Has 35 line(s). Doesn't call other functions.
 
+Uses feature(s): _setopt_
+
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ∞zinit-ps-on-update-hook
@@ -532,6 +718,8 @@ ____
 
 Has 18 line(s). Doesn't call other functions.
 
+Uses feature(s): _eval_
+
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ∞zinit-reset-hook
@@ -544,6 +732,8 @@ ____
 ____
 
 Has 79 line(s). Doesn't call other functions.
+
+Uses feature(s): _eval_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -566,5 +756,9 @@ ____
 
 Has 549 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _autoload_, _bindkey_, _compdef_, _compdump_, _eval_, _read_, _setopt_, _unfunction_, _zle_, _zstyle_
+
+Called by:
+
+ .zinit-compinit
 

--- a/doc/zsdoc/zinit-side.zsh.adoc
+++ b/doc/zsdoc/zinit-side.zsh.adoc
@@ -47,33 +47,9 @@ ____
 
 Has 22 line(s). Calls functions:
 
- .zinit-any-colorify-as-uspl2
- |-- zinit.zsh/.zinit-any-to-pid
- `-- zinit.zsh/.zinit-any-to-user-plugin
+ 
 
-Called by:
-
- .zinit-exists-physically-message
- zinit-autoload.zsh/.zinit-clear-completions
- zinit-autoload.zsh/.zinit-compile-uncompile-all
- zinit-autoload.zsh/.zinit-compiled
- zinit-autoload.zsh/.zinit-create
- zinit-autoload.zsh/.zinit-exists-message
- zinit-autoload.zsh/.zinit-get-completion-owner-uspl2col
- zinit-autoload.zsh/.zinit-list-bindkeys
- zinit-autoload.zsh/.zinit-recently
- zinit-autoload.zsh/.zinit-search-completions
- zinit-autoload.zsh/.zinit-show-completions
- zinit-autoload.zsh/.zinit-show-registered-plugins
- zinit-autoload.zsh/.zinit-show-times
- zinit-autoload.zsh/.zinit-uncompile-plugin
- zinit-autoload.zsh/.zinit-unload
- zinit-autoload.zsh/.zinit-update-all-parallel
- zinit-autoload.zsh/.zinit-update-or-status-all
- zinit-autoload.zsh/.zinit-update-or-status
- zinit-install.zsh/.zinit-install-completions
- zinit-install.zsh/.zinit-setup-plugin-dir
- zinit.zsh/.zinit-formatter-pid
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-compute-ice
 ~~~~~~~~~~~~~~~~~~
@@ -99,23 +75,9 @@ ____
  $6 - name of output string parameter, to hold is-snippet 0/1-bool ("is_snippet")
 ____
 
-Has 111 line(s). Calls functions:
+Has 111 line(s). Doesn't call other functions.
 
- .zinit-compute-ice
- |-- zinit.zsh/.zinit-any-to-user-plugin
- |-- zinit.zsh/.zinit-pack-ice
- `-- zmv
-
-Uses feature(s): _autoload_, _setopt_, _zmv_
-
-Called by:
-
- zinit-autoload.zsh/.zinit-delete
- zinit-autoload.zsh/.zinit-edit
- zinit-autoload.zsh/.zinit-recall
- zinit-autoload.zsh/.zinit-update-or-status-snippet
- zinit-autoload.zsh/.zinit-update-or-status
- zinit-install.zsh/.zinit-compile-plugin
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-countdown
 ~~~~~~~~~~~~~~~~
@@ -128,22 +90,11 @@ ____
  sucessfully reaches 0, or 1 if Ctrl-C will be pressed.
 ____
 
-Has 15 line(s). Calls functions:
-
- .zinit-countdown
- `-- zinit.zsh/+zinit-message
-
-Uses feature(s): _trap_
+Has 15 line(s). Doesn't call other functions.
 
 Called by:
 
- zinit-autoload.zsh/.zinit-run-delete-hooks
- zinit-install.zsh/∞zinit-atclone-hook
- zinit-install.zsh/∞zinit-atpull-e-hook
- zinit-install.zsh/∞zinit-atpull-hook
- zinit-install.zsh/∞zinit-make-e-hook
- zinit-install.zsh/∞zinit-make-ee-hook
- zinit-install.zsh/∞zinit-make-hook
+ zinit-install.zsh/$'\342'$'\210'$'\236'zinit-atclone-hook
 
 .zinit-exists-physically
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -159,16 +110,9 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 10 line(s). Calls functions:
+Has 10 line(s). Doesn't call other functions.
 
- .zinit-exists-physically
- `-- zinit.zsh/.zinit-any-to-user-plugin
-
-Called by:
-
- .zinit-exists-physically-message
- zinit-autoload.zsh/.zinit-create
- zinit-autoload.zsh/.zinit-update-or-status
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-exists-physically-message
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -185,23 +129,9 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 23 line(s). Calls functions:
+Has 23 line(s). Doesn't call other functions.
 
- .zinit-exists-physically-message
- |-- zinit.zsh/+zinit-message
- |-- zinit.zsh/.zinit-any-to-pid
- `-- zinit.zsh/.zinit-any-to-user-plugin
-
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-compute-ice
- zinit-autoload.zsh/.zinit-changes
- zinit-autoload.zsh/.zinit-glance
- zinit-autoload.zsh/.zinit-stress
- zinit-autoload.zsh/.zinit-update-or-status
- zinit-install.zsh/.zinit-install-completions
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-first
 ~~~~~~~~~~~~
@@ -220,20 +150,9 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 20 line(s). Calls functions:
+Has 20 line(s). Doesn't call other functions.
 
- .zinit-first
- |-- zinit.zsh/.zinit-any-to-pid
- |-- zinit.zsh/.zinit-any-to-user-plugin
- |-- zinit.zsh/.zinit-find-other-matches
- `-- zinit.zsh/.zinit-get-object-path
-
-Called by:
-
- .zinit-two-paths
- zinit-autoload.zsh/.zinit-glance
- zinit-autoload.zsh/.zinit-stress
- zinit-install.zsh/.zinit-compile-plugin
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-store-ices
 ~~~~~~~~~~~~~~~~~
@@ -254,11 +173,7 @@ ____
 
 Has 32 line(s). Doesn't call other functions.
 
-Called by:
-
- zinit-autoload.zsh/.zinit-update-or-status
- zinit-install.zsh/.zinit-download-snippet
- zinit-install.zsh/.zinit-setup-plugin-dir
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-two-paths
 ~~~~~~~~~~~~~~~~
@@ -271,17 +186,9 @@ ____
  further examination
 ____
 
-Has 24 line(s). Calls functions:
+Has 24 line(s). Doesn't call other functions.
 
- .zinit-two-paths
- `-- zinit.zsh/.zinit-get-object-path
-
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-compute-ice
- zinit-autoload.zsh/.zinit-update-or-status
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 zmv
 ~~~
@@ -302,9 +209,5 @@ ____
 
 Has 299 line(s). Doesn't call other functions.
 
-Uses feature(s): _eval_, _getopts_, _read_, _setopt_
-
-Called by:
-
- .zinit-compute-ice
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 

--- a/doc/zsdoc/zinit-side.zsh.adoc
+++ b/doc/zsdoc/zinit-side.zsh.adoc
@@ -47,9 +47,33 @@ ____
 
 Has 22 line(s). Calls functions:
 
- 
+ .zinit-any-colorify-as-uspl2
+ |-- zinit.zsh/.zinit-any-to-pid
+ `-- zinit.zsh/.zinit-any-to-user-plugin
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ .zinit-exists-physically-message
+ zinit-autoload.zsh/.zinit-clear-completions
+ zinit-autoload.zsh/.zinit-compile-uncompile-all
+ zinit-autoload.zsh/.zinit-compiled
+ zinit-autoload.zsh/.zinit-create
+ zinit-autoload.zsh/.zinit-exists-message
+ zinit-autoload.zsh/.zinit-get-completion-owner-uspl2col
+ zinit-autoload.zsh/.zinit-list-bindkeys
+ zinit-autoload.zsh/.zinit-recently
+ zinit-autoload.zsh/.zinit-search-completions
+ zinit-autoload.zsh/.zinit-show-completions
+ zinit-autoload.zsh/.zinit-show-registered-plugins
+ zinit-autoload.zsh/.zinit-show-times
+ zinit-autoload.zsh/.zinit-uncompile-plugin
+ zinit-autoload.zsh/.zinit-unload
+ zinit-autoload.zsh/.zinit-update-all-parallel
+ zinit-autoload.zsh/.zinit-update-or-status-all
+ zinit-autoload.zsh/.zinit-update-or-status
+ zinit-install.zsh/.zinit-install-completions
+ zinit-install.zsh/.zinit-setup-plugin-dir
+ zinit.zsh/.zinit-formatter-pid
 
 .zinit-compute-ice
 ~~~~~~~~~~~~~~~~~~
@@ -75,9 +99,23 @@ ____
  $6 - name of output string parameter, to hold is-snippet 0/1-bool ("is_snippet")
 ____
 
-Has 111 line(s). Doesn't call other functions.
+Has 111 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-compute-ice
+ |-- zinit.zsh/.zinit-any-to-user-plugin
+ |-- zinit.zsh/.zinit-pack-ice
+ `-- zmv
+
+Uses feature(s): _autoload_, _setopt_, _zmv_
+
+Called by:
+
+ zinit-autoload.zsh/.zinit-delete
+ zinit-autoload.zsh/.zinit-edit
+ zinit-autoload.zsh/.zinit-recall
+ zinit-autoload.zsh/.zinit-update-or-status-snippet
+ zinit-autoload.zsh/.zinit-update-or-status
+ zinit-install.zsh/.zinit-compile-plugin
 
 .zinit-countdown
 ~~~~~~~~~~~~~~~~
@@ -90,11 +128,22 @@ ____
  sucessfully reaches 0, or 1 if Ctrl-C will be pressed.
 ____
 
-Has 15 line(s). Doesn't call other functions.
+Has 15 line(s). Calls functions:
+
+ .zinit-countdown
+ `-- zinit.zsh/+zinit-message
+
+Uses feature(s): _trap_
 
 Called by:
 
+ zinit-autoload.zsh/.zinit-run-delete-hooks
  zinit-install.zsh/$'\342'$'\210'$'\236'zinit-atclone-hook
+ zinit-install.zsh/$'\342'$'\210'$'\236'zinit-atpull-e-hook
+ zinit-install.zsh/$'\342'$'\210'$'\236'zinit-atpull-hook
+ zinit-install.zsh/$'\342'$'\210'$'\236'zinit-make-e-hook
+ zinit-install.zsh/$'\342'$'\210'$'\236'zinit-make-ee-hook
+ zinit-install.zsh/$'\342'$'\210'$'\236'zinit-make-hook
 
 .zinit-exists-physically
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -110,9 +159,16 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 10 line(s). Doesn't call other functions.
+Has 10 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-exists-physically
+ `-- zinit.zsh/.zinit-any-to-user-plugin
+
+Called by:
+
+ .zinit-exists-physically-message
+ zinit-autoload.zsh/.zinit-create
+ zinit-autoload.zsh/.zinit-update-or-status
 
 .zinit-exists-physically-message
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -129,9 +185,23 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 23 line(s). Doesn't call other functions.
+Has 23 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-exists-physically-message
+ |-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/.zinit-any-to-pid
+ `-- zinit.zsh/.zinit-any-to-user-plugin
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-compute-ice
+ zinit-autoload.zsh/.zinit-changes
+ zinit-autoload.zsh/.zinit-glance
+ zinit-autoload.zsh/.zinit-stress
+ zinit-autoload.zsh/.zinit-update-or-status
+ zinit-install.zsh/.zinit-install-completions
 
 .zinit-first
 ~~~~~~~~~~~~
@@ -150,9 +220,20 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 20 line(s). Doesn't call other functions.
+Has 20 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-first
+ |-- zinit.zsh/.zinit-any-to-pid
+ |-- zinit.zsh/.zinit-any-to-user-plugin
+ |-- zinit.zsh/.zinit-find-other-matches
+ `-- zinit.zsh/.zinit-get-object-path
+
+Called by:
+
+ .zinit-two-paths
+ zinit-autoload.zsh/.zinit-glance
+ zinit-autoload.zsh/.zinit-stress
+ zinit-install.zsh/.zinit-compile-plugin
 
 .zinit-store-ices
 ~~~~~~~~~~~~~~~~~
@@ -173,7 +254,11 @@ ____
 
 Has 32 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ zinit-autoload.zsh/.zinit-update-or-status
+ zinit-install.zsh/.zinit-download-snippet
+ zinit-install.zsh/.zinit-setup-plugin-dir
 
 .zinit-two-paths
 ~~~~~~~~~~~~~~~~
@@ -186,9 +271,17 @@ ____
  further examination
 ____
 
-Has 24 line(s). Doesn't call other functions.
+Has 24 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-two-paths
+ `-- zinit.zsh/.zinit-get-object-path
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-compute-ice
+ zinit-autoload.zsh/.zinit-update-or-status
 
 zmv
 ~~~
@@ -209,5 +302,9 @@ ____
 
 Has 299 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _eval_, _getopts_, _read_, _setopt_
+
+Called by:
+
+ .zinit-compute-ice
 

--- a/doc/zsdoc/zinit-side.zsh.adoc
+++ b/doc/zsdoc/zinit-side.zsh.adoc
@@ -55,8 +55,8 @@ Called by:
 
  .zinit-exists-physically-message
  zinit-autoload.zsh/.zinit-clear-completions
- zinit-autoload.zsh/.zinit-compiled
  zinit-autoload.zsh/.zinit-compile-uncompile-all
+ zinit-autoload.zsh/.zinit-compiled
  zinit-autoload.zsh/.zinit-create
  zinit-autoload.zsh/.zinit-exists-message
  zinit-autoload.zsh/.zinit-get-completion-owner-uspl2col
@@ -141,8 +141,8 @@ Called by:
  zinit-install.zsh/∞zinit-atclone-hook
  zinit-install.zsh/∞zinit-atpull-e-hook
  zinit-install.zsh/∞zinit-atpull-hook
- zinit-install.zsh/∞zinit-make-ee-hook
  zinit-install.zsh/∞zinit-make-e-hook
+ zinit-install.zsh/∞zinit-make-ee-hook
  zinit-install.zsh/∞zinit-make-hook
 
 .zinit-exists-physically
@@ -188,9 +188,9 @@ ____
 Has 23 line(s). Calls functions:
 
  .zinit-exists-physically-message
+ |-- zinit.zsh/+zinit-message
  |-- zinit.zsh/.zinit-any-to-pid
- |-- zinit.zsh/.zinit-any-to-user-plugin
- `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/.zinit-any-to-user-plugin
 
 Uses feature(s): _setopt_
 

--- a/doc/zsdoc/zinit.zsh.adoc
+++ b/doc/zsdoc/zinit.zsh.adoc
@@ -90,7 +90,16 @@ DETAILS
 Script Body
 ~~~~~~~~~~~
 
-Has 225 line(s). No functions are called (may set up e.g. a hook, a Zle widget bound to a key, etc.).
+Has 225 line(s). Calls functions:
+
+ Script-Body
+ |-- +zinit-message
+ |-- @zinit-register-hook
+ |-- add-zsh-hook
+ |-- is-at-least
+ `-- zinit-autoload.zsh/.zinit-module
+
+Uses feature(s): _add-zsh-hook_, _alias_, _autoload_, _export_, _is-at-least_, _setopt_, _source_, _zmodload_, _zstyle_
 
 _Exports (environment):_ PMSPEC [big]*//* ZPFX [big]*//* ZSH_CACHE_DIR
 
@@ -107,7 +116,13 @@ ____
 
 Has 13 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _read_, _zle_
+
+Called by:
+
+ .zinit-load-snippet
+ .zinit-load
+ zinit-autoload.zsh/.zinit-recall
 
 +zinit-message
 ~~~~~~~~~~~~~~
@@ -123,6 +138,42 @@ Has 14 line(s). Doesn't call other functions.
 Called by:
 
  +zinit-prehelp-usage-message
+ .zinit-compdef-clear
+ .zinit-compdef-replay
+ .zinit-load-snippet
+ .zinit-register-plugin
+ .zinit-run
+ .zinit-set-m-func
+ :zinit-tmp-subst-autoload
+ Script-Body
+ zinit
+ zinit-autoload.zsh/.zinit-build-module
+ zinit-autoload.zsh/.zinit-cd
+ zinit-autoload.zsh/.zinit-self-update
+ zinit-autoload.zsh/.zinit-show-zstatus
+ zinit-autoload.zsh/.zinit-uninstall-completions
+ zinit-autoload.zsh/.zinit-update-all-parallel
+ zinit-autoload.zsh/.zinit-update-or-status-all
+ zinit-autoload.zsh/.zinit-update-or-status
+ zinit-autoload.zsh/.zinit-wait-for-update-jobs
+ zinit-install.zsh/$'\342'$'\210'$'\236'zinit-mv-hook
+ zinit-install.zsh/$'\342'$'\210'$'\236'zinit-ps-on-update-hook
+ zinit-install.zsh/$'\342'$'\210'$'\236'zinit-reset-hook
+ zinit-install.zsh/.zinit-compile-plugin
+ zinit-install.zsh/.zinit-compinit
+ zinit-install.zsh/.zinit-download-file-stdout
+ zinit-install.zsh/.zinit-download-snippet
+ zinit-install.zsh/.zinit-extract
+ zinit-install.zsh/.zinit-get-cygwin-package
+ zinit-install.zsh/.zinit-get-latest-gh-r-url-part
+ zinit-install.zsh/.zinit-get-package
+ zinit-install.zsh/.zinit-install-completions
+ zinit-install.zsh/.zinit-jq-check
+ zinit-install.zsh/.zinit-setup-plugin-dir
+ zinit-install.zsh/.zinit-update-snippet
+ zinit-install.zsh/ziextract
+ zinit-side.zsh/.zinit-countdown
+ zinit-side.zsh/.zinit-exists-physically-message
 
 +zinit-prehelp-usage-message
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -135,9 +186,13 @@ ____
 
 Has 38 line(s). Calls functions:
 
- 
+ +zinit-prehelp-usage-message
+ `-- +zinit-message
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ zinit
+ zinit-autoload.zsh/.zinit-delete
 
 -zinit_scheduler_add_sh
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -163,9 +218,13 @@ ____
  FUNCTION: .zinit-add-fpath. [[[
 ____
 
-Has 10 line(s). Doesn't call other functions.
+Has 10 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-add-fpath
+
+Called by:
+
+ zinit
 
 .zinit-add-report
 ~~~~~~~~~~~~~~~~~
@@ -181,7 +240,16 @@ ____
 
 Has 3 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ .zinit-load-plugin
+ .zinit-load-snippet
+ :zinit-tmp-subst-alias
+ :zinit-tmp-subst-autoload
+ :zinit-tmp-subst-bindkey
+ :zinit-tmp-subst-compdef
+ :zinit-tmp-subst-zle
+ :zinit-tmp-subst-zstyle
 
 .zinit-any-to-pid
 ~~~~~~~~~~~~~~~~~
@@ -191,11 +259,17 @@ ____
  FUNCTION: .zinit-any-to-pid. [[[
 ____
 
-Has 22 line(s). Doesn't call other functions.
+Has 22 line(s). Calls functions:
+
+ .zinit-any-to-pid
+
+Uses feature(s): _setopt_
 
 Called by:
 
  zinit-side.zsh/.zinit-any-colorify-as-uspl2
+ zinit-side.zsh/.zinit-exists-physically-message
+ zinit-side.zsh/.zinit-first
 
 .zinit-any-to-user-plugin
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -214,10 +288,39 @@ ____
 
 Has 29 line(s). Doesn't call other functions.
 
+Uses feature(s): _setopt_
+
 Called by:
 
+ .zinit-add-fpath
+ .zinit-get-object-path
+ .zinit-load
+ .zinit-run
+ :zinit-tmp-subst-autoload
  zinit-autoload.zsh/.zinit-any-to-uspl2
+ zinit-autoload.zsh/.zinit-changes
+ zinit-autoload.zsh/.zinit-compile-uncompile-all
+ zinit-autoload.zsh/.zinit-compiled
+ zinit-autoload.zsh/.zinit-create
+ zinit-autoload.zsh/.zinit-delete
+ zinit-autoload.zsh/.zinit-find-completions-of-plugin
+ zinit-autoload.zsh/.zinit-glance
+ zinit-autoload.zsh/.zinit-show-report
+ zinit-autoload.zsh/.zinit-stress
+ zinit-autoload.zsh/.zinit-uncompile-plugin
+ zinit-autoload.zsh/.zinit-unload
+ zinit-autoload.zsh/.zinit-unregister-plugin
+ zinit-autoload.zsh/.zinit-update-all-parallel
+ zinit-autoload.zsh/.zinit-update-or-status-all
+ zinit-autoload.zsh/.zinit-update-or-status
+ zinit-install.zsh/.zinit-install-completions
  zinit-side.zsh/.zinit-any-colorify-as-uspl2
+ zinit-side.zsh/.zinit-compute-ice
+ zinit-side.zsh/.zinit-exists-physically-message
+ zinit-side.zsh/.zinit-exists-physically
+ zinit-side.zsh/.zinit-first
+
+_Environment variables used:_ ZPFX
 
 .zinit-compdef-clear
 ~~~~~~~~~~~~~~~~~~~~
@@ -228,9 +331,16 @@ ____
  Implements user-exposed functionality to clear gathered compdefs.
 ____
 
-Has 3 line(s). Doesn't call other functions.
+Has 3 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-compdef-clear
+ `-- +zinit-message
+
+Called by:
+
+ zicdclear
+ zinit
+ zpcdclear
 
 .zinit-compdef-replay
 ~~~~~~~~~~~~~~~~~~~~~
@@ -242,9 +352,18 @@ ____
  after loading plugins.
 ____
 
-Has 17 line(s). Doesn't call other functions.
+Has 17 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-compdef-replay
+ `-- +zinit-message
+
+Uses feature(s): _compdef_
+
+Called by:
+
+ zicdreplay
+ zinit
+ zpcdreplay
 
 .zinit-diff
 ~~~~~~~~~~~
@@ -255,9 +374,13 @@ ____
  Performs diff actions of all types
 ____
 
-Has 4 line(s). Doesn't call other functions.
+Has 4 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-diff
+
+Called by:
+
+ .zinit-load-plugin
 
 .zinit-diff-env
 ~~~~~~~~~~~~~~~
@@ -273,7 +396,10 @@ ____
 
 Has 18 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ .zinit-diff
+ .zinit-load-plugin
 
 .zinit-diff-functions
 ~~~~~~~~~~~~~~~~~~~~~
@@ -290,7 +416,9 @@ ____
 
 Has 8 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ .zinit-diff
 
 .zinit-diff-options
 ~~~~~~~~~~~~~~~~~~~
@@ -307,7 +435,9 @@ ____
 
 Has 7 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ .zinit-diff
 
 .zinit-diff-parameter
 ~~~~~~~~~~~~~~~~~~~~~
@@ -324,7 +454,9 @@ ____
 
 Has 9 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ .zinit-diff
 
 .zinit-find-other-matches
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -339,7 +471,11 @@ ____
 
 Has 17 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ .zinit-load-plugin
+ .zinit-load-snippet
+ zinit-side.zsh/.zinit-first
 
 .zinit-formatter-bar
 ~~~~~~~~~~~~~~~~~~~~
@@ -350,7 +486,9 @@ ____
  FUNCTION: .zinit-formatter-bar. [[[
 ____
 
-Has 1 line(s). Doesn't call other functions.
+Has 1 line(s). Calls functions:
+
+ .zinit-formatter-bar
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -364,7 +502,10 @@ ____
 
 Has 7 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ .zinit-formatter-bar
+ .zinit-formatter-th-bar
 
 .zinit-formatter-pid
 ~~~~~~~~~~~~~~~~~~~~
@@ -375,7 +516,12 @@ ____
  FUNCTION: .zinit-formatter-pid. [[[
 ____
 
-Has 11 line(s). Doesn't call other functions.
+Has 11 line(s). Calls functions:
+
+ .zinit-formatter-pid
+ `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
+
+Uses feature(s): _source_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -388,7 +534,9 @@ ____
  FUNCTION: .zinit-formatter-th-bar. [[[
 ____
 
-Has 1 line(s). Doesn't call other functions.
+Has 1 line(s). Calls functions:
+
+ .zinit-formatter-th-bar
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -415,7 +563,11 @@ ____
 
 Has 7 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ Script-Body
+ zinit-autoload.zsh/.zinit-self-update
+ zinit-autoload.zsh/.zinit-update-or-status-all
 
 .zinit-get-object-path
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -425,9 +577,21 @@ ____
  FUNCTION: .zinit-get-object-path. [[[
 ____
 
-Has 28 line(s). Doesn't call other functions.
+Has 28 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-get-object-path
+
+Called by:
+
+ .zinit-load-ices
+ .zinit-load-snippet
+ .zinit-run
+ zinit
+ zinit-autoload.zsh/.zinit-get-path
+ zinit-install.zsh/.zinit-setup-plugin-dir
+ zinit-install.zsh/.zinit-update-snippet
+ zinit-side.zsh/.zinit-first
+ zinit-side.zsh/.zinit-two-paths
 
 .zinit-ice
 ~~~~~~~~~~
@@ -442,7 +606,13 @@ ____
 
 Has 13 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _setopt_
+
+Called by:
+
+ zinit
+
+_Environment variables used:_ ZPFX
 
 .zinit-load
 ~~~~~~~~~~~
@@ -456,9 +626,19 @@ ____
  $2 - plugin name, if the third format is used
 ____
 
-Has 94 line(s). Doesn't call other functions.
+Has 94 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-load
+ |-- +zinit-deploy-message
+ |-- zinit-install.zsh/.zinit-get-package
+ `-- zinit-install.zsh/.zinit-setup-plugin-dir
+
+Uses feature(s): _eval_, _setopt_, _source_, _zle_
+
+Called by:
+
+ .zinit-load-object
+ .zinit-run-task
 
 .zinit-load-ices
 ~~~~~~~~~~~~~~~~
@@ -468,9 +648,15 @@ ____
  FUNCTION: .zinit-load-ices. [[[
 ____
 
-Has 22 line(s). Doesn't call other functions.
+Has 22 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-load-ices
+
+Called by:
+
+ zinit
+
+_Environment variables used:_ ZPFX
 
 .zinit-load-object
 ~~~~~~~~~~~~~~~~~~
@@ -480,9 +666,13 @@ ____
  FUNCTION: .zinit-load-object. [[[
 ____
 
-Has 12 line(s). Doesn't call other functions.
+Has 12 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-load-object
+
+Called by:
+
+ zinit
 
 .zinit-load-plugin
 ~~~~~~~~~~~~~~~~~~
@@ -497,9 +687,18 @@ ____
  $3 - mode (light or load)
 ____
 
-Has 127 line(s). Doesn't call other functions.
+Has 127 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-load-plugin
+ `-- :zinit-tmp-subst-autoload
+     |-- +zinit-message
+     `-- is-at-least
+
+Uses feature(s): _eval_, _setopt_, _source_, _unfunction_, _zle_
+
+Called by:
+
+ .zinit-load
 
 .zinit-load-snippet
 ~~~~~~~~~~~~~~~~~~~
@@ -513,9 +712,21 @@ ____
  $1 - url (can be local, absolute path).
 ____
 
-Has 203 line(s). Doesn't call other functions.
+Has 203 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-load-snippet
+ |-- +zinit-deploy-message
+ |-- +zinit-message
+ `-- zinit-install.zsh/.zinit-download-snippet
+
+Uses feature(s): _autoload_, _eval_, _setopt_, _source_, _unfunction_, _zparseopts_, _zstyle_
+
+Called by:
+
+ .zinit-load-object
+ .zinit-load
+ .zinit-run-task
+ pmodload
 
 .zinit-main-message-formatter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -545,7 +756,14 @@ ____
 
 Has 3 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ .zinit-load-snippet
+ .zinit-load
+ @zsh-plugin-run-on-unload
+ @zsh-plugin-run-on-update
+ zinit-install.zsh/.zinit-update-snippet
+ zinit-side.zsh/.zinit-compute-ice
 
 .zinit-parse-opts
 ~~~~~~~~~~~~~~~~~
@@ -558,7 +776,10 @@ ____
 
 Has 2 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ zinit
+ zinit-autoload.zsh/.zinit-delete
 
 .zinit-prepare-home
 ~~~~~~~~~~~~~~~~~~~
@@ -570,9 +791,19 @@ ____
  already exist.
 ____
 
-Has 40 line(s). Doesn't call other functions.
+Has 40 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-prepare-home
+ |-- zinit-autoload.zsh/.zinit-clear-completions
+ `-- zinit-install.zsh/.zinit-compinit
+
+Uses feature(s): _source_
+
+Called by:
+
+ Script-Body
+
+_Environment variables used:_ ZPFX
 
 .zinit-register-plugin
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -585,9 +816,14 @@ ____
  https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html).
 ____
 
-Has 23 line(s). Doesn't call other functions.
+Has 23 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-register-plugin
+ `-- +zinit-message
+
+Called by:
+
+ .zinit-load
 
 .zinit-run
 ~~~~~~~~~~
@@ -600,9 +836,16 @@ ____
  It uses the `correct' parameter from upper's scope zinit().
 ____
 
-Has 24 line(s). Doesn't call other functions.
+Has 24 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-run
+ `-- +zinit-message
+
+Uses feature(s): _eval_, _setopt_
+
+Called by:
+
+ zinit
 
 .zinit-run-task
 ~~~~~~~~~~~~~~~
@@ -623,9 +866,16 @@ ____
  $6 - the plugin-spec or snippet URL or alias name (from id-as'')
 ____
 
-Has 46 line(s). Doesn't call other functions.
+Has 46 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-run-task
+ `-- zinit-autoload.zsh/.zinit-unload
+
+Uses feature(s): _eval_, _source_, _zle_, _zpty_
+
+Called by:
+
+ @zinit-scheduler
 
 .zinit-set-m-func
 ~~~~~~~~~~~~~~~~~
@@ -637,9 +887,18 @@ ____
  Sets and withdraws the temporary, atclone/atpull time function `m`.
 ____
 
-Has 17 line(s). Doesn't call other functions.
+Has 17 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ .zinit-set-m-func
+ `-- +zinit-message
+
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-load-snippet
+ .zinit-load
+ zinit-autoload.zsh/.zinit-update-or-status
 
 .zinit-setup-params
 ~~~~~~~~~~~~~~~~~~~
@@ -652,7 +911,10 @@ ____
 
 Has 3 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ .zinit-load-snippet
+ .zinit-load
 
 .zinit-submit-turbo
 ~~~~~~~~~~~~~~~~~~~
@@ -669,7 +931,9 @@ ____
 
 Has 16 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ zinit
 
 .zinit-tmp-subst-off
 ~~~~~~~~~~~~~~~~~~~~
@@ -683,7 +947,11 @@ ____
 
 Has 21 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _setopt_, _unfunction_
+
+Called by:
+
+ .zinit-load-plugin
 
 .zinit-tmp-subst-on
 ~~~~~~~~~~~~~~~~~~~
@@ -699,7 +967,11 @@ ____
 
 Has 32 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _source_
+
+Called by:
+
+ .zinit-load-plugin
 
 .zinit-util-shands-path
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -712,7 +984,13 @@ ____
 
 Has 9 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _setopt_
+
+Called by:
+
+ .zinit-any-to-pid
+
+_Environment variables used:_ ZPFX
 
 :zinit-reload-and-run
 ~~~~~~~~~~~~~~~~~~~~~
@@ -737,6 +1015,8 @@ ____
 
 Has 11 line(s). Doesn't call other functions.
 
+Uses feature(s): _autoload_, _unfunction_
+
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 :zinit-tmp-subst-alias
@@ -750,7 +1030,11 @@ ____
  The hijacking is to gather report data (which is used in unload).
 ____
 
-Has 36 line(s). Doesn't call other functions.
+Has 36 line(s). Calls functions:
+
+ :zinit-tmp-subst-alias
+
+Uses feature(s): _alias_, _setopt_, _zparseopts_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -766,9 +1050,18 @@ ____
  run custom `autoload' function, that doesn't need FPATH.
 ____
 
-Has 111 line(s). Doesn't call other functions.
+Has 111 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ :zinit-tmp-subst-autoload
+ |-- +zinit-message
+ `-- is-at-least
+
+Uses feature(s): _autoload_, _eval_, _is-at-least_, _setopt_, _zparseopts_
+
+Called by:
+
+ .zinit-load-plugin
+ @autoload
 
 :zinit-tmp-subst-bindkey
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -781,7 +1074,12 @@ ____
  The hijacking is to gather report data (which is used in unload).
 ____
 
-Has 120 line(s). Doesn't call other functions.
+Has 120 line(s). Calls functions:
+
+ :zinit-tmp-subst-bindkey
+ `-- is-at-least
+
+Uses feature(s): _bindkey_, _is-at-least_, _setopt_, _zparseopts_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -796,7 +1094,11 @@ ____
  calls so that `compinit' can be called after loading plugins.
 ____
 
-Has 6 line(s). Doesn't call other functions.
+Has 6 line(s). Calls functions:
+
+ :zinit-tmp-subst-compdef
+
+Uses feature(s): _setopt_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -811,7 +1113,11 @@ ____
  The hijacking is to gather report data (which is used in unload).
 ____
 
-Has 36 line(s). Doesn't call other functions.
+Has 36 line(s). Calls functions:
+
+ :zinit-tmp-subst-zle
+
+Uses feature(s): _setopt_, _zle_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -826,7 +1132,11 @@ ____
  The hijacking is to gather report data (which is used in unload).
 ____
 
-Has 23 line(s). Doesn't call other functions.
+Has 23 line(s). Calls functions:
+
+ :zinit-tmp-subst-zstyle
+
+Uses feature(s): _setopt_, _zparseopts_, _zstyle_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -839,7 +1149,12 @@ ____
  FUNCTION: @autoload. [[[
 ____
 
-Has 3 line(s). Doesn't call other functions.
+Has 3 line(s). Calls functions:
+
+ @autoload
+ `-- :zinit-tmp-subst-autoload
+     |-- +zinit-message
+     `-- is-at-least
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -869,7 +1184,9 @@ ____
 
 Has 4 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ Script-Body
 
 @zinit-scheduler
 ~~~~~~~~~~~~~~~~
@@ -895,7 +1212,12 @@ ____
  
 ____
 
-Has 75 line(s). *Is a precmd hook*. Doesn't call other functions.
+Has 75 line(s). *Is a precmd hook*. Calls functions:
+
+ @zinit-scheduler
+ `-- add-zsh-hook
+
+Uses feature(s): _add-zsh-hook_, _sched_, _setopt_, _zle_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -910,9 +1232,22 @@ ____
 
 Has 40 line(s). Doesn't call other functions.
 
+Uses feature(s): _setopt_
+
 Called by:
 
+ zinit-autoload.zsh/.zinit-at-eval
  zinit-install.zsh/$'\342'$'\210'$'\236'zinit-atclone-hook
+ zinit-install.zsh/$'\342'$'\210'$'\236'zinit-cp-hook
+ zinit-install.zsh/$'\342'$'\210'$'\236'zinit-extract-hook
+ zinit-install.zsh/$'\342'$'\210'$'\236'zinit-make-e-hook
+ zinit-install.zsh/$'\342'$'\210'$'\236'zinit-make-ee-hook
+ zinit-install.zsh/$'\342'$'\210'$'\236'zinit-make-hook
+ zinit-install.zsh/$'\342'$'\210'$'\236'zinit-mv-hook
+ zinit-install.zsh/.zinit-at-eval
+ zinit-install.zsh/.zinit-get-package
+
+_Environment variables used:_ ZPFX
 
 @zsh-plugin-run-on-unload
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -925,7 +1260,9 @@ ____
  https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
 ____
 
-Has 2 line(s). Doesn't call other functions.
+Has 2 line(s). Calls functions:
+
+ @zsh-plugin-run-on-unload
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -939,7 +1276,9 @@ ____
  The Plugin Standard required mechanism
 ____
 
-Has 2 line(s). Doesn't call other functions.
+Has 2 line(s). Calls functions:
+
+ @zsh-plugin-run-on-update
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -952,7 +1291,11 @@ ____
  Compatibility with Prezto. Calls can be recursive.
 ____
 
-Has 15 line(s). Doesn't call other functions.
+Has 15 line(s). Calls functions:
+
+ pmodload
+
+Uses feature(s): _zstyle_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -967,7 +1310,9 @@ ____
  ices like the atinit'', atload'', etc. ices.
 ____
 
-Has 1 line(s). Doesn't call other functions.
+Has 1 line(s). Calls functions:
+
+ zicdclear
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -982,7 +1327,9 @@ ____
  from such hook ices.
 ____
 
-Has 1 line(s). Doesn't call other functions.
+Has 1 line(s). Calls functions:
+
+ zicdreplay
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1014,7 +1361,12 @@ ____
  ZINIT[ZCOMPDUMP_PATH] and ZINIT[COMPINIT_OPTS].
 ____
 
-Has 1 line(s). Doesn't call other functions.
+Has 1 line(s). Calls functions:
+
+ zicompinit
+ `-- compinit
+
+Uses feature(s): _autoload_, _compinit_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1028,21 +1380,64 @@ ____
  arguments, has completion.
 ____
 
-Has 560 line(s). Doesn't call other functions.
+Has 560 line(s). Calls functions:
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+ zinit
+ |-- +zinit-message
+ |-- +zinit-prehelp-usage-message
+ |   `-- +zinit-message
+ |-- compinit
+ |-- zinit-autoload.zsh/.zinit-cdisable
+ |-- zinit-autoload.zsh/.zinit-cenable
+ |-- zinit-autoload.zsh/.zinit-clear-completions
+ |-- zinit-autoload.zsh/.zinit-compile-uncompile-all
+ |-- zinit-autoload.zsh/.zinit-compiled
+ |-- zinit-autoload.zsh/.zinit-help
+ |-- zinit-autoload.zsh/.zinit-list-bindkeys
+ |-- zinit-autoload.zsh/.zinit-list-compdef-replay
+ |-- zinit-autoload.zsh/.zinit-ls
+ |-- zinit-autoload.zsh/.zinit-module
+ |-- zinit-autoload.zsh/.zinit-recently
+ |-- zinit-autoload.zsh/.zinit-search-completions
+ |-- zinit-autoload.zsh/.zinit-self-update
+ |-- zinit-autoload.zsh/.zinit-show-all-reports
+ |-- zinit-autoload.zsh/.zinit-show-completions
+ |-- zinit-autoload.zsh/.zinit-show-debug-report
+ |-- zinit-autoload.zsh/.zinit-show-registered-plugins
+ |-- zinit-autoload.zsh/.zinit-show-report
+ |-- zinit-autoload.zsh/.zinit-show-times
+ |-- zinit-autoload.zsh/.zinit-show-zstatus
+ |-- zinit-autoload.zsh/.zinit-uncompile-plugin
+ |-- zinit-autoload.zsh/.zinit-uninstall-completions
+ |-- zinit-autoload.zsh/.zinit-unload
+ |-- zinit-autoload.zsh/.zinit-update-or-status
+ |-- zinit-autoload.zsh/.zinit-update-or-status-all
+ |-- zinit-install.zsh/.zinit-compile-plugin
+ |-- zinit-install.zsh/.zinit-compinit
+ |-- zinit-install.zsh/.zinit-forget-completion
+ `-- zinit-install.zsh/.zinit-install-completions
+
+Uses feature(s): _autoload_, _compinit_, _eval_, _setopt_, _source_
+
+Called by:
+
+ zplugin
 
 zpcdclear
 ~~~~~~~~~
 
-Has 1 line(s). Doesn't call other functions.
+Has 1 line(s). Calls functions:
+
+ zpcdclear
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 zpcdreplay
 ~~~~~~~~~~
 
-Has 1 line(s). Doesn't call other functions.
+Has 1 line(s). Calls functions:
+
+ zpcdreplay
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1056,7 +1451,12 @@ Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 zpcompinit
 ~~~~~~~~~~
 
-Has 1 line(s). Doesn't call other functions.
+Has 1 line(s). Calls functions:
+
+ zpcompinit
+ `-- compinit
+
+Uses feature(s): _autoload_, _compinit_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1068,7 +1468,43 @@ ____
  Compatibility functions. [[[
 ____
 
-Has 1 line(s). Doesn't call other functions.
+Has 1 line(s). Calls functions:
+
+ zplugin
+ `-- zinit
+     |-- +zinit-message
+     |-- +zinit-prehelp-usage-message
+     |   `-- +zinit-message
+     |-- compinit
+     |-- zinit-autoload.zsh/.zinit-cdisable
+     |-- zinit-autoload.zsh/.zinit-cenable
+     |-- zinit-autoload.zsh/.zinit-clear-completions
+     |-- zinit-autoload.zsh/.zinit-compile-uncompile-all
+     |-- zinit-autoload.zsh/.zinit-compiled
+     |-- zinit-autoload.zsh/.zinit-help
+     |-- zinit-autoload.zsh/.zinit-list-bindkeys
+     |-- zinit-autoload.zsh/.zinit-list-compdef-replay
+     |-- zinit-autoload.zsh/.zinit-ls
+     |-- zinit-autoload.zsh/.zinit-module
+     |-- zinit-autoload.zsh/.zinit-recently
+     |-- zinit-autoload.zsh/.zinit-search-completions
+     |-- zinit-autoload.zsh/.zinit-self-update
+     |-- zinit-autoload.zsh/.zinit-show-all-reports
+     |-- zinit-autoload.zsh/.zinit-show-completions
+     |-- zinit-autoload.zsh/.zinit-show-debug-report
+     |-- zinit-autoload.zsh/.zinit-show-registered-plugins
+     |-- zinit-autoload.zsh/.zinit-show-report
+     |-- zinit-autoload.zsh/.zinit-show-times
+     |-- zinit-autoload.zsh/.zinit-show-zstatus
+     |-- zinit-autoload.zsh/.zinit-uncompile-plugin
+     |-- zinit-autoload.zsh/.zinit-uninstall-completions
+     |-- zinit-autoload.zsh/.zinit-unload
+     |-- zinit-autoload.zsh/.zinit-update-or-status
+     |-- zinit-autoload.zsh/.zinit-update-or-status-all
+     |-- zinit-install.zsh/.zinit-compile-plugin
+     |-- zinit-install.zsh/.zinit-compinit
+     |-- zinit-install.zsh/.zinit-forget-completion
+     `-- zinit-install.zsh/.zinit-install-completions
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1091,7 +1527,12 @@ ____
 
 Has 93 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _autoload_, _getopts_
+
+Called by:
+
+ @zinit-scheduler
+ Script-Body
 
 compinit
 ~~~~~~~~
@@ -1112,7 +1553,13 @@ ____
 
 Has 549 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Uses feature(s): _autoload_, _bindkey_, _compdef_, _compdump_, _eval_, _read_, _setopt_, _unfunction_, _zle_, _zstyle_
+
+Called by:
+
+ zicompinit
+ zinit
+ zpcompinit
 
 is-at-least
 ~~~~~~~~~~~
@@ -1133,5 +1580,9 @@ ____
 
 Has 56 line(s). Doesn't call other functions.
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ :zinit-tmp-subst-autoload
+ :zinit-tmp-subst-bindkey
+ Script-Body
 

--- a/doc/zsdoc/zinit.zsh.adoc
+++ b/doc/zsdoc/zinit.zsh.adoc
@@ -90,16 +90,7 @@ DETAILS
 Script Body
 ~~~~~~~~~~~
 
-Has 225 line(s). Calls functions:
-
- Script-Body
- |-- +zinit-message
- |-- @zinit-register-hook
- |-- add-zsh-hook
- |-- is-at-least
- `-- zinit-autoload.zsh/.zinit-module
-
-Uses feature(s): _add-zsh-hook_, _alias_, _autoload_, _export_, _is-at-least_, _setopt_, _source_, _zmodload_, _zstyle_
+Has 225 line(s). No functions are called (may set up e.g. a hook, a Zle widget bound to a key, etc.).
 
 _Exports (environment):_ PMSPEC [big]*//* ZPFX [big]*//* ZSH_CACHE_DIR
 
@@ -116,13 +107,7 @@ ____
 
 Has 13 line(s). Doesn't call other functions.
 
-Uses feature(s): _read_, _zle_
-
-Called by:
-
- .zinit-load-snippet
- .zinit-load
- zinit-autoload.zsh/.zinit-recall
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 +zinit-message
 ~~~~~~~~~~~~~~
@@ -138,42 +123,6 @@ Has 14 line(s). Doesn't call other functions.
 Called by:
 
  +zinit-prehelp-usage-message
- .zinit-compdef-clear
- .zinit-compdef-replay
- .zinit-load-snippet
- .zinit-register-plugin
- .zinit-run
- .zinit-set-m-func
- :zinit-tmp-subst-autoload
- Script-Body
- zinit
- zinit-autoload.zsh/.zinit-build-module
- zinit-autoload.zsh/.zinit-cd
- zinit-autoload.zsh/.zinit-self-update
- zinit-autoload.zsh/.zinit-show-zstatus
- zinit-autoload.zsh/.zinit-uninstall-completions
- zinit-autoload.zsh/.zinit-update-all-parallel
- zinit-autoload.zsh/.zinit-update-or-status-all
- zinit-autoload.zsh/.zinit-update-or-status
- zinit-autoload.zsh/.zinit-wait-for-update-jobs
- zinit-install.zsh/.zinit-compile-plugin
- zinit-install.zsh/.zinit-compinit
- zinit-install.zsh/.zinit-download-file-stdout
- zinit-install.zsh/.zinit-download-snippet
- zinit-install.zsh/.zinit-extract
- zinit-install.zsh/.zinit-get-cygwin-package
- zinit-install.zsh/.zinit-get-latest-gh-r-url-part
- zinit-install.zsh/.zinit-get-package
- zinit-install.zsh/.zinit-install-completions
- zinit-install.zsh/.zinit-jq-check
- zinit-install.zsh/.zinit-setup-plugin-dir
- zinit-install.zsh/.zinit-update-snippet
- zinit-install.zsh/ziextract
- zinit-install.zsh/∞zinit-mv-hook
- zinit-install.zsh/∞zinit-ps-on-update-hook
- zinit-install.zsh/∞zinit-reset-hook
- zinit-side.zsh/.zinit-countdown
- zinit-side.zsh/.zinit-exists-physically-message
 
 +zinit-prehelp-usage-message
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -186,13 +135,9 @@ ____
 
 Has 38 line(s). Calls functions:
 
- +zinit-prehelp-usage-message
- `-- +zinit-message
+ 
 
-Called by:
-
- zinit
- zinit-autoload.zsh/.zinit-delete
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 -zinit_scheduler_add_sh
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -218,13 +163,9 @@ ____
  FUNCTION: .zinit-add-fpath. [[[
 ____
 
-Has 10 line(s). Calls functions:
+Has 10 line(s). Doesn't call other functions.
 
- .zinit-add-fpath
-
-Called by:
-
- zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-add-report
 ~~~~~~~~~~~~~~~~~
@@ -240,16 +181,7 @@ ____
 
 Has 3 line(s). Doesn't call other functions.
 
-Called by:
-
- .zinit-load-plugin
- .zinit-load-snippet
- :zinit-tmp-subst-alias
- :zinit-tmp-subst-autoload
- :zinit-tmp-subst-bindkey
- :zinit-tmp-subst-compdef
- :zinit-tmp-subst-zle
- :zinit-tmp-subst-zstyle
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-any-to-pid
 ~~~~~~~~~~~~~~~~~
@@ -259,17 +191,11 @@ ____
  FUNCTION: .zinit-any-to-pid. [[[
 ____
 
-Has 22 line(s). Calls functions:
-
- .zinit-any-to-pid
-
-Uses feature(s): _setopt_
+Has 22 line(s). Doesn't call other functions.
 
 Called by:
 
  zinit-side.zsh/.zinit-any-colorify-as-uspl2
- zinit-side.zsh/.zinit-exists-physically-message
- zinit-side.zsh/.zinit-first
 
 .zinit-any-to-user-plugin
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -288,39 +214,10 @@ ____
 
 Has 29 line(s). Doesn't call other functions.
 
-Uses feature(s): _setopt_
-
 Called by:
 
- .zinit-add-fpath
- .zinit-get-object-path
- .zinit-load
- .zinit-run
- :zinit-tmp-subst-autoload
  zinit-autoload.zsh/.zinit-any-to-uspl2
- zinit-autoload.zsh/.zinit-changes
- zinit-autoload.zsh/.zinit-compile-uncompile-all
- zinit-autoload.zsh/.zinit-compiled
- zinit-autoload.zsh/.zinit-create
- zinit-autoload.zsh/.zinit-delete
- zinit-autoload.zsh/.zinit-find-completions-of-plugin
- zinit-autoload.zsh/.zinit-glance
- zinit-autoload.zsh/.zinit-show-report
- zinit-autoload.zsh/.zinit-stress
- zinit-autoload.zsh/.zinit-uncompile-plugin
- zinit-autoload.zsh/.zinit-unload
- zinit-autoload.zsh/.zinit-unregister-plugin
- zinit-autoload.zsh/.zinit-update-all-parallel
- zinit-autoload.zsh/.zinit-update-or-status-all
- zinit-autoload.zsh/.zinit-update-or-status
- zinit-install.zsh/.zinit-install-completions
  zinit-side.zsh/.zinit-any-colorify-as-uspl2
- zinit-side.zsh/.zinit-compute-ice
- zinit-side.zsh/.zinit-exists-physically-message
- zinit-side.zsh/.zinit-exists-physically
- zinit-side.zsh/.zinit-first
-
-_Environment variables used:_ ZPFX
 
 .zinit-compdef-clear
 ~~~~~~~~~~~~~~~~~~~~
@@ -331,16 +228,9 @@ ____
  Implements user-exposed functionality to clear gathered compdefs.
 ____
 
-Has 3 line(s). Calls functions:
+Has 3 line(s). Doesn't call other functions.
 
- .zinit-compdef-clear
- `-- +zinit-message
-
-Called by:
-
- zicdclear
- zinit
- zpcdclear
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-compdef-replay
 ~~~~~~~~~~~~~~~~~~~~~
@@ -352,18 +242,9 @@ ____
  after loading plugins.
 ____
 
-Has 17 line(s). Calls functions:
+Has 17 line(s). Doesn't call other functions.
 
- .zinit-compdef-replay
- `-- +zinit-message
-
-Uses feature(s): _compdef_
-
-Called by:
-
- zicdreplay
- zinit
- zpcdreplay
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-diff
 ~~~~~~~~~~~
@@ -374,13 +255,9 @@ ____
  Performs diff actions of all types
 ____
 
-Has 4 line(s). Calls functions:
+Has 4 line(s). Doesn't call other functions.
 
- .zinit-diff
-
-Called by:
-
- .zinit-load-plugin
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-diff-env
 ~~~~~~~~~~~~~~~
@@ -396,10 +273,7 @@ ____
 
 Has 18 line(s). Doesn't call other functions.
 
-Called by:
-
- .zinit-diff
- .zinit-load-plugin
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-diff-functions
 ~~~~~~~~~~~~~~~~~~~~~
@@ -416,9 +290,7 @@ ____
 
 Has 8 line(s). Doesn't call other functions.
 
-Called by:
-
- .zinit-diff
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-diff-options
 ~~~~~~~~~~~~~~~~~~~
@@ -435,9 +307,7 @@ ____
 
 Has 7 line(s). Doesn't call other functions.
 
-Called by:
-
- .zinit-diff
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-diff-parameter
 ~~~~~~~~~~~~~~~~~~~~~
@@ -454,9 +324,7 @@ ____
 
 Has 9 line(s). Doesn't call other functions.
 
-Called by:
-
- .zinit-diff
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-find-other-matches
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -471,11 +339,7 @@ ____
 
 Has 17 line(s). Doesn't call other functions.
 
-Called by:
-
- .zinit-load-plugin
- .zinit-load-snippet
- zinit-side.zsh/.zinit-first
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-formatter-bar
 ~~~~~~~~~~~~~~~~~~~~
@@ -486,9 +350,7 @@ ____
  FUNCTION: .zinit-formatter-bar. [[[
 ____
 
-Has 1 line(s). Calls functions:
-
- .zinit-formatter-bar
+Has 1 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -502,10 +364,7 @@ ____
 
 Has 7 line(s). Doesn't call other functions.
 
-Called by:
-
- .zinit-formatter-bar
- .zinit-formatter-th-bar
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-formatter-pid
 ~~~~~~~~~~~~~~~~~~~~
@@ -516,12 +375,7 @@ ____
  FUNCTION: .zinit-formatter-pid. [[[
 ____
 
-Has 11 line(s). Calls functions:
-
- .zinit-formatter-pid
- `-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
-
-Uses feature(s): _source_
+Has 11 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -534,9 +388,7 @@ ____
  FUNCTION: .zinit-formatter-th-bar. [[[
 ____
 
-Has 1 line(s). Calls functions:
-
- .zinit-formatter-th-bar
+Has 1 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -563,11 +415,7 @@ ____
 
 Has 7 line(s). Doesn't call other functions.
 
-Called by:
-
- Script-Body
- zinit-autoload.zsh/.zinit-self-update
- zinit-autoload.zsh/.zinit-update-or-status-all
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-get-object-path
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -577,21 +425,9 @@ ____
  FUNCTION: .zinit-get-object-path. [[[
 ____
 
-Has 28 line(s). Calls functions:
+Has 28 line(s). Doesn't call other functions.
 
- .zinit-get-object-path
-
-Called by:
-
- .zinit-load-ices
- .zinit-load-snippet
- .zinit-run
- zinit
- zinit-autoload.zsh/.zinit-get-path
- zinit-install.zsh/.zinit-setup-plugin-dir
- zinit-install.zsh/.zinit-update-snippet
- zinit-side.zsh/.zinit-first
- zinit-side.zsh/.zinit-two-paths
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-ice
 ~~~~~~~~~~
@@ -606,13 +442,7 @@ ____
 
 Has 13 line(s). Doesn't call other functions.
 
-Uses feature(s): _setopt_
-
-Called by:
-
- zinit
-
-_Environment variables used:_ ZPFX
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-load
 ~~~~~~~~~~~
@@ -626,19 +456,9 @@ ____
  $2 - plugin name, if the third format is used
 ____
 
-Has 94 line(s). Calls functions:
+Has 94 line(s). Doesn't call other functions.
 
- .zinit-load
- |-- +zinit-deploy-message
- |-- zinit-install.zsh/.zinit-get-package
- `-- zinit-install.zsh/.zinit-setup-plugin-dir
-
-Uses feature(s): _eval_, _setopt_, _source_, _zle_
-
-Called by:
-
- .zinit-load-object
- .zinit-run-task
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-load-ices
 ~~~~~~~~~~~~~~~~
@@ -648,15 +468,9 @@ ____
  FUNCTION: .zinit-load-ices. [[[
 ____
 
-Has 22 line(s). Calls functions:
+Has 22 line(s). Doesn't call other functions.
 
- .zinit-load-ices
-
-Called by:
-
- zinit
-
-_Environment variables used:_ ZPFX
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-load-object
 ~~~~~~~~~~~~~~~~~~
@@ -666,13 +480,9 @@ ____
  FUNCTION: .zinit-load-object. [[[
 ____
 
-Has 12 line(s). Calls functions:
+Has 12 line(s). Doesn't call other functions.
 
- .zinit-load-object
-
-Called by:
-
- zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-load-plugin
 ~~~~~~~~~~~~~~~~~~
@@ -687,18 +497,9 @@ ____
  $3 - mode (light or load)
 ____
 
-Has 127 line(s). Calls functions:
+Has 127 line(s). Doesn't call other functions.
 
- .zinit-load-plugin
- `-- :zinit-tmp-subst-autoload
-     |-- +zinit-message
-     `-- is-at-least
-
-Uses feature(s): _eval_, _setopt_, _source_, _unfunction_, _zle_
-
-Called by:
-
- .zinit-load
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-load-snippet
 ~~~~~~~~~~~~~~~~~~~
@@ -712,21 +513,9 @@ ____
  $1 - url (can be local, absolute path).
 ____
 
-Has 203 line(s). Calls functions:
+Has 203 line(s). Doesn't call other functions.
 
- .zinit-load-snippet
- |-- +zinit-deploy-message
- |-- +zinit-message
- `-- zinit-install.zsh/.zinit-download-snippet
-
-Uses feature(s): _autoload_, _eval_, _setopt_, _source_, _unfunction_, _zparseopts_, _zstyle_
-
-Called by:
-
- .zinit-load-object
- .zinit-load
- .zinit-run-task
- pmodload
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-main-message-formatter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -756,14 +545,7 @@ ____
 
 Has 3 line(s). Doesn't call other functions.
 
-Called by:
-
- .zinit-load-snippet
- .zinit-load
- @zsh-plugin-run-on-unload
- @zsh-plugin-run-on-update
- zinit-install.zsh/.zinit-update-snippet
- zinit-side.zsh/.zinit-compute-ice
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-parse-opts
 ~~~~~~~~~~~~~~~~~
@@ -776,10 +558,7 @@ ____
 
 Has 2 line(s). Doesn't call other functions.
 
-Called by:
-
- zinit
- zinit-autoload.zsh/.zinit-delete
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-prepare-home
 ~~~~~~~~~~~~~~~~~~~
@@ -791,19 +570,9 @@ ____
  already exist.
 ____
 
-Has 40 line(s). Calls functions:
+Has 40 line(s). Doesn't call other functions.
 
- .zinit-prepare-home
- |-- zinit-autoload.zsh/.zinit-clear-completions
- `-- zinit-install.zsh/.zinit-compinit
-
-Uses feature(s): _source_
-
-Called by:
-
- Script-Body
-
-_Environment variables used:_ ZPFX
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-register-plugin
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -816,14 +585,9 @@ ____
  https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html).
 ____
 
-Has 23 line(s). Calls functions:
+Has 23 line(s). Doesn't call other functions.
 
- .zinit-register-plugin
- `-- +zinit-message
-
-Called by:
-
- .zinit-load
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-run
 ~~~~~~~~~~
@@ -836,16 +600,9 @@ ____
  It uses the `correct' parameter from upper's scope zinit().
 ____
 
-Has 24 line(s). Calls functions:
+Has 24 line(s). Doesn't call other functions.
 
- .zinit-run
- `-- +zinit-message
-
-Uses feature(s): _eval_, _setopt_
-
-Called by:
-
- zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-run-task
 ~~~~~~~~~~~~~~~
@@ -866,16 +623,9 @@ ____
  $6 - the plugin-spec or snippet URL or alias name (from id-as'')
 ____
 
-Has 46 line(s). Calls functions:
+Has 46 line(s). Doesn't call other functions.
 
- .zinit-run-task
- `-- zinit-autoload.zsh/.zinit-unload
-
-Uses feature(s): _eval_, _source_, _zle_, _zpty_
-
-Called by:
-
- @zinit-scheduler
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-set-m-func
 ~~~~~~~~~~~~~~~~~
@@ -887,18 +637,9 @@ ____
  Sets and withdraws the temporary, atclone/atpull time function `m`.
 ____
 
-Has 17 line(s). Calls functions:
+Has 17 line(s). Doesn't call other functions.
 
- .zinit-set-m-func
- `-- +zinit-message
-
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-load-snippet
- .zinit-load
- zinit-autoload.zsh/.zinit-update-or-status
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-setup-params
 ~~~~~~~~~~~~~~~~~~~
@@ -911,10 +652,7 @@ ____
 
 Has 3 line(s). Doesn't call other functions.
 
-Called by:
-
- .zinit-load-snippet
- .zinit-load
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-submit-turbo
 ~~~~~~~~~~~~~~~~~~~
@@ -931,9 +669,7 @@ ____
 
 Has 16 line(s). Doesn't call other functions.
 
-Called by:
-
- zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-tmp-subst-off
 ~~~~~~~~~~~~~~~~~~~~
@@ -947,11 +683,7 @@ ____
 
 Has 21 line(s). Doesn't call other functions.
 
-Uses feature(s): _setopt_, _unfunction_
-
-Called by:
-
- .zinit-load-plugin
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-tmp-subst-on
 ~~~~~~~~~~~~~~~~~~~
@@ -967,11 +699,7 @@ ____
 
 Has 32 line(s). Doesn't call other functions.
 
-Uses feature(s): _source_
-
-Called by:
-
- .zinit-load-plugin
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-util-shands-path
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -984,13 +712,7 @@ ____
 
 Has 9 line(s). Doesn't call other functions.
 
-Uses feature(s): _setopt_
-
-Called by:
-
- .zinit-any-to-pid
-
-_Environment variables used:_ ZPFX
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 :zinit-reload-and-run
 ~~~~~~~~~~~~~~~~~~~~~
@@ -1015,8 +737,6 @@ ____
 
 Has 11 line(s). Doesn't call other functions.
 
-Uses feature(s): _autoload_, _unfunction_
-
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 :zinit-tmp-subst-alias
@@ -1030,11 +750,7 @@ ____
  The hijacking is to gather report data (which is used in unload).
 ____
 
-Has 36 line(s). Calls functions:
-
- :zinit-tmp-subst-alias
-
-Uses feature(s): _alias_, _setopt_, _zparseopts_
+Has 36 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1050,18 +766,9 @@ ____
  run custom `autoload' function, that doesn't need FPATH.
 ____
 
-Has 111 line(s). Calls functions:
+Has 111 line(s). Doesn't call other functions.
 
- :zinit-tmp-subst-autoload
- |-- +zinit-message
- `-- is-at-least
-
-Uses feature(s): _autoload_, _eval_, _is-at-least_, _setopt_, _zparseopts_
-
-Called by:
-
- .zinit-load-plugin
- @autoload
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 :zinit-tmp-subst-bindkey
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1074,12 +781,7 @@ ____
  The hijacking is to gather report data (which is used in unload).
 ____
 
-Has 120 line(s). Calls functions:
-
- :zinit-tmp-subst-bindkey
- `-- is-at-least
-
-Uses feature(s): _bindkey_, _is-at-least_, _setopt_, _zparseopts_
+Has 120 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1094,11 +796,7 @@ ____
  calls so that `compinit' can be called after loading plugins.
 ____
 
-Has 6 line(s). Calls functions:
-
- :zinit-tmp-subst-compdef
-
-Uses feature(s): _setopt_
+Has 6 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1113,11 +811,7 @@ ____
  The hijacking is to gather report data (which is used in unload).
 ____
 
-Has 36 line(s). Calls functions:
-
- :zinit-tmp-subst-zle
-
-Uses feature(s): _setopt_, _zle_
+Has 36 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1132,11 +826,7 @@ ____
  The hijacking is to gather report data (which is used in unload).
 ____
 
-Has 23 line(s). Calls functions:
-
- :zinit-tmp-subst-zstyle
-
-Uses feature(s): _setopt_, _zparseopts_, _zstyle_
+Has 23 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1149,12 +839,7 @@ ____
  FUNCTION: @autoload. [[[
 ____
 
-Has 3 line(s). Calls functions:
-
- @autoload
- `-- :zinit-tmp-subst-autoload
-     |-- +zinit-message
-     `-- is-at-least
+Has 3 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1184,9 +869,7 @@ ____
 
 Has 4 line(s). Doesn't call other functions.
 
-Called by:
-
- Script-Body
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 @zinit-scheduler
 ~~~~~~~~~~~~~~~~
@@ -1212,12 +895,7 @@ ____
  
 ____
 
-Has 75 line(s). *Is a precmd hook*. Calls functions:
-
- @zinit-scheduler
- `-- add-zsh-hook
-
-Uses feature(s): _add-zsh-hook_, _sched_, _setopt_, _zle_
+Has 75 line(s). *Is a precmd hook*. Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1232,22 +910,9 @@ ____
 
 Has 40 line(s). Doesn't call other functions.
 
-Uses feature(s): _setopt_
-
 Called by:
 
- zinit-autoload.zsh/.zinit-at-eval
- zinit-install.zsh/.zinit-at-eval
- zinit-install.zsh/.zinit-get-package
- zinit-install.zsh/∞zinit-atclone-hook
- zinit-install.zsh/∞zinit-cp-hook
- zinit-install.zsh/∞zinit-extract-hook
- zinit-install.zsh/∞zinit-make-e-hook
- zinit-install.zsh/∞zinit-make-ee-hook
- zinit-install.zsh/∞zinit-make-hook
- zinit-install.zsh/∞zinit-mv-hook
-
-_Environment variables used:_ ZPFX
+ zinit-install.zsh/$'\342'$'\210'$'\236'zinit-atclone-hook
 
 @zsh-plugin-run-on-unload
 ~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1260,9 +925,7 @@ ____
  https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
 ____
 
-Has 2 line(s). Calls functions:
-
- @zsh-plugin-run-on-unload
+Has 2 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1276,9 +939,7 @@ ____
  The Plugin Standard required mechanism
 ____
 
-Has 2 line(s). Calls functions:
-
- @zsh-plugin-run-on-update
+Has 2 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1291,11 +952,7 @@ ____
  Compatibility with Prezto. Calls can be recursive.
 ____
 
-Has 15 line(s). Calls functions:
-
- pmodload
-
-Uses feature(s): _zstyle_
+Has 15 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1310,9 +967,7 @@ ____
  ices like the atinit'', atload'', etc. ices.
 ____
 
-Has 1 line(s). Calls functions:
-
- zicdclear
+Has 1 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1327,9 +982,7 @@ ____
  from such hook ices.
 ____
 
-Has 1 line(s). Calls functions:
-
- zicdreplay
+Has 1 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1361,12 +1014,7 @@ ____
  ZINIT[ZCOMPDUMP_PATH] and ZINIT[COMPINIT_OPTS].
 ____
 
-Has 1 line(s). Calls functions:
-
- zicompinit
- `-- compinit
-
-Uses feature(s): _autoload_, _compinit_
+Has 1 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1380,64 +1028,21 @@ ____
  arguments, has completion.
 ____
 
-Has 560 line(s). Calls functions:
+Has 560 line(s). Doesn't call other functions.
 
- zinit
- |-- +zinit-message
- |-- +zinit-prehelp-usage-message
- |   `-- +zinit-message
- |-- compinit
- |-- zinit-autoload.zsh/.zinit-cdisable
- |-- zinit-autoload.zsh/.zinit-cenable
- |-- zinit-autoload.zsh/.zinit-clear-completions
- |-- zinit-autoload.zsh/.zinit-compile-uncompile-all
- |-- zinit-autoload.zsh/.zinit-compiled
- |-- zinit-autoload.zsh/.zinit-help
- |-- zinit-autoload.zsh/.zinit-list-bindkeys
- |-- zinit-autoload.zsh/.zinit-list-compdef-replay
- |-- zinit-autoload.zsh/.zinit-ls
- |-- zinit-autoload.zsh/.zinit-module
- |-- zinit-autoload.zsh/.zinit-recently
- |-- zinit-autoload.zsh/.zinit-search-completions
- |-- zinit-autoload.zsh/.zinit-self-update
- |-- zinit-autoload.zsh/.zinit-show-all-reports
- |-- zinit-autoload.zsh/.zinit-show-completions
- |-- zinit-autoload.zsh/.zinit-show-debug-report
- |-- zinit-autoload.zsh/.zinit-show-registered-plugins
- |-- zinit-autoload.zsh/.zinit-show-report
- |-- zinit-autoload.zsh/.zinit-show-times
- |-- zinit-autoload.zsh/.zinit-show-zstatus
- |-- zinit-autoload.zsh/.zinit-uncompile-plugin
- |-- zinit-autoload.zsh/.zinit-uninstall-completions
- |-- zinit-autoload.zsh/.zinit-unload
- |-- zinit-autoload.zsh/.zinit-update-or-status
- |-- zinit-autoload.zsh/.zinit-update-or-status-all
- |-- zinit-install.zsh/.zinit-compile-plugin
- |-- zinit-install.zsh/.zinit-compinit
- |-- zinit-install.zsh/.zinit-forget-completion
- `-- zinit-install.zsh/.zinit-install-completions
-
-Uses feature(s): _autoload_, _compinit_, _eval_, _setopt_, _source_
-
-Called by:
-
- zplugin
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 zpcdclear
 ~~~~~~~~~
 
-Has 1 line(s). Calls functions:
-
- zpcdclear
+Has 1 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 zpcdreplay
 ~~~~~~~~~~
 
-Has 1 line(s). Calls functions:
-
- zpcdreplay
+Has 1 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1451,12 +1056,7 @@ Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 zpcompinit
 ~~~~~~~~~~
 
-Has 1 line(s). Calls functions:
-
- zpcompinit
- `-- compinit
-
-Uses feature(s): _autoload_, _compinit_
+Has 1 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1468,43 +1068,7 @@ ____
  Compatibility functions. [[[
 ____
 
-Has 1 line(s). Calls functions:
-
- zplugin
- `-- zinit
-     |-- +zinit-message
-     |-- +zinit-prehelp-usage-message
-     |   `-- +zinit-message
-     |-- compinit
-     |-- zinit-autoload.zsh/.zinit-cdisable
-     |-- zinit-autoload.zsh/.zinit-cenable
-     |-- zinit-autoload.zsh/.zinit-clear-completions
-     |-- zinit-autoload.zsh/.zinit-compile-uncompile-all
-     |-- zinit-autoload.zsh/.zinit-compiled
-     |-- zinit-autoload.zsh/.zinit-help
-     |-- zinit-autoload.zsh/.zinit-list-bindkeys
-     |-- zinit-autoload.zsh/.zinit-list-compdef-replay
-     |-- zinit-autoload.zsh/.zinit-ls
-     |-- zinit-autoload.zsh/.zinit-module
-     |-- zinit-autoload.zsh/.zinit-recently
-     |-- zinit-autoload.zsh/.zinit-search-completions
-     |-- zinit-autoload.zsh/.zinit-self-update
-     |-- zinit-autoload.zsh/.zinit-show-all-reports
-     |-- zinit-autoload.zsh/.zinit-show-completions
-     |-- zinit-autoload.zsh/.zinit-show-debug-report
-     |-- zinit-autoload.zsh/.zinit-show-registered-plugins
-     |-- zinit-autoload.zsh/.zinit-show-report
-     |-- zinit-autoload.zsh/.zinit-show-times
-     |-- zinit-autoload.zsh/.zinit-show-zstatus
-     |-- zinit-autoload.zsh/.zinit-uncompile-plugin
-     |-- zinit-autoload.zsh/.zinit-uninstall-completions
-     |-- zinit-autoload.zsh/.zinit-unload
-     |-- zinit-autoload.zsh/.zinit-update-or-status
-     |-- zinit-autoload.zsh/.zinit-update-or-status-all
-     |-- zinit-install.zsh/.zinit-compile-plugin
-     |-- zinit-install.zsh/.zinit-compinit
-     |-- zinit-install.zsh/.zinit-forget-completion
-     `-- zinit-install.zsh/.zinit-install-completions
+Has 1 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1527,12 +1091,7 @@ ____
 
 Has 93 line(s). Doesn't call other functions.
 
-Uses feature(s): _autoload_, _getopts_
-
-Called by:
-
- @zinit-scheduler
- Script-Body
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 compinit
 ~~~~~~~~
@@ -1553,13 +1112,7 @@ ____
 
 Has 549 line(s). Doesn't call other functions.
 
-Uses feature(s): _autoload_, _bindkey_, _compdef_, _compdump_, _eval_, _read_, _setopt_, _unfunction_, _zle_, _zstyle_
-
-Called by:
-
- zicompinit
- zinit
- zpcompinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 is-at-least
 ~~~~~~~~~~~
@@ -1580,9 +1133,5 @@ ____
 
 Has 56 line(s). Doesn't call other functions.
 
-Called by:
-
- :zinit-tmp-subst-autoload
- :zinit-tmp-subst-bindkey
- Script-Body
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 

--- a/doc/zsdoc/zinit.zsh.adoc
+++ b/doc/zsdoc/zinit.zsh.adoc
@@ -13,20 +13,16 @@ Documentation automatically generated with `zshelldoc'
 FUNCTIONS
 ---------
 
- @autoload
- pmodload
- zicdclear
- zicdreplay
- zicompdef
- zicompinit
- zinit
+ +zinit-deploy-message
+ +zinit-message
+ +zinit-prehelp-usage-message
+ -zinit_scheduler_add_sh
  .zinit-add-fpath
  .zinit-add-report
  .zinit-any-to-pid
  .zinit-any-to-user-plugin
  .zinit-compdef-clear
  .zinit-compdef-replay
- +zinit-deploy-message
  .zinit-diff
  .zinit-diff-env
  .zinit-diff-functions
@@ -47,38 +43,42 @@ FUNCTIONS
  .zinit-load-plugin
  .zinit-load-snippet
  .zinit-main-message-formatter
- +zinit-message
  .zinit-pack-ice
  .zinit-parse-opts
- +zinit-prehelp-usage-message
  .zinit-prepare-home
- @zinit-register-annex
- @zinit-register-hook
  .zinit-register-plugin
- :zinit-reload-and-run
  .zinit-run
  .zinit-run-task
- -zinit_scheduler_add_sh
  .zinit-set-m-func
  .zinit-setup-params
  .zinit-submit-turbo
- @zinit-substitute
+ .zinit-tmp-subst-off
+ .zinit-tmp-subst-on
+ .zinit-util-shands-path
+ :zinit-reload-and-run
  :zinit-tmp-subst-alias
  :zinit-tmp-subst-autoload
  :zinit-tmp-subst-bindkey
  :zinit-tmp-subst-compdef
- .zinit-tmp-subst-off
- .zinit-tmp-subst-on
  :zinit-tmp-subst-zle
  :zinit-tmp-subst-zstyle
- .zinit-util-shands-path
+ @autoload
+ @zinit-register-annex
+ @zinit-register-hook
+ @zinit-substitute
+ @zsh-plugin-run-on-unload
+ @zsh-plugin-run-on-update
+ pmodload
+ zicdclear
+ zicdreplay
+ zicompdef
+ zicompinit
+ zinit
  zpcdclear
  zpcdreplay
  zpcompdef
  zpcompinit
  zplugin
- @zsh-plugin-run-on-unload
- @zsh-plugin-run-on-update
 AUTOLOAD add-zsh-hook
 AUTOLOAD compinit
 AUTOLOAD is-at-least
@@ -90,177 +90,125 @@ DETAILS
 Script Body
 ~~~~~~~~~~~
 
-Has 217 line(s). Calls functions:
+Has 225 line(s). Calls functions:
 
  Script-Body
+ |-- +zinit-message
+ |-- @zinit-register-hook
  |-- add-zsh-hook
  |-- is-at-least
- |-- zinit-autoload.zsh/.zinit-module
- |-- +zinit-message
- `-- @zinit-register-hook
+ `-- zinit-autoload.zsh/.zinit-module
 
 Uses feature(s): _add-zsh-hook_, _alias_, _autoload_, _export_, _is-at-least_, _setopt_, _source_, _zmodload_, _zstyle_
 
 _Exports (environment):_ PMSPEC [big]*//* ZPFX [big]*//* ZSH_CACHE_DIR
 
-@autoload
-~~~~~~~~~
++zinit-deploy-message
+~~~~~~~~~~~~~~~~~~~~~
 
 ____
  
  ]]]
- FUNCTION: @autoload. [[[
+ FUNCTION: +zinit-deploy-message. [[[
+ Deploys a sub-prompt message to be displayed OR a `zle
+ .reset-prompt' call to be invoked
 ____
 
-Has 3 line(s). Calls functions:
+Has 13 line(s). Doesn't call other functions.
 
- @autoload
- `-- :zinit-tmp-subst-autoload
-     |-- is-at-least
-     `-- +zinit-message
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
-
-pmodload
-~~~~~~~~
-
-____
- 
- FUNCTION: pmodload. [[[
- Compatibility with Prezto. Calls can be recursive.
-____
-
-Has 15 line(s). Calls functions:
-
- pmodload
-
-Uses feature(s): _zstyle_
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
-
-zicdclear
-~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: zicdclear. [[[
- A wrapper for `zinit cdclear -q' which can be called from hook
- ices like the atinit'', atload'', etc. ices.
-____
-
-Has 1 line(s). Calls functions:
-
- zicdclear
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
-
-zicdreplay
-~~~~~~~~~~
-
-____
- 
- FUNCTION: zicdreplay. [[[
- A function that can be invoked from within `atinit', `atload', etc.
- ice-mod.  It works like `zinit cdreplay', which cannot be invoked
- from such hook ices.
-____
-
-Has 1 line(s). Calls functions:
-
- zicdreplay
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
-
-zicompdef
-~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: zicompdef. [[[
- Stores compdef for a replay with `zicdreplay' (turbo mode) or
- with `zinit cdreplay' (normal mode). An utility functton of
- an undefined use case.
-____
-
-Has 1 line(s). Doesn't call other functions.
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
-
-zicompinit
-~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: zicompinit. [[[
- A function that can be invoked from within `atinit', `atload', etc.
- ice-mod.  It runs `autoload compinit; compinit' and respects
- ZINIT[ZCOMPDUMP_PATH] and ZINIT[COMPINIT_OPTS].
-____
-
-Has 1 line(s). Calls functions:
-
- zicompinit
- `-- compinit
-
-Uses feature(s): _autoload_, _compinit_
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
-
-zinit
-~~~~~
-
-____
- 
- FUNCTION: zinit. [[[
- Main function directly exposed to user, obtains subcommand and its
- arguments, has completion.
-____
-
-Has 560 line(s). Calls functions:
-
- zinit
- |-- compinit
- |-- zinit-autoload.zsh/.zinit-cdisable
- |-- zinit-autoload.zsh/.zinit-cenable
- |-- zinit-autoload.zsh/.zinit-clear-completions
- |-- zinit-autoload.zsh/.zinit-compiled
- |-- zinit-autoload.zsh/.zinit-compile-uncompile-all
- |-- zinit-autoload.zsh/.zinit-help
- |-- zinit-autoload.zsh/.zinit-list-bindkeys
- |-- zinit-autoload.zsh/.zinit-list-compdef-replay
- |-- zinit-autoload.zsh/.zinit-ls
- |-- zinit-autoload.zsh/.zinit-module
- |-- zinit-autoload.zsh/.zinit-recently
- |-- zinit-autoload.zsh/.zinit-search-completions
- |-- zinit-autoload.zsh/.zinit-self-update
- |-- zinit-autoload.zsh/.zinit-show-all-reports
- |-- zinit-autoload.zsh/.zinit-show-completions
- |-- zinit-autoload.zsh/.zinit-show-debug-report
- |-- zinit-autoload.zsh/.zinit-show-registered-plugins
- |-- zinit-autoload.zsh/.zinit-show-report
- |-- zinit-autoload.zsh/.zinit-show-times
- |-- zinit-autoload.zsh/.zinit-show-zstatus
- |-- zinit-autoload.zsh/.zinit-uncompile-plugin
- |-- zinit-autoload.zsh/.zinit-uninstall-completions
- |-- zinit-autoload.zsh/.zinit-unload
- |-- zinit-autoload.zsh/.zinit-update-or-status
- |-- zinit-autoload.zsh/.zinit-update-or-status-all
- |-- zinit-install.zsh/.zinit-compile-plugin
- |-- zinit-install.zsh/.zinit-compinit
- |-- zinit-install.zsh/.zinit-forget-completion
- |-- zinit-install.zsh/.zinit-install-completions
- |-- +zinit-message
- `-- +zinit-prehelp-usage-message
-     `-- +zinit-message
-
-Uses feature(s): _autoload_, _compinit_, _eval_, _setopt_, _source_
+Uses feature(s): _read_, _zle_
 
 Called by:
 
- zplugin
+ .zinit-load-snippet
+ .zinit-load
+ zinit-autoload.zsh/.zinit-recall
+
++zinit-message
+~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: +zinit-message. [[[
+____
+
+Has 14 line(s). Doesn't call other functions.
+
+Called by:
+
+ +zinit-prehelp-usage-message
+ .zinit-compdef-clear
+ .zinit-compdef-replay
+ .zinit-load-snippet
+ .zinit-register-plugin
+ .zinit-run
+ .zinit-set-m-func
+ :zinit-tmp-subst-autoload
+ Script-Body
+ zinit
+ zinit-autoload.zsh/.zinit-build-module
+ zinit-autoload.zsh/.zinit-cd
+ zinit-autoload.zsh/.zinit-self-update
+ zinit-autoload.zsh/.zinit-show-zstatus
+ zinit-autoload.zsh/.zinit-uninstall-completions
+ zinit-autoload.zsh/.zinit-update-all-parallel
+ zinit-autoload.zsh/.zinit-update-or-status-all
+ zinit-autoload.zsh/.zinit-update-or-status
+ zinit-autoload.zsh/.zinit-wait-for-update-jobs
+ zinit-install.zsh/.zinit-compile-plugin
+ zinit-install.zsh/.zinit-compinit
+ zinit-install.zsh/.zinit-download-file-stdout
+ zinit-install.zsh/.zinit-download-snippet
+ zinit-install.zsh/.zinit-extract
+ zinit-install.zsh/.zinit-get-cygwin-package
+ zinit-install.zsh/.zinit-get-latest-gh-r-url-part
+ zinit-install.zsh/.zinit-get-package
+ zinit-install.zsh/.zinit-install-completions
+ zinit-install.zsh/.zinit-jq-check
+ zinit-install.zsh/.zinit-setup-plugin-dir
+ zinit-install.zsh/.zinit-update-snippet
+ zinit-install.zsh/ziextract
+ zinit-install.zsh/∞zinit-mv-hook
+ zinit-install.zsh/∞zinit-ps-on-update-hook
+ zinit-install.zsh/∞zinit-reset-hook
+ zinit-side.zsh/.zinit-countdown
+ zinit-side.zsh/.zinit-exists-physically-message
+
++zinit-prehelp-usage-message
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: +zinit-prehelp-usage-message. [[[
+____
+
+Has 38 line(s). Calls functions:
+
+ +zinit-prehelp-usage-message
+ `-- +zinit-message
+
+Called by:
+
+ zinit
+ zinit-autoload.zsh/.zinit-delete
+
+-zinit_scheduler_add_sh
+~~~~~~~~~~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: -zinit_scheduler_add_sh. [[[
+ Copies task into ZINIT_RUN array, called when a task timeouts.
+ A small function ran from pattern in /-substitution as a math
+ function.
+____
+
+Has 7 line(s). Doesn't call other functions.
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-add-fpath
 ~~~~~~~~~~~~~~~~
@@ -351,8 +299,8 @@ Called by:
  :zinit-tmp-subst-autoload
  zinit-autoload.zsh/.zinit-any-to-uspl2
  zinit-autoload.zsh/.zinit-changes
- zinit-autoload.zsh/.zinit-compiled
  zinit-autoload.zsh/.zinit-compile-uncompile-all
+ zinit-autoload.zsh/.zinit-compiled
  zinit-autoload.zsh/.zinit-create
  zinit-autoload.zsh/.zinit-delete
  zinit-autoload.zsh/.zinit-find-completions-of-plugin
@@ -416,27 +364,6 @@ Called by:
  zicdreplay
  zinit
  zpcdreplay
-
-+zinit-deploy-message
-~~~~~~~~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: +zinit-deploy-message. [[[
- Deploys a sub-prompt message to be displayed OR a `zle
- .reset-prompt' call to be invoked
-____
-
-Has 13 line(s). Doesn't call other functions.
-
-Uses feature(s): _read_, _zle_
-
-Called by:
-
- .zinit-load-snippet
- .zinit-load
- zinit-autoload.zsh/.zinit-recall
 
 .zinit-diff
 ~~~~~~~~~~~
@@ -764,8 +691,8 @@ Has 127 line(s). Calls functions:
 
  .zinit-load-plugin
  `-- :zinit-tmp-subst-autoload
-     |-- is-at-least
-     `-- +zinit-message
+     |-- +zinit-message
+     `-- is-at-least
 
 Uses feature(s): _eval_, _setopt_, _source_, _unfunction_, _zle_
 
@@ -789,17 +716,17 @@ Has 203 line(s). Calls functions:
 
  .zinit-load-snippet
  |-- +zinit-deploy-message
- |-- zinit-install.zsh/.zinit-download-snippet
- `-- +zinit-message
+ |-- +zinit-message
+ `-- zinit-install.zsh/.zinit-download-snippet
 
 Uses feature(s): _autoload_, _eval_, _setopt_, _source_, _unfunction_, _zparseopts_, _zstyle_
 
 Called by:
 
- pmodload
  .zinit-load-object
  .zinit-load
  .zinit-run-task
+ pmodload
 
 .zinit-main-message-formatter
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -813,57 +740,6 @@ ____
 Has 18 line(s). Doesn't call other functions.
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
-
-+zinit-message
-~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: +zinit-message. [[[
-____
-
-Has 14 line(s). Doesn't call other functions.
-
-Called by:
-
- Script-Body
- .zinit-compdef-clear
- .zinit-compdef-replay
- .zinit-load-snippet
- +zinit-prehelp-usage-message
- .zinit-register-plugin
- .zinit-run
- .zinit-set-m-func
- :zinit-tmp-subst-autoload
- zinit
- zinit-autoload.zsh/.zinit-build-module
- zinit-autoload.zsh/.zinit-cd
- zinit-autoload.zsh/.zinit-self-update
- zinit-autoload.zsh/.zinit-show-zstatus
- zinit-autoload.zsh/.zinit-uninstall-completions
- zinit-autoload.zsh/.zinit-update-all-parallel
- zinit-autoload.zsh/.zinit-update-or-status-all
- zinit-autoload.zsh/.zinit-update-or-status
- zinit-autoload.zsh/.zinit-wait-for-update-jobs
- zinit-install.zsh/ziextract
- zinit-install.zsh/.zinit-compile-plugin
- zinit-install.zsh/.zinit-compinit
- zinit-install.zsh/.zinit-download-file-stdout
- zinit-install.zsh/.zinit-download-snippet
- zinit-install.zsh/.zinit-extract
- zinit-install.zsh/.zinit-get-cygwin-package
- zinit-install.zsh/.zinit-get-latest-gh-r-url-part
- zinit-install.zsh/.zinit-get-package
- zinit-install.zsh/.zinit-install-completions
- zinit-install.zsh/.zinit-jq-check
- zinit-install.zsh/∞zinit-mv-hook
- zinit-install.zsh/∞zinit-ps-on-update-hook
- zinit-install.zsh/∞zinit-reset-hook
- zinit-install.zsh/.zinit-setup-plugin-dir
- zinit-install.zsh/.zinit-update-snippet
- zinit-side.zsh/.zinit-countdown
- zinit-side.zsh/.zinit-exists-physically-message
 
 .zinit-pack-ice
 ~~~~~~~~~~~~~~~
@@ -905,25 +781,6 @@ Called by:
  zinit
  zinit-autoload.zsh/.zinit-delete
 
-+zinit-prehelp-usage-message
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: +zinit-prehelp-usage-message. [[[
-____
-
-Has 38 line(s). Calls functions:
-
- +zinit-prehelp-usage-message
- `-- +zinit-message
-
-Called by:
-
- zinit
- zinit-autoload.zsh/.zinit-delete
-
 .zinit-prepare-home
 ~~~~~~~~~~~~~~~~~~~
 
@@ -948,36 +805,6 @@ Called by:
 
 _Environment variables used:_ ZPFX
 
-@zinit-register-annex
-~~~~~~~~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: @zinit-register-annex. [[[
- Registers the z-annex inside Zinit – i.e. an Zinit extension
-____
-
-Has 8 line(s). Doesn't call other functions.
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
-
-@zinit-register-hook
-~~~~~~~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: @zinit-register-hook. [[[
- Registers the z-annex inside Zinit – i.e. an Zinit extension
-____
-
-Has 4 line(s). Doesn't call other functions.
-
-Called by:
-
- Script-Body
-
 .zinit-register-plugin
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -997,33 +824,6 @@ Has 23 line(s). Calls functions:
 Called by:
 
  .zinit-load
-
-:zinit-reload-and-run
-~~~~~~~~~~~~~~~~~~~~~
-
-____
- 
- FUNCTION: :zinit-reload-and-run. [[[
- Marks given function ($3) for autoloading, and executes it triggering the
- load. $1 is the fpath dedicated to the function, $2 are autoload options.
- This function replaces "autoload -X", because using that on older Zsh
- versions causes problems with traps.
- 
- So basically one creates function stub that calls :zinit-reload-and-run()
- instead of "autoload -X".
- 
- $1 - FPATH dedicated to function
- $2 - autoload options
- $3 - function name (one that needs autoloading)
- 
- Author: Bart Schaefer
-____
-
-Has 11 line(s). Doesn't call other functions.
-
-Uses feature(s): _autoload_, _unfunction_
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-run
 ~~~~~~~~~~
@@ -1076,55 +876,6 @@ Uses feature(s): _eval_, _source_, _zle_, _zpty_
 Called by:
 
  @zinit-scheduler
-
-@zinit-scheduler
-~~~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: @zinit-scheduler. [[[
- Searches for timeout tasks, executes them. There's an array of tasks
- waiting for execution, this scheduler manages them, detects which ones
- should be run at current moment, decides to remove (or not) them from
- the array after execution.
- 
- $1 - if "following", then it is non-first (second and more)
- invocation of the scheduler; this results in chain of `sched'
- invocations that results in repetitive @zinit-scheduler activity.
- 
- if "burst", then all tasks are marked timeout and executed one
- by one; this is handy if e.g. a docker image starts up and
- needs to install all turbo-mode plugins without any hesitation
- (delay), i.e. "burst" allows to run package installations from
- script, not from prompt.
- 
-____
-
-Has 75 line(s). *Is a precmd hook*. Calls functions:
-
- @zinit-scheduler
- `-- add-zsh-hook
-
-Uses feature(s): _add-zsh-hook_, _sched_, _setopt_, _zle_
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
-
--zinit_scheduler_add_sh
-~~~~~~~~~~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: -zinit_scheduler_add_sh. [[[
- Copies task into ZINIT_RUN array, called when a task timeouts.
- A small function ran from pattern in /-substitution as a math
- function.
-____
-
-Has 7 line(s). Doesn't call other functions.
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-set-m-func
 ~~~~~~~~~~~~~~~~~
@@ -1184,33 +935,89 @@ Called by:
 
  zinit
 
-@zinit-substitute
-~~~~~~~~~~~~~~~~~
+.zinit-tmp-subst-off
+~~~~~~~~~~~~~~~~~~~~
 
 ____
  
- ]]]
- FUNCTION: @zinit-substitute. [[[
+ FUNCTION: .zinit-tmp-subst-off. [[[
+ Turn off temporary substituting of functions completely for a given mode ("load", "light",
+ "light-b" (i.e. the `trackbinds' mode) or "compdef").
 ____
 
-Has 40 line(s). Doesn't call other functions.
+Has 21 line(s). Doesn't call other functions.
+
+Uses feature(s): _setopt_, _unfunction_
+
+Called by:
+
+ .zinit-load-plugin
+
+.zinit-tmp-subst-on
+~~~~~~~~~~~~~~~~~~~
+
+____
+ 
+ FUNCTION: .zinit-tmp-subst-on. [[[
+ Turn on temporary substituting of functions of builtins and functions according to passed
+ mode ("load", "light", "light-b" or "compdef"). The temporary substituting of functions is
+ to gather report data, and to hijack `autoload', `bindkey' and
+ `compdef' calls.
+____
+
+Has 32 line(s). Doesn't call other functions.
+
+Uses feature(s): _source_
+
+Called by:
+
+ .zinit-load-plugin
+
+.zinit-util-shands-path
+~~~~~~~~~~~~~~~~~~~~~~~
+
+____
+ 
+ FUNCTION: .zinit-util-shands-path. [[[
+ Replaces parts of path with %HOME, etc.
+____
+
+Has 9 line(s). Doesn't call other functions.
 
 Uses feature(s): _setopt_
 
 Called by:
 
- zinit-autoload.zsh/.zinit-at-eval
- zinit-install.zsh/∞zinit-atclone-hook
- zinit-install.zsh/.zinit-at-eval
- zinit-install.zsh/∞zinit-cp-hook
- zinit-install.zsh/∞zinit-extract-hook
- zinit-install.zsh/.zinit-get-package
- zinit-install.zsh/∞zinit-make-ee-hook
- zinit-install.zsh/∞zinit-make-e-hook
- zinit-install.zsh/∞zinit-make-hook
- zinit-install.zsh/∞zinit-mv-hook
+ .zinit-any-to-pid
 
 _Environment variables used:_ ZPFX
+
+:zinit-reload-and-run
+~~~~~~~~~~~~~~~~~~~~~
+
+____
+ 
+ FUNCTION: :zinit-reload-and-run. [[[
+ Marks given function ($3) for autoloading, and executes it triggering the
+ load. $1 is the fpath dedicated to the function, $2 are autoload options.
+ This function replaces "autoload -X", because using that on older Zsh
+ versions causes problems with traps.
+ 
+ So basically one creates function stub that calls :zinit-reload-and-run()
+ instead of "autoload -X".
+ 
+ $1 - FPATH dedicated to function
+ $2 - autoload options
+ $3 - function name (one that needs autoloading)
+ 
+ Author: Bart Schaefer
+____
+
+Has 11 line(s). Doesn't call other functions.
+
+Uses feature(s): _autoload_, _unfunction_
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 :zinit-tmp-subst-alias
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -1246,15 +1053,15 @@ ____
 Has 111 line(s). Calls functions:
 
  :zinit-tmp-subst-autoload
- |-- is-at-least
- `-- +zinit-message
+ |-- +zinit-message
+ `-- is-at-least
 
 Uses feature(s): _autoload_, _eval_, _is-at-least_, _setopt_, _zparseopts_
 
 Called by:
 
- @autoload
  .zinit-load-plugin
+ @autoload
 
 :zinit-tmp-subst-bindkey
 ~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1295,44 +1102,6 @@ Uses feature(s): _setopt_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
-.zinit-tmp-subst-off
-~~~~~~~~~~~~~~~~~~~~
-
-____
- 
- FUNCTION: .zinit-tmp-subst-off. [[[
- Turn off temporary substituting of functions completely for a given mode ("load", "light",
- "light-b" (i.e. the `trackbinds' mode) or "compdef").
-____
-
-Has 21 line(s). Doesn't call other functions.
-
-Uses feature(s): _setopt_, _unfunction_
-
-Called by:
-
- .zinit-load-plugin
-
-.zinit-tmp-subst-on
-~~~~~~~~~~~~~~~~~~~
-
-____
- 
- FUNCTION: .zinit-tmp-subst-on. [[[
- Turn on temporary substituting of functions of builtins and functions according to passed
- mode ("load", "light", "light-b" or "compdef"). The temporary substituting of functions is
- to gather report data, and to hijack `autoload', `bindkey' and
- `compdef' calls.
-____
-
-Has 32 line(s). Doesn't call other functions.
-
-Uses feature(s): _source_
-
-Called by:
-
- .zinit-load-plugin
-
 :zinit-tmp-subst-zle
 ~~~~~~~~~~~~~~~~~~~~
 
@@ -1371,24 +1140,288 @@ Uses feature(s): _setopt_, _zparseopts_, _zstyle_
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
-.zinit-util-shands-path
-~~~~~~~~~~~~~~~~~~~~~~~
+@autoload
+~~~~~~~~~
 
 ____
  
- FUNCTION: .zinit-util-shands-path. [[[
- Replaces parts of path with %HOME, etc.
+ ]]]
+ FUNCTION: @autoload. [[[
 ____
 
-Has 9 line(s). Doesn't call other functions.
+Has 3 line(s). Calls functions:
+
+ @autoload
+ `-- :zinit-tmp-subst-autoload
+     |-- +zinit-message
+     `-- is-at-least
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+@zinit-register-annex
+~~~~~~~~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: @zinit-register-annex. [[[
+ Registers the z-annex inside Zinit – i.e. an Zinit extension
+____
+
+Has 8 line(s). Doesn't call other functions.
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+@zinit-register-hook
+~~~~~~~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: @zinit-register-hook. [[[
+ Registers the z-annex inside Zinit – i.e. an Zinit extension
+____
+
+Has 4 line(s). Doesn't call other functions.
+
+Called by:
+
+ Script-Body
+
+@zinit-scheduler
+~~~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: @zinit-scheduler. [[[
+ Searches for timeout tasks, executes them. There's an array of tasks
+ waiting for execution, this scheduler manages them, detects which ones
+ should be run at current moment, decides to remove (or not) them from
+ the array after execution.
+ 
+ $1 - if "following", then it is non-first (second and more)
+ invocation of the scheduler; this results in chain of `sched'
+ invocations that results in repetitive @zinit-scheduler activity.
+ 
+ if "burst", then all tasks are marked timeout and executed one
+ by one; this is handy if e.g. a docker image starts up and
+ needs to install all turbo-mode plugins without any hesitation
+ (delay), i.e. "burst" allows to run package installations from
+ script, not from prompt.
+ 
+____
+
+Has 75 line(s). *Is a precmd hook*. Calls functions:
+
+ @zinit-scheduler
+ `-- add-zsh-hook
+
+Uses feature(s): _add-zsh-hook_, _sched_, _setopt_, _zle_
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+@zinit-substitute
+~~~~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: @zinit-substitute. [[[
+____
+
+Has 40 line(s). Doesn't call other functions.
 
 Uses feature(s): _setopt_
 
 Called by:
 
- .zinit-any-to-pid
+ zinit-autoload.zsh/.zinit-at-eval
+ zinit-install.zsh/.zinit-at-eval
+ zinit-install.zsh/.zinit-get-package
+ zinit-install.zsh/∞zinit-atclone-hook
+ zinit-install.zsh/∞zinit-cp-hook
+ zinit-install.zsh/∞zinit-extract-hook
+ zinit-install.zsh/∞zinit-make-e-hook
+ zinit-install.zsh/∞zinit-make-ee-hook
+ zinit-install.zsh/∞zinit-make-hook
+ zinit-install.zsh/∞zinit-mv-hook
 
 _Environment variables used:_ ZPFX
+
+@zsh-plugin-run-on-unload
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: @zsh-plugin-run-on-update. [[[
+ The Plugin Standard required mechanism, see:
+ https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
+____
+
+Has 2 line(s). Calls functions:
+
+ @zsh-plugin-run-on-unload
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+@zsh-plugin-run-on-update
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: @zsh-plugin-run-on-update. [[[
+ The Plugin Standard required mechanism
+____
+
+Has 2 line(s). Calls functions:
+
+ @zsh-plugin-run-on-update
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+pmodload
+~~~~~~~~
+
+____
+ 
+ FUNCTION: pmodload. [[[
+ Compatibility with Prezto. Calls can be recursive.
+____
+
+Has 15 line(s). Calls functions:
+
+ pmodload
+
+Uses feature(s): _zstyle_
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+zicdclear
+~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: zicdclear. [[[
+ A wrapper for `zinit cdclear -q' which can be called from hook
+ ices like the atinit'', atload'', etc. ices.
+____
+
+Has 1 line(s). Calls functions:
+
+ zicdclear
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+zicdreplay
+~~~~~~~~~~
+
+____
+ 
+ FUNCTION: zicdreplay. [[[
+ A function that can be invoked from within `atinit', `atload', etc.
+ ice-mod.  It works like `zinit cdreplay', which cannot be invoked
+ from such hook ices.
+____
+
+Has 1 line(s). Calls functions:
+
+ zicdreplay
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+zicompdef
+~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: zicompdef. [[[
+ Stores compdef for a replay with `zicdreplay' (turbo mode) or
+ with `zinit cdreplay' (normal mode). An utility functton of
+ an undefined use case.
+____
+
+Has 1 line(s). Doesn't call other functions.
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+zicompinit
+~~~~~~~~~~
+
+____
+ 
+ ]]]
+ FUNCTION: zicompinit. [[[
+ A function that can be invoked from within `atinit', `atload', etc.
+ ice-mod.  It runs `autoload compinit; compinit' and respects
+ ZINIT[ZCOMPDUMP_PATH] and ZINIT[COMPINIT_OPTS].
+____
+
+Has 1 line(s). Calls functions:
+
+ zicompinit
+ `-- compinit
+
+Uses feature(s): _autoload_, _compinit_
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
+zinit
+~~~~~
+
+____
+ 
+ FUNCTION: zinit. [[[
+ Main function directly exposed to user, obtains subcommand and its
+ arguments, has completion.
+____
+
+Has 560 line(s). Calls functions:
+
+ zinit
+ |-- +zinit-message
+ |-- +zinit-prehelp-usage-message
+ |   `-- +zinit-message
+ |-- compinit
+ |-- zinit-autoload.zsh/.zinit-cdisable
+ |-- zinit-autoload.zsh/.zinit-cenable
+ |-- zinit-autoload.zsh/.zinit-clear-completions
+ |-- zinit-autoload.zsh/.zinit-compile-uncompile-all
+ |-- zinit-autoload.zsh/.zinit-compiled
+ |-- zinit-autoload.zsh/.zinit-help
+ |-- zinit-autoload.zsh/.zinit-list-bindkeys
+ |-- zinit-autoload.zsh/.zinit-list-compdef-replay
+ |-- zinit-autoload.zsh/.zinit-ls
+ |-- zinit-autoload.zsh/.zinit-module
+ |-- zinit-autoload.zsh/.zinit-recently
+ |-- zinit-autoload.zsh/.zinit-search-completions
+ |-- zinit-autoload.zsh/.zinit-self-update
+ |-- zinit-autoload.zsh/.zinit-show-all-reports
+ |-- zinit-autoload.zsh/.zinit-show-completions
+ |-- zinit-autoload.zsh/.zinit-show-debug-report
+ |-- zinit-autoload.zsh/.zinit-show-registered-plugins
+ |-- zinit-autoload.zsh/.zinit-show-report
+ |-- zinit-autoload.zsh/.zinit-show-times
+ |-- zinit-autoload.zsh/.zinit-show-zstatus
+ |-- zinit-autoload.zsh/.zinit-uncompile-plugin
+ |-- zinit-autoload.zsh/.zinit-uninstall-completions
+ |-- zinit-autoload.zsh/.zinit-unload
+ |-- zinit-autoload.zsh/.zinit-update-or-status
+ |-- zinit-autoload.zsh/.zinit-update-or-status-all
+ |-- zinit-install.zsh/.zinit-compile-plugin
+ |-- zinit-install.zsh/.zinit-compinit
+ |-- zinit-install.zsh/.zinit-forget-completion
+ `-- zinit-install.zsh/.zinit-install-completions
+
+Uses feature(s): _autoload_, _compinit_, _eval_, _setopt_, _source_
+
+Called by:
+
+ zplugin
 
 zpcdclear
 ~~~~~~~~~
@@ -1439,12 +1472,15 @@ Has 1 line(s). Calls functions:
 
  zplugin
  `-- zinit
+     |-- +zinit-message
+     |-- +zinit-prehelp-usage-message
+     |   `-- +zinit-message
      |-- compinit
      |-- zinit-autoload.zsh/.zinit-cdisable
      |-- zinit-autoload.zsh/.zinit-cenable
      |-- zinit-autoload.zsh/.zinit-clear-completions
-     |-- zinit-autoload.zsh/.zinit-compiled
      |-- zinit-autoload.zsh/.zinit-compile-uncompile-all
+     |-- zinit-autoload.zsh/.zinit-compiled
      |-- zinit-autoload.zsh/.zinit-help
      |-- zinit-autoload.zsh/.zinit-list-bindkeys
      |-- zinit-autoload.zsh/.zinit-list-compdef-replay
@@ -1468,43 +1504,7 @@ Has 1 line(s). Calls functions:
      |-- zinit-install.zsh/.zinit-compile-plugin
      |-- zinit-install.zsh/.zinit-compinit
      |-- zinit-install.zsh/.zinit-forget-completion
-     |-- zinit-install.zsh/.zinit-install-completions
-     |-- +zinit-message
-     `-- +zinit-prehelp-usage-message
-         `-- +zinit-message
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
-
-@zsh-plugin-run-on-unload
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: @zsh-plugin-run-on-update. [[[
- The Plugin Standard required mechanism, see:
- https://zdharma-continuum.github.io/Zsh-100-Commits-Club/Zsh-Plugin-Standard.html
-____
-
-Has 2 line(s). Calls functions:
-
- @zsh-plugin-run-on-unload
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
-
-@zsh-plugin-run-on-update
-~~~~~~~~~~~~~~~~~~~~~~~~~
-
-____
- 
- ]]]
- FUNCTION: @zsh-plugin-run-on-update. [[[
- The Plugin Standard required mechanism
-____
-
-Has 2 line(s). Calls functions:
-
- @zsh-plugin-run-on-update
+     `-- zinit-install.zsh/.zinit-install-completions
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1531,8 +1531,8 @@ Uses feature(s): _autoload_, _getopts_
 
 Called by:
 
- Script-Body
  @zinit-scheduler
+ Script-Body
 
 compinit
 ~~~~~~~~
@@ -1582,7 +1582,7 @@ Has 56 line(s). Doesn't call other functions.
 
 Called by:
 
- Script-Body
  :zinit-tmp-subst-autoload
  :zinit-tmp-subst-bindkey
+ Script-Body
 

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -3244,7 +3244,8 @@ EOF
         setopt localoptions extendedglob nokshglob noksharrays
         builtin cd -q "${ZINIT[SNIPPETS_DIR]}"
         local -a list
-        list=( "${(f@)"$(LANG=en_US.utf-8 tree -L 3 --charset utf-8)"}" )
+        local -x LANG=en_US.utf-8
+        list=( "${(f@)"$(${=ZINIT[LIST_COMMAND]})"}" )
         # Oh-My-Zsh single file
         list=( "${list[@]//(#b)(https--github.com--(ohmyzsh|robbyrussel)l--oh-my-zsh--raw--master(--)(#c0,1)(*))/$ZINIT[col-info]Oh-My-Zsh$ZINIT[col-error]${match[2]/--//}$ZINIT[col-pname]${match[3]//--/$ZINIT[col-error]/$ZINIT[col-pname]} $ZINIT[col-info](single-file)$ZINIT[col-rst] ${match[1]}}" )
         # Oh-My-Zsh SVN

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -57,6 +57,14 @@ if [[ -z ${ZINIT[HOME_DIR]} ]]; then
     fi
 fi
 
+if [[ -z ${ZINIT[LIST_COMMAND]} ]]; then
+    if (( ${+commands[exa]} )); then
+        ZINIT[LIST_COMMAND]='exa --color=always --tree --icons -L3'
+    else
+        ZINIT[LIST_COMMAND]='tree -L 3 -C --charset utf-8'
+    fi
+fi
+
 ZINIT[ice-list]="svn|proto|from|teleid|bindmap|cloneopts|id-as|depth|if|wait|load|\
 unload|blockf|pick|bpick|src|as|ver|silent|lucid|notify|mv|cp|\
 atinit|atclone|atload|atpull|nocd|run-atpull|has|cloneonly|make|\


### PR DESCRIPTION
Enable users to specify the zinit ls command via ZINIT[LIST_COMMAND] and
provide default commands for exa and tree. Prefer exa if it is installed.

Addresses issue #170 