### PR TITLE
docs: update install command to bash to avoid error

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ it to get the most out of Zinit.
 
 The easiest way to install Zinit is to execute:
 
-```zsh
-sh -c "$(curl -fsSL https://git.io/zinit-install)"
+```bash
+bash -c "$(curl -fsSL https://git.io/zinit-install)"
 ```
 
 This will install Zinit in `~/.local/share/zinit/zinit.git`. `.zshrc` will be updated with three lines of code that will
@@ -146,7 +146,7 @@ zinit self-update
 
 To manually install Zinit, clone the repo to, e.g. `~/.local/share/zinit/zinit.git`:
 
-```sh
+```zsh
 ZINIT_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}/zinit/zinit.git"
 mkdir -p "$(dirname $ZINIT_HOME)"
 git clone https://github.com/zdharma-continuum/zinit.git "$ZINIT_HOME"
@@ -155,7 +155,7 @@ git clone https://github.com/zdharma-continuum/zinit.git "$ZINIT_HOME"
 and source `zinit.zsh` from your `.zshrc` (above
 [compinit](http://zsh.sourceforge.net/Doc/Release/Completion-System.html#Initialization)):
 
-```sh
+```zsh
 ZINIT_HOME="${XDG_DATA_HOME:-${HOME}/.local/share}/zinit/zinit.git"
 source "${ZINIT_HOME}/zinit.zsh"
 ```
@@ -446,7 +446,7 @@ zinit snippet OMZP::fd/_fd
 
 **Basic**
 
-```shell
+```zsh
 zinit snippet <URL>        # Raw Syntax with URL
 zinit snippet PZT::<PATH>  # Shorthand PZT/ (https://github.com/sorin-ionescu/prezto/tree/master/)
 zinit snippet PZTM::<PATH> # Shorthand PZT/modules/
@@ -498,7 +498,7 @@ zinit snippet PZTM::archive
 Use `zinit ice atclone"git clone <repo> <location>"` if module have external module. Like
 [completion](https://github.com/sorin-ionescu/prezto/tree/master/modules/completion):
 
-```shell
+```zsh
 zplugin ice svn blockf \ # use blockf to prevent any unnecessary additions to fpath, as zinit manages fpath
             atclone"git clone --recursive https://github.com/zsh-users/zsh-completions.git external"
 zplugin snippet PZTM::completion


### PR DESCRIPTION
## Description

Update the `README.md` install command to use Bash due to sh lacking support for `${VAR//foo/bar}` brace substation and breaking the Zinit installer.

## Motivation and Context

See #217 

## Usage examples

N/A

## How Has This Been Tested?

See #217 

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
