### PR TITLE
maint: remove the "pokeget" gh-r test due to project being deleted or made private

### DIFF
--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -529,11 +529,6 @@ $kopia --version; assert $state equals 0
   local pmy="$ZBIN/pmy"; assert "$pmy" is_executable
   $pmy --version; assert $state equals 0
 }
-@test 'pokeget' { # a bash script you can use to display cool sprites of pokemon in your terminal
-  run zinit bpick'*.tar.gz' lbin'!* -> pokeget' for @talwat/pokeget; assert $state equals 0
-  local pokeget="$ZBIN/pokeget"; assert "$pokeget" is_executable
-  $pokeget pikachu; assert $state equals 0
-}
 @test 'procs' { # A modern replacement for ps written in Rust
   run zinit for @dalance/procs; assert $state equals 0
   local procs="$ZBIN/procs"; assert "$procs" is_executable


### PR DESCRIPTION
## Description

Remove `pokeget` gh-r zunit test due to repository being deleted or made private.

## Motivation and Context

Allow z-unit tests to run full test-suite.

## Usage examples

N/A

## How Has This Been Tested?

N/A

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

Signed-off-by: Vladislav Doster <vladislav.doster@Mastercard.com>