### PR TITLE
(fix): add `os-x` to darwin gh-r pattern

### DIFF
--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -436,6 +436,11 @@ $kopia --version; assert $state equals 0
   local lsd="$ZBIN/lsd"; assert "$lsd" is_executable
   $lsd --version; assert $state equals 0
 }
+@test 'lnav' { # advanced log file viewer
+  run zinit for tstack/lnav; assert $state equals 0
+  local lnav="$ZBIN/lnav"; assert "$lnav" is_executable
+  $lnav --version; assert $state equals 0
+}
 @test 'lstf' { # The aggregated TCP flows printer in Linux
   if [[ ! $OSTYPE =~ 'linux.*' ]]; then skip 'lstf test only ran on Linux'; fi
   run zinit for yuuki/lstf; assert $state equals 0

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1486,7 +1486,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
       linux-android '(apk|android|linux-android)'
       linux-gnu "*(linux-musl|musl|linux)*~^*(${MACHTYPE}|${CPUTYPE}|)*"
       linux-musl "*(linux-musl|musl|linux-~gnu|linux)*~^*(${MACHTYPE}|${CPUTYPE}|)*"
-      darwin '*((#s)|/)*(apple|darwin|mac|macos|osx|dmg)*((#e)|/)*'
+      darwin '*((#s)|/)*(apple|darwin|mac|macos|os(-|)x|dmg)*((#e)|/)*'
       cygwin '(win((dows|32|64))|cygwin)'
       msys '(win((dows|32|64))|cygwin)'
       windows '(win((dows|32|64))|cygwin)'


### PR DESCRIPTION
## Description <!--- Describe your changes in detail -->

- add `os-x` to darwin gh-r pattern
- add zunit test for tstack/lnav

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

Closes #367

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>