### PR TITLE
Fix #396

### DIFF
--- a/_zinit
+++ b/_zinit
@@ -70,6 +70,7 @@ case $state in
     _describe -t commands "Zinit command" commands && ret=0
     ;;
   argument)
+    curcontext="${curcontext%:*:*}:zinit-$words[2]:"
     case $words[2] in
       help)
         _message "Hit enter to get usage information" && ret=0


### PR DESCRIPTION

<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->

Now the context is correct.

```sh
❯ zinit cd <C-X>h
tags in context :completion::complete:zinit::
    argument-rest  (_arguments _zinit)
tags in context :completion::complete:zinit-cd::
    dsnippets lsnippets plugins  (_zinit)
```

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

Use can use different context to `zstyle` some different behaviour.

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

Fix #396

## Usage examples <!--- Provide examples of intended usage -->

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
