### PR TITLE
fix: gh-r removes linux32 assets on 64 bit OS

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1516,8 +1516,8 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
       armv5 'arm[?v]5'
       armv6 'arm[?v]6'
       armv7 'armv[?v]7'
-      amd64 '(amd|amd64|x64|x86|x86_64|64bit|)*~*(eabi(hf|)|powerpc|ppc64(le|)|[-_]mips*|aarch64|riscv(64|)|s390x|[-_.]arm*)*'
-      x86_64 '(amd|amd64|x64|x86|x86_64|64bit|)*~*(eabi(hf|)|powerpc|ppc64(le|)|[-_]mips*|aarch64|riscv(64|)|s390x|[-_.]arm*)*'
+      amd64 '(amd|amd64|x64|x86|x86_64|64bit|)*~*(linux32|eabi(hf|)|powerpc|ppc64(le|)|[-_]mips*|aarch64|riscv(64|)|s390x|[-_.]arm*)*'
+      x86_64 '(amd|amd64|x64|x86|x86_64|64bit|)*~*(linux32|eabi(hf|)|powerpc|ppc64(le|)|[-_]mips*|aarch64|riscv(64|)|s390x|[-_.]arm*)*'
       linux "*(linux-musl|musl|linux64|linux)*~^*(linux*${MACHTYPE}|${CPUTYPE}*linux)*"
       linux-android '(apk|android|linux-android)'
       linux-gnu "*(linux-musl|musl|linux)*~^*(${MACHTYPE}|${CPUTYPE}|)*"


### PR DESCRIPTION
Signed-off-by: Vladislav Doster <mvdoster@gmail.com>

## Description <!--- Describe your changes in detail -->



## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

### Before

<img width="824" alt="Screenshot 2022-10-30 at 22 57 46" src="https://user-images.githubusercontent.com/10052309/198928086-b71a0153-8eb2-4f6d-b2d3-ecbab2b99fc6.png">

### After

<img width="792" alt="Screenshot 2022-10-30 at 23 02 49" src="https://user-images.githubusercontent.com/10052309/198928572-6d56d569-45bd-43fd-a929-8936503f07b7.png">

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
