### PR TITLE
Make scheduler be called in 5 seconds interval after no more scheduled tasks

### DIFF
--- a/zinit.zsh
+++ b/zinit.zsh
@@ -2390,7 +2390,7 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
 #      (delay), i.e. "burst" allows to run package installations from
 #      script, not from prompt.
 @zinit-scheduler() {
-    integer ___ret="${${ZINIT[lro-data]%:*}##*:}" \
+    integer ___ret="${${ZINIT[lro-data]%:*}##*:}" ___secs=$(($#ZINIT_TASKS>1?1:10))
             ___secs=$(($#ZINIT_TASKS>1?1:10))
     # lro stands for lastarg-retval-option.
     [[ $1 = following ]] && \

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -2390,10 +2390,14 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
 #      (delay), i.e. "burst" allows to run package installations from
 #      script, not from prompt.
 @zinit-scheduler() {
-    integer ___ret="${${ZINIT[lro-data]%:*}##*:}"
+    integer ___ret="${${ZINIT[lro-data]%:*}##*:}" \
+            ___secs=$(($#ZINIT_TASKS>1?1:10))
     # lro stands for lastarg-retval-option.
-    [[ $1 = following ]] && sched +1 'ZINIT[lro-data]="$_:$?:${options[printexitvalue]}"; @zinit-scheduler following "${ZINIT[lro-data]%:*:*}"'
-    [[ -n $1 && $1 != (following*|burst) ]] && { local THEFD="$1"; zle -F "$THEFD"; exec {THEFD}<&-; }
+    [[ $1 = following ]] && \
+        sched +$___secs 'ZINIT[lro-data]="$_:$?:${options[printexitvalue]}"; @zinit-scheduler following "${ZINIT[lro-data]%:*:*}"'
+    ((___secs==10))&&return 0
+    [[ -n $1 && $1 != (following*|burst) ]] && \
+        { local THEFD="$1"; zle -F "$THEFD"; exec {THEFD}<&-; }
     [[ $1 = burst ]] && local -h EPOCHSECONDS=$(( EPOCHSECONDS+10000 ))
     ZINIT[START_TIME]="${ZINIT[START_TIME]:-$EPOCHREALTIME}"
 

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -2395,7 +2395,7 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
     # lro stands for lastarg-retval-option.
     [[ $1 = following ]] && \
         sched +$___secs 'ZINIT[lro-data]="$_:$?:${options[printexitvalue]}"; @zinit-scheduler following "${ZINIT[lro-data]%:*:*}"'
-    ((___secs==10))&&return 0
+    (( ___secs == 10 )) && return 0
     [[ -n $1 && $1 != (following*|burst) ]] && \
         { local THEFD="$1"; zle -F "$THEFD"; exec {THEFD}<&-; }
     [[ $1 = burst ]] && local -h EPOCHSECONDS=$(( EPOCHSECONDS+10000 ))


### PR DESCRIPTION
## Description

Change the time interval for the scheduler to check for queued tasks to ten seconds.

## Motivation and Context

Lower system resource usage.

## Related Issue(s)

#362

## How Has This Been Tested?

## Types of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
