### PR TITLE
*autoload: Make retval a local variable

### DIFF
--- a/doc/zsdoc/zinit-autoload.zsh.adoc
+++ b/doc/zsdoc/zinit-autoload.zsh.adoc
@@ -1451,7 +1451,7 @@ ____
  User-action entry point.
 ____
 
-Has 131 line(s). Calls functions:
+Has 133 line(s). Calls functions:
 
  .zinit-update-or-status-all
  |-- zinit-install.zsh/.zinit-compinit

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -1865,11 +1865,13 @@ ZINIT[EXTENDED_GLOB]=""
         return $?
     }
 
+    integer retval
+
     if (( OPTS[opt_-p,--parallel] )) && [[ $1 = update ]] {
         (( !OPTS[opt_-q,--quiet] )) && \
             +zinit-message '{info2}Parallel Update Starts Now{…}{rst}'
         .zinit-update-all-parallel
-        integer retval=$?
+        retval=$?
         .zinit-compinit 1 1 &>/dev/null
         rehash
         if (( !OPTS[opt_-q,--quiet] )) {


### PR DESCRIPTION
8355489 Added added a retval variable which is a global variable when a non-parallelized `zinit update` was run. This simply localizes it for parallel and non-parallel runs.