### PR TITLE
feat: append `${ZPFX}/lib/pkg-config` to `$PKG_CONFIG_PATH`

### DIFF
--- a/share/config.site
+++ b/share/config.site
@@ -1,0 +1,4 @@
+# Prepend directories carrying libs and headers to appropriate vars
+export CPPFLAGS="-I$ZPFX/include $CPPFLAGS"
+export LDFLAGS="-L$ZPFX/lib -L$ZPFX/lib64 $LDFLAGS"
+ 

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -3321,6 +3321,7 @@ zle -N zi-browse-symbol
 zle -N zi-browse-symbol-backwards zi-browse-symbol
 zle -N zi-browse-symbol-pbackwards zi-browse-symbol
 zle -N zi-browse-symbol-pforwards zi-browse-symbol
+
 zstyle -s ':zinit:browse-symbol' key ZINIT_TMP || ZINIT_TMP='\eQ'
 [[ -n $ZINIT_TMP ]] && bindkey $ZINIT_TMP zi-browse-symbol
 

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -143,6 +143,7 @@ export ZPFX=${~ZPFX} ZSH_CACHE_DIR="${ZSH_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.ca
     PMSPEC=0uUpiPsf
 [[ -z ${path[(re)$ZPFX/bin]} ]] && [[ -d "$ZPFX/bin" ]] && path=( "$ZPFX/bin" "${path[@]}" )
 [[ -z ${path[(re)$ZPFX/sbin]} ]] && [[ -d "$ZPFX/sbin" ]] && path=( "$ZPFX/sbin" "${path[@]}" )
+typeset -gU PATH path
 
 # Add completions directory to fpath.
 [[ -z ${fpath[(re)${ZINIT[COMPLETIONS_DIR]}]} ]] && fpath=( "${ZINIT[COMPLETIONS_DIR]}" "${fpath[@]}" )
@@ -1267,7 +1268,7 @@ builtin setopt noaliases
         # For compaudit.
         command chmod go-w "${ZINIT[HOME_DIR]}"
         # Also set up */bin and ZPFX in general.
-        command mkdir 2>/dev/null -p $ZPFX/bin
+        command mkdir 2>/dev/null -p $ZPFX/bin $ZPFX/share
     }
     [[ ! -d ${ZINIT[PLUGINS_DIR]}/_local---zinit ]] && {
         command rm -rf "${ZINIT[PLUGINS_DIR]:-${TMPDIR:-/tmp}/132bcaCAB}/_local---zplugin"
@@ -1276,7 +1277,7 @@ builtin setopt noaliases
         command ln -s "${ZINIT[BIN_DIR]}/_zinit" "${ZINIT[PLUGINS_DIR]}/_local---zinit"
 
         # Also set up */bin and ZPFX in general.
-        command mkdir 2>/dev/null -p $ZPFX/bin
+        command mkdir 2>/dev/null -p $ZPFX/bin $ZPFX/share
 
         (( ${+functions[.zinit-setup-plugin-dir]} )) || builtin source "${ZINIT[BIN_DIR]}/zinit-install.zsh" || return 1
         (( ${+functions[.zinit-confirm]} )) || builtin source "${ZINIT[BIN_DIR]}/zinit-autoload.zsh" || return 1
@@ -1292,7 +1293,7 @@ builtin setopt noaliases
         command ln -s "${ZINIT[PLUGINS_DIR]}/_local---zinit/_zinit" "${ZINIT[COMPLETIONS_DIR]}"
 
         # Also set up */bin and ZPFX in general.
-        command mkdir 2>/dev/null -p $ZPFX/bin
+        command mkdir 2>/dev/null -p $ZPFX/bin $ZPFX/share
 
         (( ${+functions[.zinit-setup-plugin-dir]} )) || builtin source "${ZINIT[BIN_DIR]}/zinit-install.zsh" || return 1
         .zinit-compinit &>/dev/null
@@ -1307,7 +1308,7 @@ builtin setopt noaliases
         command chmod go-w "${ZINIT[SERVICES_DIR]}"
 
         # Also set up */bin and ZPFX in general.
-        command mkdir 2>/dev/null -p $ZPFX/bin
+        command mkdir 2>/dev/null -p $ZPFX/bin $ZPFX/share
     }
     [[ ! -d ${~ZINIT[MAN_DIR]}/man9 ]] && {
         # Create ZINIT[MAN_DIR]/man{1..9}
@@ -1318,6 +1319,11 @@ builtin setopt noaliases
         $ZINIT[MAN_DIR]/man1/zinit.1 -ot $ZINIT[BIN_DIR]/doc/zinit.1 ]] && {
         command mkdir -p $ZINIT[MAN_DIR]/man1
         command cp -f $ZINIT[BIN_DIR]/doc/zinit.1 $ZINIT[MAN_DIR]/man1
+    }
+    # Copy Autotools compilation options setting
+    [[ ! -f $ZPFX/share/config.site ]] && {
+        command mkdir -p $ZPFX/share
+        command cp $ZINIT[BIN_DIR]/share/config.site $ZPFX/share
     }
 } # ]]]
 # FUNCTION: .zinit-load-object [[[
