### PR TITLE
Enable developers to build docs in docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ zmodules/Src/zdharma/curses_keys.h
 zmodules/Test/*.tmp
 /.project
 doc/zsdoc/data
+doc/docker/image-id

--- a/Makefile
+++ b/Makefile
@@ -30,9 +30,21 @@ doc: zinit.zsh zinit-side.zsh zinit-install.zsh zinit-autoload.zsh
 	# cd is required since zsd outputs to PWD/zsdoc/
 	cd doc; zsd -v --scomm --cignore '(\#*FUNCTION:*{{{*|\#[[:space:]]#}}}*)' ../zinit.zsh ../zinit-side.zsh ../zinit-install.zsh ../zinit-autoload.zsh
 
+IMAGE_ID_PATH := $(PWD)/doc/docker/image-id
+
+doc-docker-image:
+	cd doc/docker && docker build --rm --iidfile ${IMAGE_ID_PATH}  .
+
+doc-in-docker:
+	docker image inspect \
+		$$([[ -f ${IMAGE_ID_PATH} ]] && cat ${IMAGE_ID_PATH}) \
+		>/dev/null 2>&1 || \
+		$(MAKE) doc-docker-image
+	cat ${IMAGE_ID_PATH} | xargs docker run --rm -v $(PWD):/zinit.git
+
 clean:
 	rm -f zinit.zsh.zwc zinit-side.zsh.zwc zinit-install.zsh.zwc zinit-autoload.zsh.zwc
 	rm -rf doc/zsdoc/data
 
-.PHONY: all test clean doc
+.PHONY: all test clean doc doc-in-docker doc-docker-image
 # vim:noet:sts=8:ts=8

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -19,6 +19,17 @@ doctoc --github README.md
 make doc
 ```
 
+## Update asciidoc and/or zshelldoc in Docker container
+
+Due to some challenges with generating the same docs from the same inputs on different platforms, the docs can be built in a docker container.
+
+1. Make sure you have Docker installed
+2. From the root of the repo run:
+
+```zsh
+make doc-in-docker
+```
+
 ## Generate the manpage (doc/zinit.1)
 
 1. Install [pandoc](https://pandoc.org/)

--- a/doc/docker/Dockerfile
+++ b/doc/docker/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:latest
+
+RUN apt-get update && \
+    apt-get install -y \
+    git \
+    locales \
+    make \
+    tree \
+    zsh \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN sed -i '/en_US.UTF-8/s/^# //g' /etc/locale.gen && \
+    locale-gen
+
+RUN git clone https://github.com/zdharma-continuum/zshelldoc.git /tmp/zsd.git && \
+        cd /tmp/zsd.git && make install
+
+VOLUME /zinit.git
+WORKDIR /zinit.git
+ENTRYPOINT ["/bin/bash"]
+CMD [ "-c", "make doc"]


### PR DESCRIPTION
After my struggles to generate the docs such that they pass the documentation check, I used docker to execute ``make doc``.

I also added ``doc-in-docker`` as a target in the Makefile which will build the docker image and generate the docs in the current git clone.