### PR TITLE
fix: remove extraneous whitespace and  '\' breaking `zinit-install.zsh`

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1491,8 +1491,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 
     local -a list init_list
 
-    init_list=( ${(@f)"$( { .zinit-download-file-stdout $url || .zinit-download-file-stdout $url 1; } 2>/dev/null | \
-                      command grep -o 'href=./'$user'/'$plugin'/releases/download/[^"]\+')"} )
+    init_list=( ${(@f)"$( { .zinit-download-file-stdout $url || .zinit-download-file-stdout $url 1; } 2>/dev/null | command grep -o 'href=./'$user'/'$plugin'/releases/download/[^"]\+')"} )
     init_list=( ${init_list[@]#href=?} )
 
     local -a filtered bpicks
@@ -1788,8 +1787,7 @@ ziextract() {
                 for prog ( hdiutil cp ) { →zinit-check $prog "$file" || return 1; }
 
                 integer retval
-                local attached_vol="$( command hdiutil attach "$file" | \
-                           command tail -n1 | command cut -f 3 )"
+                local attached_vol="$( command hdiutil attach "$file" | command tail -n1 | command cut -f 3 )"
 
                 command cp -Rf ${attached_vol:-${TMPDIR:-/tmp}/acb321GEF}/*(D) .
                 retval=$?


### PR DESCRIPTION
## Description

Removed spaces and the '\' character on both lines 1494 and 1790 of zinit-install.zsh which seemed to be causing the error `Unmatched " on line 1397 (unsure why it specified that, there was no unmatched " on that line).

## Motivation and Context

It gets rid of an error that happens on default zinit installations, should make it more approachable to newcomers.

It does sacrifice readability for lack of errors, and I don't fully know why the `\` for ignoring whitespace caused said error.

## How Has This Been Tested?

I just reloaded zsh, and the error was gone.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
