### PR TITLE
maint: check for `jq` command in `.zinit-get-package`

### DIFF
--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -284,7 +284,7 @@ ____
  FUNCTION: .zinit-get-package [[[
 ____
 
-Has 194 line(s). Calls functions:
+Has 196 line(s). Calls functions:
 
  .zinit-get-package
  |-- ziextract

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -64,6 +64,8 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 
 # FUNCTION: .zinit-get-package [[[
 .zinit-get-package() {
+    zinit-jq-check || return 1
+
     emulate -LR zsh
     setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes
 


### PR DESCRIPTION
Error loudly instead of silently exiting when erroring due to `jq`
absent.

Closes #135 

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>