### PR TITLE
Make variables created with param'name → value' be exported. Also

### DIFF
--- a/zinit-additional.zsh
+++ b/zinit-additional.zsh
@@ -47,7 +47,7 @@
     [[ ! -e ${___fle:r}.fifo ]] && command mkfifo "${___fle:r}.fifo" 2>/dev/null 1>&2
     [[ ! -e ${___fle:r}.fifo2 ]] && command mkfifo "${___fle:r}.fifo2" 2>/dev/null 1>&2
 
-    typeset -g ZSRV_WORK_DIR="${ZINIT[SERVICES_DIR]}" ZSRV_ID="${ICE[service]}"  # should be also set by other p-m
+    typeset -gx ZSRV_WORK_DIR="${ZINIT[SERVICES_DIR]}" ZSRV_ID="${ICE[service]}"  # should be also set by other p-m
 
     while (( 1 )); do
         (
@@ -55,8 +55,12 @@
                 [[ ! -f ${___fle:r}.stop ]] && if (( ___lckd )) || zsystem 2>/dev/null 1>&2 flock -t 1 -f ___fd -e $___fle; then
                     ___lckd=1
                     if (( ! ___strd )) || [[ $___cmd = RESTART ]]; then
-                        [[ $___tpe = p ]] && { ___strd=1; .zinit-load "$___id" "" "$___mode"; }
-                        [[ $___tpe = s ]] && { ___strd=1; .zinit-load-snippet "$___id" ""; }
+                        [[ $___tpe = p ]] && { ___strd=1
+                                                .zinit-load "$___id" "" "$___mode" 0;
+                                            }
+                        [[ $___tpe = s ]] && { ___strd=1
+                                                .zinit-load-snippet "$___id" "" 0;
+                                            }
                     fi
                     ___cmd=
                     while (( 1 )); do builtin read -t 32767 ___cmd <>"${___fle:r}.fifo" && break; done


### PR DESCRIPTION
Zinit can set temporary, local variables in the moment of loading a plugin, with `param'name->value'`. However, they aren't exported. This PR adds the `-x` option to the `local …` invocation to make variables created with `param'name → value'` be exported.

Also, it makes `*.plugin.zsh` files sourced if any for services plugin besides running `*.service.plugin` in background.



## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

The motivation is to allow configuring a new service that I'm writing via a `param'MAKE_SERVER_SRC_DIRS→~/github/mc'`, without a separate line in `.zshrc`.

## Usage examples <!--- Provide examples of intended usage -->
```zsh
zi service'make' `param'MAKE_SERVER_SRC_DIRS→~/github/mc'` for zservices/make-server
```

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

**Update**: I've expanded README.md with `param''` description.