### PR TITLE
Copy zinit.1 to man1 directory for `man` to be able to open it

### DIFF
--- a/zinit.zsh
+++ b/zinit.zsh
@@ -1268,6 +1268,11 @@ builtin setopt noaliases
         # Create ZINIT[MAN_DIR]/man{1..9}
         command mkdir 2>/dev/null -p ${~ZINIT[MAN_DIR]}/man{1..9}
     }
+    # Copy Zinit manpage so that man is able to find it
+    [[ ! -f $ZINIT[MAN_DIR]/man1/zinit.1 ]] && {
+        command mkdir -p $ZINIT[MAN_DIR]/man1
+        command cp $ZINIT[BIN_DIR]/doc/zinit.1 $ZINIT[MAN_DIR]/man1
+    }
 } # ]]]
 # FUNCTION: .zinit-load-object. [[[
 .zinit-load-object() {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->

Add a single conditional that checks if `$ZPFX/man/man1/zinit.1` exists and copies it if not.

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->
There is a manual page of zinit – in `doc/zinit.1`. However I suppose that it's very rarely ever open, because its location under `BIN_DIR`. So I thought that it should be copied to `man1` dir under `ZINIT[MAN_DIR]` so that simple `man zinit` works fine.


## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples <!--- Provide examples of intended usage -->

```zsh
# After starting a new shell with the patch applied:
man zinit
```

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

```
man zinit
```

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
