### PR TITLE
fix: Don't error if $OPTS is not yet defined in .zinit-compinit call

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -601,7 +601,8 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 #
 # No arguments.
 .zinit-compinit() {
-    [[ -n ${OPTS[opt_-p,--parallel]} && $1 != 1 ]] && return
+    # This might be called during sourcing when setting up the plugins dir, so check that OPTS is actually existing
+    [[ -n $OPTS && -n ${OPTS[opt_-p,--parallel]} && $1 != 1 ]] && return
 
     emulate -LR zsh
     builtin setopt nullglob extendedglob warncreateglobal typesetsilent


### PR DESCRIPTION
This codepath was triggered when deleting the whole `~/.ziniti/plugins` dir: during recreation in `.zinit-prepare-home`, `.zinit-compinit &> /dev/null` would be called and the sourcing of `zinit.zsh` would error out with

```
+.zinit-compinit:2> [[.zinit-compinit:2: bad math expression: operand expected at `/Users/jan...'
 -n '' ]]
```

As the error was redirected to `/dev/null`, this never showed up. Any zinit install call during that session would not run any hooks as they were not yet registered. The next session would then be fine because the plugins dir would exist. 

## Motivation and Context

See https://github.com/zdharma-continuum/zinit/issues/129#issuecomment-1092111737 -> basically deleting the `~/.zinit/plugins` dir should result in complete recreation on the next run, but due to this bug, it had bad side effects.

Closes: #129 (probably, not tested on initial run, only after deleting the plugins dir)

## How Has This Been Tested?

Manually deleting the whole folder and starting the whole zinit setup from scratch

```zsh
rm -rf ~/.zinit/plugins/ && exec zsh
```

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
