### PR TITLE
Fix #395

### DIFF
--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -800,7 +800,7 @@ ____
  `#compdef <names ...>'
 ____
 
-Has 549 line(s). Doesn't call other functions.
+Has 573 line(s). Doesn't call other functions.
 
 Uses feature(s): _autoload_, _bindkey_, _compdef_, _compdump_, _eval_, _read_, _setopt_, _unfunction_, _zle_, _zstyle_
 

--- a/doc/zsdoc/zinit.zsh.adoc
+++ b/doc/zsdoc/zinit.zsh.adoc
@@ -1462,7 +1462,7 @@ ____
  Note that some terminals do not support all combinations.
 ____
 
-Has 117 line(s). Doesn't call other functions.
+Has 120 line(s). Doesn't call other functions.
 
 Called by:
 
@@ -1485,7 +1485,7 @@ ____
  `#compdef <names ...>'
 ____
 
-Has 549 line(s). Doesn't call other functions.
+Has 573 line(s). Doesn't call other functions.
 
 Uses feature(s): _autoload_, _bindkey_, _compdef_, _compdump_, _eval_, _read_, _setopt_, _unfunction_, _zle_, _zstyle_
 

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -393,7 +393,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                         command rm -f "${REPLY:t}.sig"
                     fi
 
-                    command mkdir -p ._zinit
+                    command mkdir -p ._zinit && echo '*' > ._zinit/.gitignore
                     [[ -d ._zinit ]] || return 2
                     builtin print -r -- $url >! ._zinit/url || return 3
                     builtin print -r -- ${REPLY} >! ._zinit/is_release${count:#1} || return 4
@@ -404,7 +404,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                 return 1
             }
         } elif [[ $site = cygwin ]] {
-            command mkdir -p "$local_path/._zinit"
+            command mkdir -p "$local_path/._zinit" && echo '*' > "$local_path/._zinit/.gitignore"
             [[ -d "$local_path" ]] || return 1
 
             (

--- a/zinit-side.zsh
+++ b/zinit-side.zsh
@@ -330,7 +330,7 @@
     svn
   )
 
-  command mkdir -p "$___pfx"
+  command mkdir -p "$___pfx" && echo '*' > "$___pfx/.gitignore"
   local ___key ___var_name
   # No nval_ices here
   for ___key in ${ice_order[@]:#(${(~j:|:)nval_ices[@]})} ${(s: :)___add_ices[@]}; do


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->

Create `._zinit/.gitignore` which content is '*' for every plugin.

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

zinit create `._zinit` to store some metadata. However, this metadata should not
be added to git.

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

Fix #395.

I am not sure if
<https://github.com/zdharma-continuum/zinit/blob/main/share/template-plugin/zsh.gitignore#L12>
should be removed. Maybe we should support old zinit? And I think this file
should be pushed to <https://github.com/github/gitignore/> to let more zsh
plugin developers use.

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

I have tested it can work for me.

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
