### PR TITLE
fix: use runtime detected cpu before compiled cpu (#287)

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1543,8 +1543,8 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
       }
 
       if (( $#list > 1 )) {
-        filtered=( ${(M)list[@]:#(#i)*${~matchstr[${MACHTYPE}]}*} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} )
-        # +zinit-message "{pre}gh-r{rst}:{info} ${matchstr[${MACHTYPE}]}\\n{obj}${(pj:\n:)${(@)list[1,5]:t}}{rst}"
+        filtered=( ${(M)list[@]:#(#i)*${~matchstr[${CPUTYPE}]}*} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} )
+        # +zinit-message "{pre}gh-r{rst}:{info} ${matchstr[${CPUTYPE}]}\\n{obj}${(pj:\n:)${(@)list[1,5]:t}}{rst}"
       }
 
       if (( $#list > 1 )) {
@@ -1553,8 +1553,8 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
       }
 
       if (( $#list > 1 )) {
-        filtered=( ${(M)list[@]:#(#i)*${~matchstr[${CPUTYPE}]}*} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} )
-        # +zinit-message "{pre}gh-r{rst}:{info} ${matchstr[${CPUTYPE}]}\\n{obj}${(pj:\n:)${(@)list[1,5]:t}}{rst}"
+        filtered=( ${(M)list[@]:#(#i)*${~matchstr[${MACHTYPE}]}*} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} )
+        # +zinit-message "{pre}gh-r{rst}:{info} ${matchstr[${MACHTYPE}]}\\n{obj}${(pj:\n:)${(@)list[1,5]:t}}{rst}"
       }
 
       if (( $#list > 1 )) {


### PR DESCRIPTION
Use CPUTYPE (runtime detected CPU) before using MACHTYPE (compile-time CPU) when installing plugins.
<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->
On my system I launch `/bin/zsh` (a universal binary) from [Kitty](https://sw.kovidgoyal.net/kitty/) which is x86_64 only.

Because of the universal binary, zsh has MACHTYPE of x86_64.  The CPUTYPE should be used first to try to install packages with.

## Motivation and Context

Fixes #287 
<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples

N/A
<!--- Provide examples of intended usage -->

## How Has This Been Tested?

On my M1 MBP I deleted and reinstalled `mvdan/sh`'s SHFMT tool.
<!--- Please describe in detail how you tested your changes. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I am unable to get zunit to run at the moment.  Hopefully there is CI that will run it.