### PR TITLE
fix: zinit update bug (#257)

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1190,7 +1190,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     "${${(M)OPTS[opt_-q,--quiet]:#1}:+, skip the -q/--quiet option for more information}.{rst}"; retval=4; }
                 }
             } else {
-                if (( $+commands[realpath] )) && {
+                if (( $+commands[realpath] )) {
                     local rpv="$(realpath --version | head -n1 | sed -E 's/realpath (\(.*\))?//g')"
                     if is-at-least 8.23 $rpv; then
                         rel_url="$(realpath --relative-to="$local_dir/$dirname" "$url")" && \


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description

zinit update for every plugin not work.
Occuring error is below
```
.zinit/bin/zinit-install.zsh:1217: parse error near `}'
.zinit-update-or-status:331: command not found: ∞zinit-ps-on-update-hook
...
```

I fixed invalid format `if ((...)) && {` to `if ((...)) {`

## Motivation and Context

Bug fix

### Relations 
PR: https://github.com/zdharma-continuum/zinit/pull/234
issue: #257

## How Has This Been Tested?

It seems to work on my local.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
