### PR TITLE
Propagate -o xtrace when needed and prepend builtin to emulate

### DIFF
--- a/zinit-additional.zsh
+++ b/zinit-additional.zsh
@@ -19,7 +19,7 @@
     local ___data="$(<$1)"
 
     () {
-        builtin emulate -LR zsh -o extendedglob -o interactivecomments
+        builtin emulate -LR zsh -o extendedglob -o interactivecomments ${=${options[xtrace]:#off}:+-o xtrace}
         local ___subst ___tabspc=$'\t'
         for ___subst ( "${___substs[@]}" ) {
             ___ab=( "${(@)${(@)${(@s:->:)___subst}##[[:space:]]##}%%[[:space:]]##}" )
@@ -39,7 +39,7 @@
 # $2 - mode - for plugin (light or load)
 # $3 - id - URL or plugin ID or alias name (from id-as'')
 .zinit-service() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob warncreateglobal typesetsilent noshortloops
 
     local ___tpe="$1" ___mode="$2" ___id="$3" ___fle="${ZINIT[SERVICES_DIR]}/${ICE[service]}.lock" ___fd ___cmd ___tmp ___lckd ___strd=0

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -622,7 +622,7 @@ ZINIT[EXTENDED_GLOB]=""
 # $1 - plugin spec (4 formats: user---plugin, user/plugin, user, plugin)
 # $2 - plugin (only when $1 - i.e. user - given)
 .zinit-uninstall-completions() {
-    builtin emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     builtin setopt nullglob extendedglob warncreateglobal typesetsilent noshortloops
 
     typeset -a completions symlinked backup_comps
@@ -708,7 +708,7 @@ ZINIT[EXTENDED_GLOB]=""
 #
 # User-action entry point.
 .zinit-self-update() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob typesetsilent warncreateglobal
 
     [[ $1 = -q ]] && +zinit-message -n "{pre}[self-update]{msg2} Updating Zinit repository{msg2}" \
@@ -766,7 +766,7 @@ ZINIT[EXTENDED_GLOB]=""
 #
 # User-action entry point.
 .zinit-show-registered-plugins() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob warncreateglobal typesetsilent noshortloops
 
     typeset -a filtered
@@ -882,7 +882,7 @@ ZINIT[EXTENDED_GLOB]=""
         if [[ "$sw_arr4" = "-M" && "$sw_arr6" != "-R" ]]; then
             if [[ -n "$sw_arr3" ]]; then
                 () {
-                    emulate -LR zsh -o extendedglob
+                    builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
                     (( quiet )) || builtin print -r "Restoring bindkey ${${(q)sw_arr1}//(#m)\\[\^\?\]\[\)\(\'\"\}\{\`]/${MATCH#\\}} $sw_arr3 ${ZINIT[col-info]}in map ${ZINIT[col-rst]}$sw_arr5"
                 }
                 bindkey -M "$sw_arr5" "$sw_arr1" "$sw_arr3"
@@ -915,7 +915,7 @@ ZINIT[EXTENDED_GLOB]=""
         else
             if [[ -n "$sw_arr3" ]]; then
                 () {
-                    emulate -LR zsh -o extendedglob
+                    builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
                     (( quiet )) || builtin print -r "Restoring bindkey ${${(q)sw_arr1}//(#m)\\[\^\?\]\[\)\(\'\"\}\{\`]/${MATCH#\\}} $sw_arr3"
                 }
                 bindkey "$sw_arr1" "$sw_arr3"
@@ -1422,7 +1422,7 @@ ZINIT[EXTENDED_GLOB]=""
 # $3 - plugin (only when $1 - i.e. user - given)
 .zinit-update-or-status() {
     # Set the localtraps option.
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob nullglob warncreateglobal typesetsilent noshortloops
 
     local -a arr
@@ -1831,7 +1831,7 @@ ZINIT[EXTENDED_GLOB]=""
 #
 # User-action entry point.
 .zinit-update-or-status-all() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob nullglob warncreateglobal typesetsilent noshortloops
 
     local -F2 SECONDS=0
@@ -1975,7 +1975,7 @@ ZINIT[EXTENDED_GLOB]=""
 } # ]]]
 # FUNCTION: .zinit-update-in-parallel [[[
 .zinit-update-all-parallel() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob warncreateglobal typesetsilent \
         noshortloops nomonitor nonotify
 
@@ -2173,7 +2173,7 @@ ZINIT[EXTENDED_GLOB]=""
 #
 # User-action entry point.
 .zinit-show-times() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt  extendedglob warncreateglobal noshortloops
 
     local opt="$1 $2 $3" entry entry2 entry3 user plugin
@@ -2706,7 +2706,7 @@ ZINIT[EXTENDED_GLOB]=""
 # $1 - plugin spec (4 formats: user---plugin, user/plugin, user, plugin)
 # $2 - plugin (only when $1 - i.e. user - given)
 .zinit-cd() {
-    builtin emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     builtin setopt extendedglob warncreateglobal typesetsilent rcquotes
 
     .zinit-get-path "$1" "$2" && {
@@ -2753,7 +2753,7 @@ ZINIT[EXTENDED_GLOB]=""
 # $1 - snippet URL or plugin spec (4 formats: user---plugin, user/plugin, user, plugin)
 # $2 - plugin (only when $1 - i.e. user - given)
 .zinit-delete() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob warncreateglobal typesetsilent
 
     local -a opts match mbegin mend
@@ -2933,7 +2933,7 @@ builtin print -Pr \"\$ZINIT[col-obj]Done (with the exit code: \$_retval).%f%b\""
 #
 # $1 - time spec, e.g. "1 week"
 .zinit-recently() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     builtin setopt nullglob extendedglob warncreateglobal \
                 typesetsilent noshortloops
 
@@ -2970,7 +2970,7 @@ builtin print -Pr \"\$ZINIT[col-obj]Done (with the exit code: \$_retval).%f%b\""
 # $1 - (optional) plugin spec (4 formats: user---plugin, user/plugin, user, plugin)
 # $2 - (optional) plugin (only when $1 - i.e. user - given)
 .zinit-create() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt localoptions extendedglob warncreateglobal typesetsilent \
         noshortloops rcquotes
 
@@ -3210,7 +3210,7 @@ EOF
     )
 
     (
-        emulate -LR ksh
+        builtin emulate -LR ksh ${=${options[xtrace]:#off}:+-o xtrace}
         builtin unsetopt shglob kshglob
         for i in "${ZINIT_STRESS_TEST_OPTIONS[@]}"; do
             builtin setopt "$i"
@@ -3276,7 +3276,7 @@ EOF
 # ("%" "/home/..." and also "%SNIPPETS/..." etc.), or a plugin
 # nickname (i.e. id-as'' ice-mod), or a snippet nickname.
 .zinit-get-path() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob warncreateglobal typesetsilent noshortloops
 
     [[ $1 == % ]] && local id_as=%$2 || local id_as=$1${1:+/}$2
@@ -3288,7 +3288,7 @@ EOF
 # ]]]
 # FUNCTION: .zinit-recall [[[
 .zinit-recall() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob warncreateglobal typesetsilent noshortloops
 
     local -A ice

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -37,7 +37,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 # $2: jq path
 # $3: name of the associative array to store the key/value pairs in
 .zinit-json-to-array() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt localoptions noglob
 
     .zinit-jq-check || return 1
@@ -60,7 +60,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 .zinit-get-package() {
     .zinit-jq-check || return 1
 
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes
 
     local user=$1 pkg=$2 plugin=$2 id_as=$3 dir=$4 profile=$5 \
@@ -291,7 +291,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 # $1 - user
 # $2 - plugin
 .zinit-setup-plugin-dir() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob warncreateglobal noshortloops rcquotes
 
     local user=$1 plugin=$2 id_as=$3 remote_url_path=${1:+$1/}$2 \
@@ -523,7 +523,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 # $2 - plugin (only when $1 - i.e. user - given)
 # $3 - if 1, then reinstall, otherwise only install completions that aren't there
 .zinit-install-completions() {
-    builtin emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt nullglob extendedglob warncreateglobal typesetsilent noshortloops
 
     local id_as=$1${2:+${${${(M)1:#%}:+$2}:-/$2}}
@@ -605,7 +605,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     # This might be called during sourcing when setting up the plugins dir, so check that OPTS is actually existing
     [[ -n $OPTS && -n ${OPTS[opt_-p,--parallel]} && $1 != 1 ]] && return
 
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     builtin setopt nullglob extendedglob warncreateglobal typesetsilent
 
     integer use_C=$2
@@ -643,7 +643,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 .zinit-download-file-stdout() {
     local url="$1" restart="$2" progress="${(M)3:#1}"
 
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt localtraps extendedglob
 
     # Return file directly for file:// urls, wget doesn't support this schema
@@ -784,7 +784,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 #
 # $1 - completion function name, e.g. "_cp"; can also be "cp"
 .zinit-forget-completion() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob typesetsilent warncreateglobal
 
     local f="$1" quiet="$2"
@@ -812,7 +812,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 # $1 - plugin spec (4 formats: user---plugin, user/plugin, user, plugin)
 # $2 - plugin (only when $1 - i.e. user - given)
 .zinit-compile-plugin() {
-    builtin emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     builtin setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes
 
     local id_as=$1${2:+${${${(M)1:#%}:+$2}:-/$2}} first plugin_dir filename is_snippet
@@ -856,7 +856,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
         +zinit-message -n "{note}Note:{rst} Compiling{ehi}:{rst} {b}{file}$fname{rst}{…}"
         if [[ -z ${ICE[(i)(\!|)(sh|bash|ksh|csh)]} ]] {
             () {
-                builtin emulate -LR zsh -o extendedglob
+                builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
                 if { ! zcompile -U "$first" } {
                     +zinit-message "{msg2}Warning:{rst} Compilation failed. Don't worry, the plugin will work also without compilation."
                     +zinit-message "{msg2}Warning:{rst} Consider submitting an error report to Zinit or to the plugin's author."
@@ -883,7 +883,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
             integer retval
             for first in $list; do
                 () {
-                    builtin emulate -LR zsh -o extendedglob
+                    builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
                     zcompile -U "$first"; retval+=$?
                 }
             done
@@ -907,7 +907,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 # supports Subversion protocol and allows to clone subdirectories.
 # This is used to provide a layer of support for Oh-My-Zsh and Prezto.
 .zinit-download-snippet() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob warncreateglobal typesetsilent
 
     local save_url=$1 url=$2 id_as=$3 local_dir=$4 dirname=$5 filename=$6 update=$7
@@ -1042,7 +1042,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                             ${+ICE[nocompile]} -eq 0
                         ]] {
                             () {
-                                builtin emulate -LR zsh -o extendedglob
+                                builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
                                 zcompile -U "${list[1]}" &>/dev/null || \
                                     +zinit-message "{u-warn}Warning{b-warn}:{rst} couldn't compile {apo}\`{file}${list[1]}{apo}\`{rst}."
                             }
@@ -1134,7 +1134,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                         $file_path != */dev/null && ${+ICE[nocompile]} -eq 0
                 ]] {
                     () {
-                        builtin emulate -LR zsh -o extendedglob
+                        builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
                         if ! zcompile -U "$file_path" 2>/dev/null; then
                             builtin print -r "Couldn't compile \`${file_path:t}', it MIGHT be wrongly downloaded"
                             builtin print -r "(snippet URL points to a directory instead of a file?"
@@ -1352,7 +1352,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 } # ]]]
 # FUNCTION: .zinit-update-snippet [[[
 .zinit-update-snippet() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes
 
     local -a tmp opts
@@ -1447,7 +1447,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 # Gets version string of latest release of given Github
 # package. Connects to Github releases page.
 .zinit-get-latest-gh-r-url-part() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob warncreateglobal typesetsilent noshortloops
 
     REPLY=
@@ -1593,7 +1593,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 # $1 - url
 # $2 - file
 ziextract() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob typesetsilent noshortloops # warncreateglobal
 
     local -a opt_move opt_move2 opt_norm opt_auto opt_nobkp
@@ -1903,7 +1903,7 @@ ziextract() {
 } # ]]]
 # FUNCTION: .zinit-extract [[[
 .zinit-extract() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob warncreateglobal typesetsilent
     local tpe=$1 extract=$2 local_dir=$3
     (
@@ -1951,7 +1951,7 @@ zpextract() { ziextract "$@"; }
 } # ]]]
 # FUNCTION: .zinit-get-cygwin-package [[[
 .zinit-get-cygwin-package() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes
 
     REPLY=
@@ -2036,7 +2036,7 @@ zpextract() { ziextract "$@"; }
 } # ]]]
 # FUNCTION: zicp [[[
 zicp() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes
 
     local -a mbegin mend match
@@ -2331,7 +2331,7 @@ zimv() {
     # Compile plugin
     if [[ -z $ICE[(i)(\!|)(sh|bash|ksh|csh)] ]] {
         () {
-            emulate -LR zsh
+            builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
             setopt extendedglob warncreateglobal
             if [[ $tpe == snippet ]] {
                 .zinit-compile-plugin "%$dir" ""

--- a/zinit-side.zsh
+++ b/zinit-side.zsh
@@ -29,7 +29,7 @@
 # $1 - plugin spec (4 formats: user---plugin, user/plugin, user, plugin)
 # $2 - plugin (only when $1 - i.e. user - given)
 .zinit-exists-physically-message() {
-    builtin emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     builtin setopt extendedglob warncreateglobal typesetsilent noshortloops rcquotes
     if ! .zinit-exists-physically "$1" "$2"; then
         .zinit-any-to-user-plugin "$1" "$2"
@@ -126,7 +126,7 @@
 # directory) or regular URL (points to file), returns 2 possible paths for
 # further examination
 .zinit-two-paths() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob typesetsilent warncreateglobal noshortloops
 
     local url=$1 url1 url2 local_dirA dirnameA svn_dirA \
@@ -170,7 +170,7 @@
 # $5 - name of output string parameter, to hold filename ("filename")
 # $6 - name of output string parameter, to hold is-snippet 0/1-bool ("is_snippet")
 .zinit-compute-ice() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob typesetsilent warncreateglobal noshortloops
 
     local ___URL="${1%/}" ___pack="$2" ___is_snippet=0
@@ -382,7 +382,7 @@
 .zinit-countdown() {
     (( !${+ICE[countdown]} )) && return 0
 
-    emulate -L zsh -o extendedglob
+    builtin emulate -L zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
     trap "+zinit-message \"{ehi}ABORTING, the ice {ice}$ice{ehi} not ran{rst}\"; return 1" INT
     local count=5 tpe="$1" ice
     ice="${ICE[$tpe]}"

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -247,7 +247,7 @@ builtin setopt noaliases
 # The hijacking is not only to gather report data, but also to.
 # run custom `autoload' function, that doesn't need FPATH.
 :zinit-tmp-subst-autoload () {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     builtin setopt extendedglob warncreateglobal typesetsilent rcquotes
     local -a opts opts2 custom reply
     local func
@@ -377,7 +377,7 @@ builtin setopt noaliases
 #
 # The hijacking is to gather report data (which is used in unload).
 :zinit-tmp-subst-bindkey() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     builtin setopt extendedglob warncreateglobal typesetsilent noshortloops
 
     is-at-least 5.3 && \
@@ -935,7 +935,7 @@ builtin setopt noaliases
 # Returns user and plugin in $reply.
 #
 .zinit-any-to-user-plugin() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     builtin setopt extendedglob typesetsilent noshortloops rcquotes \
          ${${${+reply}:#0}:+warncreateglobal}
 
@@ -977,7 +977,7 @@ builtin setopt noaliases
 } # ]]]
 # FUNCTION: .zinit-any-to-pid. [[[
 .zinit-any-to-pid() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     builtin setopt extendedglob typesetsilent noshortloops rcquotes \
          ${${${+REPLY}:#0}:+warncreateglobal}
 
@@ -1009,7 +1009,7 @@ builtin setopt noaliases
 # FUNCTION: .zinit-util-shands-path. [[[
 # Replaces parts of path with %HOME, etc.
 .zinit-util-shands-path() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     builtin setopt extendedglob typesetsilent noshortloops rcquotes \
          ${${${+REPLY}:#0}:+warncreateglobal}
 
@@ -1116,7 +1116,7 @@ builtin setopt noaliases
 # ]]]
 # FUNCTION: @zinit-substitute. [[[
 @zinit-substitute() {
-    emulate -LR zsh
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     builtin setopt extendedglob warncreateglobal typesetsilent noshortloops
 
     local -A ___subst_map
@@ -1165,7 +1165,7 @@ builtin setopt noaliases
     ZINIT_EXTS[seqno]=$(( ${ZINIT_EXTS[seqno]:-0} + 1 ))
     ZINIT_EXTS[$key${${(M)type#hook:}:+ ${ZINIT_EXTS[seqno]}}]="${ZINIT_EXTS[seqno]} z-annex-data: ${(q)name} ${(q)type} ${(q)handler} ${(q)helphandler} ${(q)icemods}"
     () {
-        emulate -LR zsh -o extendedglob
+        builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
         integer index="${type##[%a-zA-Z:_!-]##}"
         ZINIT_EXTS[ice-mods]="${ZINIT_EXTS[ice-mods]}${icemods:+|}${(j:|:)${(@)${(@s:|:)icemods}/(#b)(#s)(?)/$index-$match[1]}}"
     }
@@ -1316,7 +1316,7 @@ builtin setopt noaliases
     [[ -n ${ICE[(i)(\!|)(sh|bash|ksh|csh)]}${ICE[opts]} ]] && {
         local -a precm
         precm=(
-            emulate
+            builtin emulate
             ${${(M)${ICE[(i)(\!|)(sh|bash|ksh|csh)]}#\!}:+-R}
             ${${${ICE[(i)(\!|)(sh|bash|ksh|csh)]}#\!}:-zsh}
             ${${ICE[(i)(\!|)bash]}:+-${(s: :):-o noshglob -o braceexpand -o kshglob}}
@@ -1663,7 +1663,7 @@ builtin setopt noaliases
     [[ -n ${ICE[(i)(\!|)(sh|bash|ksh|csh)]}${ICE[opts]} ]] && {
         local -a ___precm
         ___precm=(
-            emulate
+            builtin emulate
             ${${(M)${ICE[(i)(\!|)(sh|bash|ksh|csh)]}#\!}:+-R}
             ${${${ICE[(i)(\!|)(sh|bash|ksh|csh)]}#\!}:-zsh}
             ${${ICE[(i)(\!|)bash]}:+-${(s: :):-o noshglob -o braceexpand -o kshglob}}
@@ -1876,7 +1876,7 @@ builtin setopt noaliases
     .zinit-any-to-user-plugin "$1" ""
     local ___id_as="$1" ___user="${reply[-2]}" ___plugin="${reply[-1]}" ___oldpwd="$PWD"
     () {
-        emulate -LR zsh
+        builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
         builtin cd &>/dev/null -q ${${${(M)___user:#%}:+$___plugin}:-${ZINIT[PLUGINS_DIR]}/${___id_as//\//---}} || {
             .zinit-get-object-path snippet "$___id_as"
             builtin cd &>/dev/null -q $REPLY
@@ -1912,10 +1912,9 @@ builtin setopt noaliases
     command true # workaround a Zsh bug, see: https://www.zsh.org/mla/workers/2018/msg00966.html
     builtin zle -F "$THEFD" +zinit-deploy-message
 } # ]]]
-
 # FUNCTION: .zinit-formatter-pid. [[[
 .zinit-formatter-pid() {
-    builtin emulate -L zsh -o extendedglob
+    builtin emulate -L zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
 
     # Save whitespace location
     local pbz=${(M)1##(#s)[[:space:]]##}
@@ -1958,7 +1957,7 @@ builtin setopt noaliases
 
 # FUNCTION: .zinit-formatter-url. [[[
 .zinit-formatter-url() {
-    builtin emulate -LR zsh -o extendedglob
+    builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
     #              1:proto        3:domain/5:start      6:end-of-it         7:no-dot-domain        9:file-path
     if [[ $1 = (#b)([^:]#)(://|::)((([[:alnum:]._+-]##).([[:alnum:]_+-]##))|([[:alnum:].+_-]##))(|/(*)) ]] {
         # The advanced coloring if recognized the format…
@@ -2021,7 +2020,7 @@ builtin setopt noaliases
 
 # FUNCTION: +zinit-message. [[[
 +zinit-message() {
-    builtin emulate -LR zsh -o extendedglob
+    builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
     local opt msg
     [[ $1 = -* ]] && { local opt=$1; shift; }
 
@@ -2053,7 +2052,7 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
 
 # FUNCTION: +zinit-prehelp-usage-message. [[[
 +zinit-prehelp-usage-message() {
-    builtin emulate -LR zsh -o extendedglob
+    builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
     local cmd=$1 allowed=$2 sep="$ZINIT[col-msg2], $ZINIT[col-ehi]" \
         sep2="$ZINIT[col-msg2], $ZINIT[col-opt]" bcol
 
@@ -2099,7 +2098,7 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
 
 # FUNCTION: +zinit-parse-opts. [[[
 .zinit-parse-opts() {
-    builtin emulate -LR zsh -o extendedglob
+    builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
     reply=( "${(@)${@[2,-1]//([  $'\t']##|(#s))(#b)(${(~j.|.)${(@s.|.)___opt_map[$1]}})(#B)([  $'\t']##|(#e))/${OPTS[${___opt_map[${match[1]}]%%:*}]::=1}ß←↓→}:#1ß←↓→}" )
 } # ]]]
 
@@ -2168,7 +2167,7 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
 
 # FUNCTION: .zinit-setup-params. [[[
 .zinit-setup-params() {
-    emulate -LR zsh -o extendedglob
+    builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
     reply=( ${(@)${(@s.;.)ICE[param]}/(#m)*/${${MATCH%%(-\>|→|=\>)*}//((#s)[[:space:]]##|[[:space:]]##(#e))}${${(M)MATCH#*(-\>|→|=\>)}:+\=${${MATCH#*(-\>|→|=\>)}//((#s)[[:space:]]##|[[:space:]]##(#e))}}} )
     (( ${#reply} )) && return 0 || return 1
 } # ]]]
@@ -2309,7 +2308,7 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
     if [[ -n $1 ]] {
         if [[ ${#ZINIT_RUN} -le 1 || $1 = following ]]  {
             () {
-                builtin emulate -L zsh
+                builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}
                 builtin setopt extendedglob
                 # Example entry:
                 # 1531252764+2+1 p 18 light zdharma/zsh-diff-so-fancy
@@ -2352,7 +2351,7 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
         add-zsh-hook -d -- precmd @zinit-scheduler
         add-zsh-hook -- chpwd @zinit-scheduler
         () {
-            builtin emulate -L zsh
+            builtin emulate -L zsh ${=${options[xtrace]:#off}:+-o xtrace}
             builtin setopt extendedglob
             # No "+" in this pattern, it will match only "1531252764"
             # in "1531252764+2" and replace it with current time.
@@ -2721,7 +2720,7 @@ env-whitelist|bindkeys|module|add-fpath|fpath|run${reply:+|${(~j:|:)"${reply[@]#
 
         if (( ___error )) {
             () {
-                emulate -LR zsh -o extendedglob
+                builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
                 +zinit-message -n "{u-warn}Error{b-warn}:{rst} No plugin or snippet ID given"
                 if [[ -n $___last_ice ]] {
                     +zinit-message -n " (the last recognized ice was: {ice}"\


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The patch adds `-o xtrace` to all `emulate -L` calls when needed, i.e.: when already active at the entry to the function.

<!--- Describe your changes in detail -->

## Motivation and Context

I've saw some GH issue where this problem, i.e.: of vanishing `xtrace` mode in `emulate -L zsh` functions was described.

Also, the patch adds `builtin` before all emulate calls.

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
