### PR TITLE
fix: allow zinit to be run from non-interactive scripts

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -72,6 +72,9 @@ jobs:
       - name: "gh-r"
         run: zunit run tests/gh-r.zunit
 
+      - name: "ices"
+        run: zunit run tests/ices.zunit
+
       - name: "plugins"
         run: zunit run tests/plugins.zunit
 

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ txt/
 zmodules/
 tests/_output/
 tests/_support/zunit/
+.idea

--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -703,7 +703,7 @@ ____
  FUNCTION: ∞zinit-cp-hook [[[
 ____
 
-Has 27 line(s). Calls functions:
+Has 30 line(s). Calls functions:
 
  ∞zinit-cp-hook
  `-- zinit.zsh/@zinit-substitute

--- a/doc/zsdoc/zinit.zsh.adoc
+++ b/doc/zsdoc/zinit.zsh.adoc
@@ -1203,7 +1203,9 @@ ____
  Registers the z-annex inside Zinit – i.e. an Zinit extension
 ____
 
-Has 4 line(s). Doesn't call other functions.
+Has 6 line(s). Doesn't call other functions.
+
+Uses feature(s): _setopt_
 
 Called by:
 

--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -145,7 +145,7 @@
   $dive --version; assert $state equals 0
 }
 @test 'docker-buildx' { # A monitor of resources
-  run zinit for as'completions' atclone'buildx* completion zsh > _buildx' lbin'!buildx-* -> buildx' @docker/buildx
+  run zinit for as'completions' atclone'./buildx* completion zsh > _buildx' lbin'!buildx-* -> buildx' @docker/buildx
   assert $state equals 0
   local buildx="$ZBIN/buildx"; assert "$buildx" is_executable
   $buildx version; assert $state equals 0

--- a/tests/ices.zunit
+++ b/tests/ices.zunit
@@ -1,0 +1,52 @@
+#!/usr/bin/env zunit
+
+@setup {
+  ZPLUGINS=$ZINIT[PLUGINS_DIR]
+
+  function _zunit_assert_not_exists() {
+    local pathname=$1 filepath
+
+    # If filepath is relative, prepend the test directory
+    if [[ "${pathname:0:1}" != "/" ]]; then
+      filepath="$testdir/${pathname}"
+    else
+      filepath="$pathname"
+    fi
+
+    [[ ! -e "$filepath" ]] && return 0
+
+    echo "'$pathname' does exist"
+    exit 1
+  }
+
+}
+
+@test 'mv' {
+  run zinit as"null" id-as"test/mv" mv"readme.md -> mv.md" for zdharma-continuum/null
+  assert $state equals 0
+  assert "$ZPLUGINS/test---mv/mv.md" is_file
+  assert "$ZPLUGINS/test---mv/mv.md" is_file
+  assert "$ZPLUGINS/test---mv/readme.md" not_exists
+}
+
+@test 'cp' {
+  run zinit as"null" id-as"test/cp" cp"readme.md -> cp.md" for zdharma-continuum/null
+  assert $state equals 0
+  assert "$ZPLUGINS/test---cp/cp.md" is_file
+  assert "$ZPLUGINS/test---cp/cp.md" is_readable
+  assert "$ZPLUGINS/test---cp/readme.md" is_file
+}
+
+@test 'atclone' {
+  run zinit as"null" id-as"test/atclone" atclone"mv readme.md atclone.md" for zdharma-continuum/null
+  assert $state equals 0
+  assert "$ZPLUGINS/test---atclone/atclone.md" is_file
+  assert "$ZPLUGINS/test---atclone/atclone.md" is_readable
+  assert "$ZPLUGINS/test---atclone/readme.md" not_exists
+}
+
+@test 'make' {
+  run zinit as"null" id-as"test/make" atclone"printf 'all:\n\ttouch whatever\n' > Makefile" make"" for zdharma-continuum/null
+  assert $state equals 0
+  assert "$ZPLUGINS/test---make/whatever" is_file
+}

--- a/tests/snippets.zunit
+++ b/tests/snippets.zunit
@@ -52,9 +52,12 @@
 }
 @test 'tldr-completion::gh-r' {
   artifact="$ZINIT[PLUGINS_DIR]/tldr-completion---gh-r"
-  run zinit for as"completion" from"gh-r" id-as'tldr-completion/gh-r' bpick"completions_zsh" @dbrgn/tealdeer
+  run zinit for as"completion" from"gh-r" id-as'tldr-completion/gh-r' bpick"completions_zsh" mv"completions_zsh -> _tldr_ghr" pick"_tldr_ghr" @dbrgn/tealdeer
   assert $state equals 0
-  assert "$artifact/completions_zsh" is_file; assert $artifact is_readable
+  assert "$artifact/_tldr_ghr" is_file
+  assert $artifact/_tldr_ghr is_readable
+  assert "$ZINIT[COMPLETIONS_DIR]"/_tldr_ghr is_file
+  assert "$ZINIT[COMPLETIONS_DIR]"/_tldr_ghr is_readable
 }
 @test 'zinit local snippet symlink' {
   mkdir -p "${ZINIT[HOME_DIR]}/external"

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -1567,9 +1567,9 @@ ZINIT[EXTENDED_GLOB]=""
                 # Run annexes' atpull hooks (the before atpull-ice ones).
                 # The gh-r / GitHub releases block.
                 reply=(
-                    ${(on)ZINIT_EXTS2[(I)zinit hook:e-\\\!atpull-pre <->]}
-                    ${${(M)ICE[atpull]#\!}:+${(on)ZINIT_EXTS[(I)z-annex hook:\\\!atpull-<-> <->]}}
-                    ${(on)ZINIT_EXTS2[(I)zinit hook:e-\\\!atpull-post <->]}
+                    ${(on)ZINIT_EXTS2[(I)zinit hook:e-\!atpull-pre <->]}
+                    ${${(M)ICE[atpull]#\!}:+${(on)ZINIT_EXTS[(I)z-annex hook:\!atpull-<-> <->]}}
+                    ${(on)ZINIT_EXTS2[(I)zinit hook:e-\!atpull-post <->]}
                 )
                 for key in "${reply[@]}"; do
                     arr=( "${(Q)${(z@)ZINIT_EXTS[$key]:-$ZINIT_EXTS2[$key]}[@]}" )
@@ -1656,9 +1656,9 @@ ZINIT[EXTENDED_GLOB]=""
                   # Run annexes' atpull hooks (the before atpull-ice ones).
                   # The regular Git-plugins block.
                   reply=(
-                      ${(on)ZINIT_EXTS2[(I)zinit hook:e-\\\!atpull-pre <->]}
-                      ${${(M)ICE[atpull]#\!}:+${(on)ZINIT_EXTS[(I)z-annex hook:\\\!atpull-<-> <->]}}
-                      ${(on)ZINIT_EXTS2[(I)zinit hook:e-\\\!atpull-post <->]}
+                      ${(on)ZINIT_EXTS2[(I)zinit hook:e-\!atpull-pre <->]}
+                      ${${(M)ICE[atpull]#\!}:+${(on)ZINIT_EXTS[(I)z-annex hook:\!atpull-<-> <->]}}
+                      ${(on)ZINIT_EXTS2[(I)zinit hook:e-\!atpull-post <->]}
                   )
                   for key in "${reply[@]}"; do
                       arr=( "${(Q)${(z@)ZINIT_EXTS[$key]:-$ZINIT_EXTS2[$key]}[@]}" )
@@ -1703,9 +1703,9 @@ ZINIT[EXTENDED_GLOB]=""
             # Run annexes' atpull hooks (the before atpull[^!]…-ice ones).
             # Block common for Git and gh-r plugins.
             reply=(
-                ${(on)ZINIT_EXTS2[(I)zinit hook:no-e-\\\!atpull-pre <->]}
-                ${${ICE[atpull]:#\!*}:+${(on)ZINIT_EXTS[(I)z-annex hook:\\\!atpull-<-> <->]}}
-                ${(on)ZINIT_EXTS2[(I)zinit hook:no-e-\\\!atpull-post <->]}
+                ${(on)ZINIT_EXTS2[(I)zinit hook:no-e-\!atpull-pre <->]}
+                ${${ICE[atpull]:#\!*}:+${(on)ZINIT_EXTS[(I)z-annex hook:\!atpull-<-> <->]}}
+                ${(on)ZINIT_EXTS2[(I)zinit hook:no-e-\!atpull-post <->]}
             )
             for key in "${reply[@]}"; do
                 arr=( "${(Q)${(z@)ZINIT_EXTS[$key]:-$ZINIT_EXTS2[$key]}[@]}" )

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -2360,18 +2360,23 @@ zimv() {
 
     @zinit-substitute from to
 
-    local -a afr
+    local -a afr retval
     ( () { setopt localoptions noautopushd; builtin cd -q "$dir"; } || return 1
       afr=( ${~from}(DN) )
       if (( ${#afr} )) {
           if (( !OPTS[opt_-q,--quiet] )) {
               command cp -vf "${afr[1]}" "$to"
+              retval=$?
+              # ignore errors if no compiled file is found
               command cp -vf "${afr[1]}".zwc "$to".zwc 2>/dev/null
           } else {
               command cp -f "${afr[1]}" "$to"
+              retval=$?
+              # ignore errors if no compiled file is found
               command cp -f "${afr[1]}".zwc "$to".zwc 2>/dev/null
           }
       }
+      return $retval
     )
 }
 # ]]]

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -451,9 +451,9 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
             # Store ices at clone of a plugin
             .zinit-store-ices "$local_path/._zinit" ICE "" "" "" ""
             reply=(
-                ${(on)ZINIT_EXTS2[(I)zinit hook:\\\!atclone-pre <->]}
-                ${(on)ZINIT_EXTS[(I)z-annex hook:\\\!atclone-<-> <->]}
-                ${(on)ZINIT_EXTS2[(I)zinit hook:\\\!atclone-post <->]}
+                ${(on)ZINIT_EXTS2[(I)zinit hook:\!atclone-pre <->]}
+                ${(on)ZINIT_EXTS[(I)z-annex hook:\!atclone-<-> <->]}
+                ${(on)ZINIT_EXTS2[(I)zinit hook:\!atclone-post <->]}
             )
             for key in "${reply[@]}"; do
                 arr=( "${(Q)${(z@)ZINIT_EXTS[$key]:-$ZINIT_EXTS2[$key]}[@]}" )
@@ -999,9 +999,9 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                         # Run annexes' atpull hooks (the before atpull-ice ones).
                         # The SVN block.
                         reply=(
-                            ${(on)ZINIT_EXTS2[(I)zinit hook:e-\\\!atpull-pre <->]}
-                            ${${(M)ICE[atpull]#\!}:+${(on)ZINIT_EXTS[(I)z-annex hook:\\\!atpull-<-> <->]}}
-                            ${(on)ZINIT_EXTS2[(I)zinit hook:e-\\\!atpull-post <->]}
+                            ${(on)ZINIT_EXTS2[(I)zinit hook:e-\!atpull-pre <->]}
+                            ${${(M)ICE[atpull]#\!}:+${(on)ZINIT_EXTS[(I)z-annex hook:\!atpull-<-> <->]}}
+                            ${(on)ZINIT_EXTS2[(I)zinit hook:e-\!atpull-post <->]}
                         )
                         for key in "${reply[@]}"; do
                             arr=( "${(Q)${(z@)ZINIT_EXTS[$key]:-$ZINIT_EXTS2[$key]}[@]}" )
@@ -1093,9 +1093,9 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                     # The URL-snippet block.
                     if [[ $update = -u && $ZINIT[annex-multi-flag:pull-active] -ge 1 ]] {
                         reply=(
-                            ${(on)ZINIT_EXTS2[(I)zinit hook:e-\\\!atpull-pre <->]}
-                            ${${ICE[atpull]#\!}:+${(on)ZINIT_EXTS[(I)z-annex hook:\\\!atpull-<-> <->]}}
-                            ${(on)ZINIT_EXTS2[(I)zinit hook:e-\\\!atpull-post <->]}
+                            ${(on)ZINIT_EXTS2[(I)zinit hook:e-\!atpull-pre <->]}
+                            ${${ICE[atpull]#\!}:+${(on)ZINIT_EXTS[(I)z-annex hook:\!atpull-<-> <->]}}
+                            ${(on)ZINIT_EXTS2[(I)zinit hook:e-\!atpull-post <->]}
                         )
                         for key in "${reply[@]}"; do
                             arr=( "${(Q)${(z@)ZINIT_EXTS[$key]:-$ZINIT_EXTS2[$key]}[@]}" )
@@ -1153,9 +1153,9 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
             # The local-file snippets block.
             if [[ $update = -u ]] {
                 reply=(
-                    ${(on)ZINIT_EXTS2[(I)zinit hook:e-\\\!atpull-pre <->]}
-                    ${${(M)ICE[atpull]#\!}:+${(on)ZINIT_EXTS[(I)z-annex hook:\\\!atpull-<-> <->]}}
-                    ${(on)ZINIT_EXTS2[(I)zinit hook:e-\\\!atpull-post <->]}
+                    ${(on)ZINIT_EXTS2[(I)zinit hook:e-\!atpull-pre <->]}
+                    ${${(M)ICE[atpull]#\!}:+${(on)ZINIT_EXTS[(I)z-annex hook:\!atpull-<-> <->]}}
+                    ${(on)ZINIT_EXTS2[(I)zinit hook:e-\!atpull-post <->]}
                 )
                 for key in "${reply[@]}"; do
                     arr=( "${(Q)${(z@)ZINIT_EXTS[$key]:-$ZINIT_EXTS2[$key]}[@]}" )
@@ -1248,9 +1248,9 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
             # Run annexes' atpull hooks (the before atpull-ice ones).
             # The block is common to all 3 snippet types.
             reply=(
-                ${(on)ZINIT_EXTS2[(I)zinit hook:no-e-\\\!atpull-pre <->]}
-                ${${ICE[atpull]:#\!*}:+${(on)ZINIT_EXTS[(I)z-annex hook:\\\!atpull-<-> <->]}}
-                ${(on)ZINIT_EXTS2[(I)zinit hook:no-e-\\\!atpull-post <->]}
+                ${(on)ZINIT_EXTS2[(I)zinit hook:no-e-\!atpull-pre <->]}
+                ${${ICE[atpull]:#\!*}:+${(on)ZINIT_EXTS[(I)z-annex hook:\!atpull-<-> <->]}}
+                ${(on)ZINIT_EXTS2[(I)zinit hook:no-e-\!atpull-post <->]}
             )
             for key in "${reply[@]}"; do
                 arr=( "${(Q)${(z@)ZINIT_EXTS[$key]:-$ZINIT_EXTS2[$key]}[@]}" )
@@ -1265,9 +1265,9 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
             # Run annexes' atclone hooks (the before atclone-ice ones)
             # The block is common to all 3 snippet types.
             reply=(
-                ${(on)ZINIT_EXTS2[(I)zinit hook:\\\!atclone-pre <->]}
-                ${(on)ZINIT_EXTS[(I)z-annex hook:\\\!atclone-<-> <->]}
-                ${(on)ZINIT_EXTS2[(I)zinit hook:\\\!atclone-post <->]}
+                ${(on)ZINIT_EXTS2[(I)zinit hook:\!atclone-pre <->]}
+                ${(on)ZINIT_EXTS[(I)z-annex hook:\!atclone-<-> <->]}
+                ${(on)ZINIT_EXTS2[(I)zinit hook:\!atclone-post <->]}
             )
             for key in "${reply[@]}"; do
                 arr=( "${(Q)${(z@)ZINIT_EXTS[$key]:-$ZINIT_EXTS2[$key]}[@]}" )

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -1184,6 +1184,12 @@ builtin setopt noaliases
 # FUNCTION: @zinit-register-hook. [[[
 # Registers the z-annex inside Zinit – i.e. an Zinit extension
 @zinit-register-hook() {
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
+    # zsh per default behaves differently in interactive sessions (escapes !) and
+    # non-interactive ones (does not). Setting 'nobanghist' option disables backslash
+    # escaping for "!" even in interactive sessions.
+    # Exclamation marks are used in a lot of hock names.
+    builtin setopt extendedglob nobanghist noshortloops typesetsilent warncreateglobal
     local name="$1" type="$2" handler="$3" icemods="$4" key="zinit ${(q)2}"
     ZINIT_EXTS2[seqno]=$(( ${ZINIT_EXTS2[seqno]:-0} + 1 ))
     ZINIT_EXTS2[$key${${(M)type#hook:}:+ ${ZINIT_EXTS2[seqno]}}]="${ZINIT_EXTS2[seqno]} z-annex-data: ${(q)name} ${(q)type} ${(q)handler} '' ${(q)icemods}"
@@ -1391,7 +1397,7 @@ builtin setopt noaliases
 
     ZINIT[CUR_USPL2]="$id_as" ZINIT_REPORTS[$id_as]=
 
-    reply=( ${(on)ZINIT_EXTS[(I)z-annex hook:\\\!atinit-<-> <->]} )
+    reply=( ${(on)ZINIT_EXTS[(I)z-annex hook:\!atinit-<-> <->]} )
     for key in "${reply[@]}"; do
         arr=( "${(Q)${(z@)ZINIT_EXTS[$key]}[@]}" )
         "${arr[5]}" snippet "$save_url" "$id_as" "$local_dir/$dirname" \!atinit || \
@@ -1453,7 +1459,7 @@ builtin setopt noaliases
         [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { setopt localoptions noautopushd; builtin cd -q "$local_dir/$dirname"; }; eval "reply=(${ICE[multisrc]})"; () { setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; local fname; for fname in "${reply[@]}"; do ZERO="${${(M)fname:#/*}:-$local_dir/$dirname/$fname}"; (( ${+ICE[silent]} )) && { { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( retval += $? )); ((1)); } || { ((1)); { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; }; (( retval += $? )); }; done; }
 
         # Run the atload hooks right before atload ice.
-        reply=( ${(on)ZINIT_EXTS[(I)z-annex hook:\\\!atload-<-> <->]} )
+        reply=( ${(on)ZINIT_EXTS[(I)z-annex hook:\!atload-<-> <->]} )
         for key in "${reply[@]}"; do
             arr=( "${(Q)${(z@)ZINIT_EXTS[$key]}[@]}" )
             "${arr[5]}" snippet "$save_url" "$id_as" "$local_dir/$dirname" \!atload
@@ -1507,7 +1513,7 @@ builtin setopt noaliases
         [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { setopt localoptions noautopushd; builtin cd -q "$local_dir/$dirname"; }; eval "reply=(${ICE[multisrc]})"; () { setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; local fname; for fname in "${reply[@]}"; do ZERO="${${(M)fname:#/*}:-$local_dir/$dirname/$fname}"; (( ${+ICE[silent]} )) && { { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( retval += $? )); ((1)); } || { ((1)); { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; }; (( retval += $? )); }; done; }
 
         # Run the atload hooks right before atload ice.
-        reply=( ${(on)ZINIT_EXTS[(I)z-annex hook:\\\!atload-<-> <->]} )
+        reply=( ${(on)ZINIT_EXTS[(I)z-annex hook:\!atload-<-> <->]} )
         for key in "${reply[@]}"; do
             arr=( "${(Q)${(z@)ZINIT_EXTS[$key]}[@]}" )
             "${arr[5]}" snippet "$save_url" "$id_as" "$local_dir/$dirname" \!atload
@@ -1624,7 +1630,7 @@ builtin setopt noaliases
         .zinit-setup-params && local ${(Q)reply[@]}
     }
 
-    reply=( ${(on)ZINIT_EXTS[(I)z-annex hook:\\\!atinit-<-> <->]} )
+    reply=( ${(on)ZINIT_EXTS[(I)z-annex hook:\!atinit-<-> <->]} )
     for ___key in "${reply[@]}"; do
         ___arr=( "${(Q)${(z@)ZINIT_EXTS[$___key]}[@]}" )
         "${___arr[5]}" plugin "$___user" "$___plugin" "$___id_as" "${${${(M)___user:#%}:+$___plugin}:-${ZINIT[PLUGINS_DIR]}/${___id_as//\//---}}" \!atinit || \
@@ -1725,7 +1731,7 @@ builtin setopt noaliases
         [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { setopt localoptions noautopushd; builtin cd -q "$___pdir_orig"; }; eval "reply=(${ICE[multisrc]})"; () { setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; local ___fname; for ___fname in "${reply[@]}"; do ZERO="${${(M)___fname:#/*}:-$___pdir_orig/$___fname}"; (( ${+ICE[silent]} )) && { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( ___retval += $? )); ((1)); } || { ((1)); { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; }; (( ___retval += $? )); }; done; }
 
         # Run the atload hooks right before atload ice.
-        reply=( ${(on)ZINIT_EXTS[(I)z-annex hook:\\\!atload-<-> <->]} )
+        reply=( ${(on)ZINIT_EXTS[(I)z-annex hook:\!atload-<-> <->]} )
         for ___key in "${reply[@]}"; do
             ___arr=( "${(Q)${(z@)ZINIT_EXTS[$___key]}[@]}" )
             "${___arr[5]}" plugin "$___user" "$___plugin" "$___id_as" "$___pdir_orig" \!atload
@@ -1776,7 +1782,7 @@ builtin setopt noaliases
         [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { setopt localoptions noautopushd; builtin cd -q "$___pdir_orig"; }; eval "reply=(${ICE[multisrc]})"; () { setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; for ___fname in "${reply[@]}"; do ZERO="${${(M)___fname:#/*}:-$___pdir_orig/$___fname}"; (( ${+ICE[silent]} )) && { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( ___retval += $? )); ((1)); } || { { [[ -n $___precm ]] && { builtin ${___precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); $___builtin source "$ZERO"; }; }; (( ___retval += $? )); } done; }
 
         # Run the atload hooks right before atload ice.
-        reply=( ${(on)ZINIT_EXTS[(I)z-annex hook:\\\!atload-<-> <->]} )
+        reply=( ${(on)ZINIT_EXTS[(I)z-annex hook:\!atload-<-> <->]} )
         for ___key in "${reply[@]}"; do
             ___arr=( "${(Q)${(z@)ZINIT_EXTS[$___key]}[@]}" )
             "${___arr[5]}" plugin "$___user" "$___plugin" "$___id_as" "$___pdir_orig" \!atload


### PR DESCRIPTION
Exclamation marks (per default) get escaped in interactive mode, but not in non-interactive modes. In this case it meant that zinit would not find any hooks which implements the ices when running in non-interactive mode (e.g. in a script). This in turn would NOT result in errors but would just silently not execute any of the ices which of course would be a bad thing(tm).

This actually happened in the zunit tests as they run non-interactively and therefore any ices based on exclamation mark hooks were not ran. I fixed the few places where (after the fix in this PR) the ice were actually ran and errored due to mis-specifications. I also added explicit checks for a few ices. -> before this PR, ices are basically not tested (and the exclamation mark hook based ones not testable at all!) :-(

## Description

This a) disables history mark expansion during hook register and changes any search pattern to not include the (double) escaped exclamation mark 

## Motivation and Context

It broke using zinit calls with ices in scripts (e.g. from a $HOME bootstrap script or an update script) 

https://github.com/zdharma-continuum/zinit/issues/199 has the details...

Closes: #199

## How Has This Been Tested?

See the new zunit tests and a few fixes in old tests which were needed because the actual ices were not run beforehand and therefore didn't error when they were not specified correctly.

Running the same ice (mv in this case)  interactively and in a script. Both calls contain the `direnv.darwin-amd64 -> direnv` log line.

```zsh

[16:30:23] λ  zinit delete direnv/direnv -y ; zsh -i -c -f --no-rcs 'source ~/.zinit/bin/zinit.zsh ; source ~/.zinit/bin/zinit-install.zsh; zinit from"gh-r" mv"direnv* -> direnv" for direnv/direnv'
bin-gem-node annex: The direnv shim didn't exist in $ZPFX/bin (or isn't a regular file)

Done (action executed, exit code: 0)

Downloading direnv/direnv…
(Requesting `direnv.darwin-amd64'…)
#################################################################################################################################################################################################################### 100.0%
ziextract: Successfully extracted and assigned +x chmod to the file: `direnv.darwin-amd64'.
direnv.darwin-amd64 -> direnv
No files for compilation found.
Warning: ∞zinit-compile-plugin-hook hook returned with 1


[16:30:29] [1] ✗  ls -la ~/.zinit/plugins/direnv---direnv/direnv*
-rwxr-xr-x  1 jankatins  staff  8811104 Apr 25 16:30 /Users/jankatins/.zinit/plugins/direnv---direnv/direnv


[16:30:37] λ  zinit delete direnv/direnv -y ; source ~/.zinit/bin/zinit.zsh ; source ~/.zinit/bin/zinit-install.zsh; zinit from"gh-r" mv"direnv* -> direnv" for direnv/direnv
bin-gem-node annex: The direnv shim didn't exist in $ZPFX/bin (or isn't a regular file)

Done (action executed, exit code: 0)

Downloading direnv/direnv…
(Requesting `direnv.darwin-amd64'…)
#################################################################################################################################################################################################################### 100.0%
ziextract: Successfully extracted and assigned +x chmod to the file: `direnv.darwin-amd64'.
direnv.darwin-amd64 -> direnv
No files for compilation found.
Warning: ∞zinit-compile-plugin-hook hook returned with 1

[16:31:02] [1] ✗  ls -la ~/.zinit/plugins/direnv---direnv/direnv*
-rwxr-xr-x  1 jankatins  staff  8811104 Apr 25 16:31 /Users/jankatins/.zinit/plugins/direnv---direnv/direnv
```

## Types of changes


- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
