### PR TITLE
feat: debug formatting to `.zinit-message`

### DIFF
--- a/zinit.zsh
+++ b/zinit.zsh
@@ -1913,6 +1913,14 @@ builtin setopt noaliases
     builtin zle -F "$THEFD" +zinit-deploy-message
 } # ]]]
 
+# FUNCTION: .zinit-formatter-dbg. [[[
+.zinit-formatter-dbg() {
+    builtin emulate -L zsh -o extendedglob
+    REPLY=
+    if (( ZINIT[DEBUG] )); then
+        REPLY=$1
+    fi
+} # ]]]
 # FUNCTION: .zinit-formatter-pid. [[[
 .zinit-formatter-pid() {
     builtin emulate -L zsh -o extendedglob
@@ -2039,6 +2047,7 @@ $(.zinit-main-message-formatter "$match[6]" "$match[7]" "$match[8]"; \
  )${${ZINIT[__last-formatter-code]::=${${${match[7]:#(…|ndsh|mdsh|mmdsh|-…|lr)}:+\
 $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
 
+    [[ -z $msg ]] && return
 
     # Reset color attributes at the end of the message
     msg=$msg$ZINIT[col-rst]


### PR DESCRIPTION
## Description

As described in #283

## Motivation and Context

Closes #283

## Usage examples

```zsh
+zinit-message "Installed plugin {pid}$1{dbg} id-as is:$id_as"
```

```zsh
+zinit-message "Ran compdef replay{dbg} [count of defs: $count]"
```

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

- [X] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
