### PR TITLE
fix: Fix download from gh-r

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1464,7 +1464,8 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     if [[ -z $urlpart ]] {
         local tag_version=${ICE[ver]}
         if [[ -z $tag_version ]]; then
-            tag_version="$( { .zinit-download-file-stdout $site/latest || .zinit-download-file-stdout $site/latest 1; } 2>/dev/null | \
+            local releases_url=https://github.com/$user/$plugin/releases/latest
+            tag_version="$( { .zinit-download-file-stdout $releases_url || .zinit-download-file-stdout $releases_url 1; } 2>/dev/null | \
                               command grep -m1 -o 'href=./'$user'/'$plugin'/releases/tag/[^"]\+')"
             tag_version=${tag_version##*/}
         fi

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -354,7 +354,13 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 
     (
         if [[ $site = */releases ]] {
-            local url=$site/${ICE[ver]}
+            local tag_version=${ICE[ver]}
+            if [[ -z $tag_version ]]; then
+                tag_version="$( { .zinit-download-file-stdout $site/latest || .zinit-download-file-stdout $site/latest 1; } 2>/dev/null | \
+                                  command grep -m1 -o 'href=./'$user'/'$plugin'/releases/tag/[^"]\+')"
+                tag_version=${tag_version##*/}
+            fi
+            local url=$site/expanded_assets/$tag_version
 
             .zinit-get-latest-gh-r-url-part "$user" "$plugin" "$url" || return $?
 
@@ -1456,7 +1462,13 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     local user=$1 plugin=$2 urlpart=$3
 
     if [[ -z $urlpart ]] {
-        local url=https://github.com/$user/$plugin/releases/$ICE[ver]
+        local tag_version=${ICE[ver]}
+        if [[ -z $tag_version ]]; then
+            tag_version="$( { .zinit-download-file-stdout $site/latest || .zinit-download-file-stdout $site/latest 1; } 2>/dev/null | \
+                              command grep -m1 -o 'href=./'$user'/'$plugin'/releases/tag/[^"]\+')"
+            tag_version=${tag_version##*/}
+        fi
+        local url=https://github.com/$user/$plugin/releases/expanded_assets/$tag_version
     } else {
         local url=https://$urlpart
     }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->

I tried to update plugins today (September 13, 2022) and the binary download from the GitHub release failed.
`gh-r: failed to find the correct GitHub release asset to download.`

It seems that the GitHub website has been updated and the method of parsing assets from HTML no longer works.
Check this command and video.
`curl https://github.com/BurntSushi/ripgrep/releases`
https://user-images.githubusercontent.com/8683947/189714315-fa1d28b0-755a-46f8-9239-5f16291df26b.mp4


I changed the process to get the list of released assets from the API.
This is a temporary patch and we may need to consider a few more things. However, I think it is better than not working.

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

## Reproduce steps <!--- Provide examples of intended usage -->

.zshrc

```zsh
ZPLG_HOME="$HOME/.config/zinit"

if ! test -d "$ZPLG_HOME"; then
  mkdir -p "$ZPLG_HOME"
  chmod g-rwX "$ZPLG_HOME"
  git clone --depth 10 https://github.com/zdharma-continuum/zinit.git ${ZPLG_HOME}/bin
fi

typeset -gAH ZPLGM
ZPLGM[HOME_DIR]="${ZPLG_HOME}"
source "$ZPLG_HOME/bin/zinit.zsh"
autoload -Uz _zinit
(( ${+_comps} )) && _comps[zinit]=_zinit

zinit for \
    from'gh-r' \
    as'program' pick'ripgrep*/rg' \
  BurntSushi/ripgrep
```

Error

```zsh
gh-r: failed to find the correct GitHub release asset to download.
```

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
