### PR TITLE
fix: Do not try to escape exclamation marks

### DIFF
--- a/zinit.zsh
+++ b/zinit.zsh
@@ -1178,11 +1178,16 @@ builtin setopt noaliases
 # FUNCTION: @zinit-register-annex. [[[
 # Registers the z-annex inside Zinit – i.e. an Zinit extension
 @zinit-register-annex() {
+    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
+    # See comment in zinit-register-hook() why nobanghist is needed
+    builtin setopt nobanghist
     local name="$1" type="$2" handler="$3" helphandler="$4" icemods="$5" key="z-annex ${(q)2}"
     ZINIT_EXTS[seqno]=$(( ${ZINIT_EXTS[seqno]:-0} + 1 ))
     ZINIT_EXTS[$key${${(M)type#hook:}:+ ${ZINIT_EXTS[seqno]}}]="${ZINIT_EXTS[seqno]} z-annex-data: ${(q)name} ${(q)type} ${(q)handler} ${(q)helphandler} ${(q)icemods}"
     () {
         builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
+        # See comment in zinit-register-hook() why nobanghist is needed
+        builtin setopt nobanghist
         integer index="${type##[%a-zA-Z:_!-]##}"
         ZINIT_EXTS[ice-mods]="${ZINIT_EXTS[ice-mods]}${icemods:+|}${(j:|:)${(@)${(@s:|:)icemods}/(#b)(#s)(?)/$index-$match[1]}}"
     }


### PR DESCRIPTION
For normal hooks, the exclamation mark handling (which adds entries into `ZINIT_EXTS2`) was fixed in https://github.com/zdharma-continuum/zinit/pull/227 and for both `ZINIT_EXTS` and `ZINIT_EXTS2` the escaped exclamation marks were adjusted. But annexes could also register hooks with exclamation marks into `ZINIT_EXTS` and this part was not modified. Therefore annex registering for exclamation mark hooks did not work anymore.

## Description <!--- Describe your changes in detail -->

See above + the part where `ZINIT_EXTS` is modified is now also adjusted in a similar manner as in #227 to not expand history chars (=exclamation marks).

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

See https://github.com/zdharma-continuum/zinit-annex-patch-dl/issues/6

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

See https://github.com/zdharma-continuum/zinit-annex-patch-dl/issues/6


## Usage examples <!--- Provide examples of intended usage -->

The following three prints should all three print the same (two) lines (espcially no escaped exclamation mark!) when the dl annex is used in `.zshrc`:

```zsh
zsh -i -c 'print -rC1 -- "$ZINIT_EXTS[@]" |sort | grep "patch-dl"'
zsh -c 'source .zshrc && print -rC1 -- "$ZINIT_EXTS[@]" |sort | grep "patch-dl"'
exec zsh 
print -rC1 -- "$ZINIT_EXTS[@]" |sort | grep "patch-dl"
```

Example:
```zsh
λ  print -rC1 -- "$ZINIT_EXTS[@]" |sort | grep 'patch-dl'
11 z-annex-data: zinit-annex-patch-dl hook:!atclone-20 za-patch-dl-handler za-patch-dl-help-null-handler dl\'\'\|patch\'\'
12 z-annex-data: zinit-annex-patch-dl hook:!atpull-20 za-patch-dl-handler za-patch-dl-help-null-handler ''
```

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

```
λ  zinit delete dltest -y

Done (action executed, exit code: 0)

λ  zi for id-as'dltest' as'null' dl'https://raw.githubusercontent.com/junegunn/fzf/master/shell/key-bindings.zsh' nocompile pick'key-bindings.zsh' @zdharma-continuum/null

Downloading zdharma-continuum/null… (at label: dltest…)
Cloning into '/home/jan/.local/share/zinit/plugins/dltest'...
⠙ ███████████ OBJ: 100, PACK: 8/8, COMPR: 100%, REC: 100%
[patch-dl annex]: File key-bindings.zsh downloaded correctly
``` 

(the last line didn't show up before this fix, but I have not verified if this actually loads the right file and so on as I don't use fzf that much)

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
