### PR TITLE
fix: docs workflow should fail if out-of-date

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -10,7 +10,6 @@ on:
   workflow_dispatch:
 
 jobs:
-
   zshelldoc:
     runs-on: ubuntu-latest
     steps:
@@ -26,5 +25,6 @@ jobs:
       - name: check for out-of-date documentation
         run: |
           if ! git --no-pager diff --exit-code; then
-            echo "::set-output zshelldocs are out-of-date, run 'make doc'"
+            echo "::error:: Z-shelldocs are out-of-date. To regenerate, run 'make doc'"
+            exit 1
           fi

--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -261,7 +261,7 @@ ____
  package. Connects to Github releases page.
 ____
 
-Has 130 line(s). Calls functions:
+Has 115 line(s). Calls functions:
 
  .zinit-get-latest-gh-r-url-part
  `-- zinit.zsh/+zinit-message


### PR DESCRIPTION

## Description

fix a bug that allowed z-shell docs workflow to pass even though it reported it was out of date.

## Motivation and Context

Code changes were not reflected in technical documentation

## Usage examples

N/A

## How Has This Been Tested?

Manually

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>