### PR TITLE
style: format single-line.zsh to zinit convention

### DIFF
--- a/share/single-line.zsh
+++ b/share/single-line.zsh
@@ -1,19 +1,27 @@
 #!/usr/bin/env zsh
+#
+# Copyright (c) 2016-2020 Sebastian Gniazdowski and contributors
+# Copyright (c) 2021-2022 zdharma-continuum and contributors
 
 emulate -R zsh
-setopt extendedglob warncreateglobal typesetsilent rcquotes noshortloops
+setopt extendedglob noshortloops rcquotes typesetsilent warncreateglobal
 
-local zero=$'\0' r=$'\r' n=$'\n' IFS=
-{ command perl -pe 'BEGIN { $|++; $/ = \1 }; tr/\r\n/\n\0/' || \
-gstdbuf -o0 gtr '\r\n' '\n\0' || \
-stdbuf -o0 tr '\r\n' '\n\0'; print } 2>/dev/null | \
-	while read -r line; do
-		if [[ $line == *$zero* ]]; then
-			# Unused by cURL (there's no newline after the previous progress bar)
-			#print -nr -- $r${(l:COLUMNS:: :):-}$r${line##*$zero}
-			print -nr -- $r${(l:COLUMNS:: :):-}$r${line%$zero}
-		else
-			print -nr -- $r${(l:COLUMNS:: :):-}$r${${line//[$r$n]/}%\%*}${${(M)line%\%}:+%}
-		fi
-	done
+local IFS= n=$'\n' r=$'\r' zero=$'\0'
+
+{
+  command perl -pe 'BEGIN { $|++; $/ = \1 }; tr/\r\n/\n\0/' \
+    || gstdbuf -o0 gtr '\r\n' '\n\0' \
+    || stdbuf -o0 tr '\r\n' '\n\0';
+  print
+} 2>/dev/null | while read -r line;
+do
+  if [[ $line == *$zero* ]]; then
+    # cURL doesn't add a newline to progress bars
+    # print -nr -- "${r}${(l:COLUMNS:: :):-}${r}${line##*${zero}}"
+    print -nr -- "${r}${(l:COLUMNS:: :):-}${r}${line%${zero}}"
+  else
+    print -nr -- "${r}${(l:COLUMNS:: :):-}${r}${${line//[${r}${n}]/}%\%*}${${(M)line%\%}:+%}"
+  fi
+done
+
 print


### PR DESCRIPTION

## Description

Format `share/single-line.zsh` to Zinit's zsh code style convention

## Motivation and Context

Consistency

## Related Issue(s)

#238

## Usage examples

## How Has This Been Tested?

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.


Signed-off-by: Vladislav Doster <mvdoster@gmail.com>