### PR TITLE
docs: remove `git.io` URL use from install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ it to get the most out of Zinit.
 The easiest way to install Zinit is to execute:
 
 ```bash
-bash -c "$(curl -fsSL https://git.io/zinit-install)"
+bash -c "$(curl --fail --show-error --silent --location https://raw.githubusercontent.com/zdharma-continuum/zinit/HEAD/scripts/install.sh)"
 ```
 
 This will install Zinit in `~/.local/share/zinit/zinit.git`. `.zshrc` will be updated with three lines of code that will


### PR DESCRIPTION
## Description

Per the [GitHub announcement](https://github.blog/changelog/2022-04-25-git-io-deprecation/):

> We will be removing all existing link redirection from git.io on April 29, 2022.

Closes #229

## Motivation and Context

Avoid out-of-date documentation

## Usage examples

N/A

## How Has This Been Tested?

Manually

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.


Signed-off-by: Vladislav Doster <mvdoster@gmail.com>