@@ -1367,6 +1373,9 @@ builtin setopt noaliases
     local -a opts
     zparseopts -E -D -a opts f -command || { +zinit-message "{u-warn}Error{b-warn}:{rst} Incorrect options (accepted ones: {opt}-f{rst}, {opt}--command{rst})."; return 1; }
     local url="$1" limit="$3"
+    # Ensure that configuration prepared for configure script
+    local -x CONFIG_SITE="$ZPFX/share/config.site"
+ 
     [[ -n ${ICE[teleid]} ]] && url="${ICE[teleid]}"
     # Hide arguments from sourced scripts. Without this calls our "$@" are visible as "$@"
     # within scripts that we `source`.
@@ -1722,6 +1731,9 @@ builtin setopt noaliases
     # within scripts that we `source`.
     builtin set --
     [[ -o ksharrays ]] && ___correct=1
+
+    # Configuration prepared for configure script
+    local -x CONFIG_SITE="$ZPFX/share/config.site"
 
     [[ -n ${ICE[(i)(\!|)(sh|bash|ksh|csh)]}${ICE[opts]} ]] && {
         local -a ___precm
@@ -3324,6 +3336,14 @@ zle -N zi-browse-symbol-pforwards zi-browse-symbol
 
 zstyle -s ':zinit:browse-symbol' key ZINIT_TMP || ZINIT_TMP='\eQ'
 [[ -n $ZINIT_TMP ]] && bindkey $ZINIT_TMP zi-browse-symbol
+
+# Add $ZPFX/lib/pkg-config to PKG_CONFIG_PATH, so that libraries
+# installed locally can be found by autotools and cmake. There
+# is also $ZPFX/share/config.site file with autotools settings.
+
+[[ $PKG_CONFIG_PATH != (|*:)$ZPFX/lib(|64)/pkgconfig(|:*) ]]&&PKG_CONFIG_PATH="$ZPFX/lib/pkgconfig:$ZPFX/lib64/pkgconfig:$PKG_CONFIG_PATH"
+[[ $CMAKE_PREFIX_PATH != (|*\;)$ZPFX(|\;*) ]]&&CMAKE_PREFIX_PATH="$ZPFX:$CMAKE_PREFIX_PATH"
+[[ $LD_LIBRARY_PATH != (|*:)$ZPFX/lib(|64)(|:*) ]]&&LD_LIBRARY_PATH="$ZPFX/lib:$ZPFX/lib64:$LD_LIBRARY_PATH"
 
 # Local Variables:
 # mode: Shell-Script


### PR DESCRIPTION
## Description <!--- Describe your changes in detail -->
I thought it be good if `$ZPFX` will get visible to `autotools` and `cmake`. In order to accomplish this `$ZPFX/lib/pkg-config` should be added to `$PKG_CONFIG_PATH`.

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

Today I've installed a library (`pcre2-8`) to `$ZPFX` and then tried to also install a dependent program (`uni-ctags`) and I've noticed that the library wasn't found. After investigation it was `pkg-config` to blame, with a solution of prepending `$ZPFX` library dir to `$PKG_CONFIG_PATH`. i think that such move is of good reasoning – the variable works like `$PATH` grouping multiple dirs, so nothing can be lost. After this `ctags` built correctly.

## Usage examples <!--- Provide examples of intended usage -->

Some can be found at #332 

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

i've removed system pcre2, obtained a build failure, performed the steps described and obtained a build success. 

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
