### PR TITLE
maint: add CODEOWNERS file for code owners feature

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+* @alichtman @pschmitt @vladdoster
+
+# Should consider adding @psprint as well


### PR DESCRIPTION
Information on the [CODEOWNERS file](https://github.blog/2017-07-06-introducing-code-owners).

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>
