### PR TITLE
Move extract'' action up, before atclone/atpull and before mv/cp

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -266,7 +266,9 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                 }
             }
 
-            ziextract "$fname" --move
+            # --move is default (or as explicit, when extract'!…' is given)
+            # Also possible is --move2 when extract'!!…' given
+            ziextract "$fname" ${ICE[extract]---move} ${${(M)ICE[extract]:#!([^!]|(#e))*}:+--move} ${${(M)ICE[extract]:#!!*}:+--move2}
             return 0
         ) && {
             reply=( "$user" "$plugin" )
@@ -389,7 +391,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                     [[ -d ._zinit ]] || return 2
                     builtin print -r -- $url >! ._zinit/url || return 3
                     builtin print -r -- ${REPLY} >! ._zinit/is_release${count:#1} || return 4
-                    ziextract ${REPLY:t} ${${${#reply}:#1}:+--nobkp}
+                    ziextract ${REPLY:t} ${${${#reply}:#1}:+--nobkp} ${${(M)ICE[extract]:#!([^!]|(#e))*}:+--move} ${${(M)ICE[extract]:#!!*}:+--move2}
                 }
                 return $?
             ) || {

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -3192,6 +3192,7 @@ if [[ -e ${${ZINIT[BIN_DIR]}}/zmodules/Src/zdharma/zplugin.so ]] {
 
 # e-!atpull-pre.
 @zinit-register-hook "make'!!'" hook:no-e-\!atpull-pre ∞zinit-make-ee-hook
+@zinit-register-hook "extract" hook:e-\!atpull-pre ∞zinit-extract-hook
 @zinit-register-hook "mv''" hook:no-e-\!atpull-pre ∞zinit-mv-hook
 @zinit-register-hook "cp''" hook:no-e-\!atpull-pre ∞zinit-cp-hook
 @zinit-register-hook "compile-plugin" hook:no-e-\!atpull-pre ∞zinit-compile-plugin-hook
@@ -3199,13 +3200,13 @@ if [[ -e ${${ZINIT[BIN_DIR]}}/zmodules/Src/zdharma/zplugin.so ]] {
 @zinit-register-hook "make'!'" hook:no-e-\!atpull-post ∞zinit-make-e-hook
 @zinit-register-hook "atpull" hook:no-e-\!atpull-post ∞zinit-atpull-hook
 @zinit-register-hook "make''" hook:no-e-\!atpull-post ∞zinit-make-hook
-@zinit-register-hook "extract" hook:atpull-post ∞zinit-extract-hook
 # atpull-post.
 @zinit-register-hook "compile-plugin" hook:atpull-post ∞zinit-compile-plugin-hook
 @zinit-register-hook "ps-on-update" hook:%atpull-post ∞zinit-ps-on-update-hook
 
 # !atclone-pre.
 @zinit-register-hook "make'!!'" hook:\!atclone-pre ∞zinit-make-ee-hook
+@zinit-register-hook "extract" hook:\!atclone-pre ∞zinit-extract-hook
 @zinit-register-hook "mv''" hook:\!atclone-pre ∞zinit-mv-hook
 @zinit-register-hook "cp''" hook:\!atclone-pre ∞zinit-cp-hook
 @zinit-register-hook "compile-plugin" hook:\!atclone-pre ∞zinit-compile-plugin-hook
@@ -3213,7 +3214,6 @@ if [[ -e ${${ZINIT[BIN_DIR]}}/zmodules/Src/zdharma/zplugin.so ]] {
 @zinit-register-hook "make'!'" hook:\!atclone-post ∞zinit-make-e-hook
 @zinit-register-hook "atclone" hook:\!atclone-post ∞zinit-atclone-hook
 @zinit-register-hook "make''" hook:\!atclone-post ∞zinit-make-hook
-@zinit-register-hook "extract" hook:\!atclone-post ∞zinit-extract-hook
 # atclone-post.
 @zinit-register-hook "compile-plugin" hook:atclone-post ∞zinit-compile-plugin-hook
 


### PR DESCRIPTION
Make the `extract''` ice execute earlier in the hook order and make it be always followed for its exclamation-mark modes during `gh-r` and `pack''` downloads.

<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->
PR moves `extract''` hook action up, before `atclone/atpull` and before `mv/cp` so that `atclone` can contain `./configure` for the *unpacked* archive. Also, for the `mv''` ice to make sense, as the extension is not required for unpacking (because `file` coreutil is used to find a file of archive type), so one can utilize `mv''` ice for something after the unpacking (not before,  like to rename `mv='tmux->tmux.tgz'` or similar, which wouldn't work  anyway because of the reversed order).

Also, the PR makes the default `ziextract` calling in `gh-r` and `pack''` obey the exclamation marks from `extract'!…'` to allow deciding whether `--move` or `--move2` mode should be enabled (the moving of all files to `1` or `2` level up directory from an inner dir, `mv */** .`, etc).

Tested on:

```zsh
zi null id-as from'gh-r'  \
        extract'!' atclone'./configure --prefix=$ZPFX' \
        atpull'%atclone' make'install' for \
                tmux/tmux
```

Could the command be added to the `wiki` `GitHub Binary Recipes` updating the current `tmux/tmux` rule there? Current rule doesn't do compilation of tmux (`gh-r` for `tmux/tmux` downloads only sources, as they're the only one exposed there).


## Motivation and Context <!--- Why is this change required? What problem does it solve? -->
I wanted to fix the `tmux/tmux` recipe on the recipes wiki so that it compiles the `gh-r`-exposed and downloaded `tmux` sources and noticed that it's impossible with `extract''` ice because it was called after `atclone='./configure'`.

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

Tested with two commands:

```zsh
zi null id-as from'gh-r'  \
        extract'!' atclone'./configure --prefix=$ZPFX' \
        atpull'%atclone' make'install' for \
                tmux/tmux
```

And for snippet mode:

```zsh
zi null id-as'tmux' extract'!' \
        atclone'./configure --prefix=$ZPFX' \
        atpull'%atclone' \
        make'install' for \
             https://github.com/tmux/tmux/releases/download/3.3a/tmux-3.3a.tar.gz
```


## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
