### PR TITLE
Copy zinit.1 if it's more recent from the one at $ZPFX/man.

### DIFF
--- a/zinit.zsh
+++ b/zinit.zsh
@@ -1297,9 +1297,10 @@ builtin setopt noaliases
         command mkdir 2>/dev/null -p ${~ZINIT[MAN_DIR]}/man{1..9}
     }
     # Copy Zinit manpage so that man is able to find it
-    [[ ! -f $ZINIT[MAN_DIR]/man1/zinit.1 ]] && {
+    [[ ! -f $ZINIT[MAN_DIR]/man1/zinit.1 || \
+        $ZINIT[MAN_DIR]/man1/zinit.1 -ot $ZINIT[BIN_DIR]/doc/zinit.1 ]] && {
         command mkdir -p $ZINIT[MAN_DIR]/man1
-        command cp $ZINIT[BIN_DIR]/doc/zinit.1 $ZINIT[MAN_DIR]/man1
+        command cp -f $ZINIT[BIN_DIR]/doc/zinit.1 $ZINIT[MAN_DIR]/man1
     }
 } # ]]]
 # FUNCTION: .zinit-load-object. [[[


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->

Keep `zinit.1` up to date by comparing timestamps of `~ZIBIN/doc/zinit.1` and of `$ZPFX/man/man1/zinit.1` and copying if the `~ZIBIN` one is more recent.

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

I've updated `zinit.1` when changed README.md, and noticed that `$ZPFX/man` isn't updated. I've used `pandoc` from `gh-r`, the latest.

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

#381 

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

I've touched `doc/zinit.1` and started a new `zsh`.

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
