### PR TITLE
fix: trigger for PR labeler GH action workflow

### DIFF
--- a/.github/workflows/labeler.yaml
+++ b/.github/workflows/labeler.yaml
@@ -4,9 +4,7 @@
 name: Labeler
 
 on:
-  pull_request:
-    branches:
-      - main
+  pull_request_target: # https://securitylab.github.com/research/github-actions-preventing-pwn-requests
 
 jobs:
   label-pull-requests:


### PR DESCRIPTION
## Description

Update trigger for PR labeler GH action workflow.

[Relevant documentation](https://securitylab.github.com/research/github-actions-preventing-pwn-requests)

## Motivation and Context

Make all PR checks pass for external contributions

## Usage examples

N/A

## How Has This Been Tested?

N/A

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


Signed-off-by: Vladislav Doster <mvdoster@gmail.com>