### PR TITLE
Assign ctags symbols browser to Alt-Q instead of ctrl-k

### DIFF
--- a/zi-browse-symbol
+++ b/zi-browse-symbol
@@ -381,8 +381,10 @@ if [[ $__tfind_spe_call_count -eq 1 ]]; then
     zle -A $pup_widget saved-$pup_widget
     zle -N $pdown_widget _tfind_simulate_widget
     zle -N $pup_widget _tfind_simulate_widget
-    zle -A zle-line-pre-redraw saved-pre-redraw
-    zle -D zle-line-pre-redraw
+    if (( $+widgets[zle-line-pre-redraw] )); then
+        zle -A zle-line-pre-redraw saved-pre-redraw
+        zle -D zle-line-pre-redraw
+    fi
     local selected_editor cd_at_edit tagtext tagline taglinebyte tagfile
     local -a comm
     comm=()
@@ -457,8 +459,11 @@ if [[ $__tfind_spe_call_count -eq 1 ]]; then
     zle -A saved-$pup_widget $pup_widget
     zle -D saved-$pdown_widget saved-$pup_widget
 
-    zle -A saved-pre-redraw zle-line-pre-redraw
-    zle -D saved-pre-redraw
+    if (( $+widgets[saved-pre-redraw] )); then
+        zle -A saved-pre-redraw zle-line-pre-redraw
+        zle -D saved-pre-redraw
+    fi
+
     # Full reinitialisation at next call
     __tfind_spe_call_count=0
 

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -3265,6 +3265,7 @@ zle -N zi-browse-symbol
 zle -N zi-browse-symbol-backwards zi-browse-symbol
 zle -N zi-browse-symbol-pbackwards zi-browse-symbol
 zle -N zi-browse-symbol-pforwards zi-browse-symbol
-bindkey "^K" zi-browse-symbol
+zstyle -s ':zinit:browse-symbol' key ZINIT_TMP || ZINIT_TMP='\eQ'
+[[ -n $ZINIT_TMP ]] && bindkey $ZINIT_TMP zi-browse-symbol
 
 # vim:ft=zsh:sw=4:sts=4:et:foldmarker=[[[,]]]:foldmethod=marker


### PR DESCRIPTION
The new Alt-Q key is already bound to push-line, however the zle widget has also two other keys, ctrl-q and Alt-q, so no problem, as IMO users who want that widget already use Alt-q, not Alt-Q.

Also, a way of customizing via `zstyle` `':zinit:browse-symbol:key'`  has been added.

<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->
Change the argument of `bindkey`.

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

Problems with ctrl-k users, e.g.: #386 

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
