### PR TITLE
maint: improve scope of docs workflow triggers

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -4,17 +4,17 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'zinit*.zsh'
   push:
     branches:
       - main
   workflow_dispatch:
 
 jobs:
-
   zshelldoc:
     runs-on: ubuntu-latest
     steps:
-
       - name: check out repository
         uses: actions/checkout@v3
 


### PR DESCRIPTION
## Description

Only run documentation (e.g., `zshelldocs`) if changes are made to relevant files.

## Motivation and Context

No need to run on every push if no documentation changes are possible.

## Usage examples

N/A

## How Has This Been Tested?

N/A

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
