### PR TITLE
fix: remove curl option "--tcp-fastopen" which is not always available

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -106,7 +106,7 @@ download_git_output_processor() {
 
   echo_info "Fetching git-process-output.zsh from $url"
   if command -v curl > /dev/null 2>&1; then
-    curl --tcp-fastopen -fsSL -o "$script_path" "$url"
+    curl -fsSL -o "$script_path" "$url"
   elif command -v wget > /dev/null 2>&1; then
     wget -q -O "$script_path" "$url"
   fi

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -3019,9 +3019,9 @@ builtin print -Pr \"\$ZINIT[col-obj]Done (with the exit code: \$_retval).%f%b\""
     if [[ "$user" != "_local" && -n "$user" ]]; then
         builtin print "${ZINIT[col-info]}Creating Github repository${ZINIT[col-rst]}"
         if [[ $isorg = (y|yes) ]]; then
-            curl --tcp-fastopen --silent -u "$user" https://api.github.com/orgs/$org/repos -d '{"name":"'"$plugin"'"}' >/dev/null
+            curl --silent -u "$user" https://api.github.com/orgs/$org/repos -d '{"name":"'"$plugin"'"}' >/dev/null
         else
-            curl --tcp-fastopen --silent -u "$user" https://api.github.com/user/repos -d '{"name":"'"$plugin"'"}' >/dev/null
+            curl --silent -u "$user" https://api.github.com/user/repos -d '{"name":"'"$plugin"'"}' >/dev/null
         fi
         command git clone "https://github.com/${${${(M)isorg:#(y|yes)}:+$org}:-$user}/${plugin}.git" "${${${(M)isorg:#(y|yes)}:+$org}:-$user}---${plugin//\//---}" || {
             builtin print "${ZINIT[col-error]}Creation of remote repository $uspl2col ${ZINIT[col-error]}failed${ZINIT[col-rst]}"

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -662,9 +662,9 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 
         if (( ${+commands[curl]} )); then
             if [[ -n $progress ]]; then
-                command curl --tcp-fastopen --progress-bar -fSL "$url" 2> >($ZINIT[BIN_DIR]/share/single-line.zsh >&2) || return 1
+                command curl --progress-bar -fSL "$url" 2> >($ZINIT[BIN_DIR]/share/single-line.zsh >&2) || return 1
             else
-                command curl --tcp-fastopen -fsSL "$url" || return 1
+                command curl -fsSL "$url" || return 1
             fi
         elif (( ${+commands[wget]} )); then
             command wget ${${progress:--q}:#1} "$url" -O - || return 1
@@ -681,9 +681,9 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     } else {
         if type curl 2>/dev/null 1>&2; then
             if [[ -n $progress ]]; then
-                command curl --tcp-fastopen --progress-bar -fSL "$url" 2> >($ZINIT[BIN_DIR]/share/single-line.zsh >&2) || return 1
+                command curl --progress-bar -fSL "$url" 2> >($ZINIT[BIN_DIR]/share/single-line.zsh >&2) || return 1
             else
-                command curl --tcp-fastopen -fsSL "$url" || return 1
+                command curl -fsSL "$url" || return 1
             fi
         elif type wget 2>/dev/null 1>&2; then
             command wget ${${progress:--q}:#1} "$url" -O - || return 1
@@ -713,7 +713,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
         }
 
     if (( ${+commands[curl]} )) || type curl 2>/dev/null 1>&2; then
-        cmd=(command curl --tcp-fastopen -sIL "$url")
+        cmd=(command curl -sIL "$url")
     elif (( ${+commands[wget]} )) || type wget 2>/dev/null 1>&2; then
         cmd=(command wget --server-response --spider -q "$url" -O -)
     else


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

Remove cURL option `--tcp-fastopen`

## Motivation and Context

Closes #298

## Usage examples

N/A

## How Has This Been Tested?

N/A

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>