### PR TITLE
maint: update Makefile targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,22 +1,22 @@
 .EXPORT_ALL_VARIABLES:
-# SHELL=zsh
+
+ZSH := $(shell command -v zsh 2> /dev/null)
 SRC := zinit.zsh zinit-side.zsh zinit-install.zsh zinit-autoload.zsh
 DOC_SRC := $(foreach wrd,$(SRC),../$(wrd))
 
-cur-dir := $(shell pwd)
+zwc:
+	$(or $(ZSH),:) -fc 'for f in *.zsh; do zcompile -R -- $$f.zwc $$f || exit; done'
 
-all: $(wildcard *.zsh)
-
-%.zsh: %.zwc
-	scripts/zcompile $(@)
-
-doc-container: zinit.zsh zinit-side.zsh zinit-install.zsh zinit-autoload.zsh
+doc-container:
 	./scripts/docker-run.sh --docs --debug
 
 doc: clean
 	cd doc; zsh -d -f -i -c "zsd -v --scomm --cignore '(\#*FUNCTION:*{{{*|\#[[:space:]]#}}}*)' $(DOC_SRC)"
 
+test:
+	zunit run
+
 clean:
-	rm -rf doc/zsdoc/data doc/zsdoc/*.adoc
+	rm -rvf *.zwc doc/zsdoc/zinit{'','-autoload','-install','-side'}.zsh.adoc doc/zsdoc/data/
 
 .PHONY: all test clean doc doc-container

--- a/scripts/zcompile
+++ b/scripts/zcompile
@@ -1,3 +1,0 @@
-#!/usr/bin/env zsh
-
-zcompile "$@"


### PR DESCRIPTION
## Description

- add `zwc` target to compile zinit source to `.zwc`
- add zsh path variable
- add 'test' target to easily run zunit tests
- clean target cleans `.zwc` and more explicit for `.adoc`
- remove `zcompile` script

## Motivation and Context

General repository cleanup

## Usage examples

Run zunit via:

```zsh
make test
```

Compile *.zsh files

```zsh
make zwc
```

## How Has This Been Tested?

Manually

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>