### PR TITLE
fix: update docs for new jq-check

### DIFF
--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -367,6 +367,7 @@ Has 8 line(s). Calls functions:
 
 Called by:
 
+ .zinit-get-package
  .zinit-json-get-value
  .zinit-json-to-array
 


### PR DESCRIPTION
- regenerate docs for `zinit-install`

Missed in the [initial PR](https://github.com/zdharma-continuum/zinit/pull/202) due to a bug and overlooked in [bugfix PR](https://github.com/zdharma-continuum/zinit/pull/203)

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>