### PR TITLE
fix: ziextract execs discovery regex

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1880,8 +1880,8 @@ ziextract() {
     execs=( **/*~(._zinit(|/*)|.git(|/*)|.svn(|/*)|.hg(|/*)|._backup(|/*))(DN-.) )
     if [[ ${#execs} -gt 0 && -n $execs ]] {
         execs=( ${(@f)"$( file ${execs[@]} )"} )
-        execs=( "${(M)execs[@]:#[^:]##:*executable*}" )
-        execs=( "${execs[@]/(#b)([^:]##):*/${match[1]}}" )
+        execs=( "${(M)execs[@]:#[^(:]##:*executable*}" )
+        execs=( "${execs[@]/(#b)([^(:]##):*/${match[1]}}" )
     }
 
     builtin print -rl -- ${execs[@]} >! ${TMPDIR:-/tmp}/zinit-execs.$$.lst


### PR DESCRIPTION
Fix regex to disregard `file` output regarding support for different systems.

<img width="1727" alt="Screenshot 2022-11-05 at 01 59 11" src="https://user-images.githubusercontent.com/10052309/200107228-62d91f1c-9e9c-4c3e-963b-414ba2d39682.png">

## Before

<img width="1728" alt="Screenshot 2022-11-05 at 01 58 26" src="https://user-images.githubusercontent.com/10052309/200107227-11903854-5c6d-4b6e-b6ad-82144dd27cc8.png">

## After

<img width="1728" alt="Screenshot 2022-11-05 at 01 57 47" src="https://user-images.githubusercontent.com/10052309/200107226-72533fb7-500d-49d3-846b-104d08cb5c6c.png">

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>