### PR TITLE
Fix zinit-jq-check command in zinit-get-package

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -64,7 +64,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 
 # FUNCTION: .zinit-get-package [[[
 .zinit-get-package() {
-    zinit-jq-check || return 1
+    .zinit-jq-check || return 1
 
     emulate -LR zsh
     setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes


### PR DESCRIPTION
This is failing for lack of a `.`.