### PR TITLE
feat: add completions ice

### DIFF
--- a/README.md
+++ b/README.md
@@ -734,6 +734,7 @@ You may safely assume a given ice works with both plugins and snippets unless ex
 | :-------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 |    `blockf`     | <div align="justify" style="text-align: justify;">Disallow plugin to modify `fpath`. Useful when a plugin wants to provide completions in traditional way. Zinit can manage completions and plugin can be blocked from exposing them.</div> |
 | `nocompletions` | <div align="justify" style="text-align: justify;">Don't detect, install and manage completions for this plugin. Completions can be installed later with `zinit creinstall {plugin-spec}`.</div>                                             |
+|  `completions`  | <div align="justify" style="text-align: justify;">Do detect, install and manage completions for this plugin. Overwrites `as'null'` or `nocompletions`.</div>                                                                                |
 
 ### Command Execution After Cloning, Updating or Loading<a name="command-execution-after-cloning-updating-or-loading"></a>
 

--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -184,7 +184,7 @@ ____
  
  Downloads snippet
  file – with curl, wget, lftp or lynx,
- directory, with Subversion – when svn-ICE is active. 
+ directory, with Subversion – when svn-ICE is active.
  
  Github supports Subversion protocol and allows to clone subdirectories.
  This is used to provide a layer of support for Oh-My-Zsh and Prezto.

--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -792,7 +792,7 @@ ____
  `#compdef <names ...>'
 ____
 
-Has 549 line(s). Doesn't call other functions.
+Has 573 line(s). Doesn't call other functions.
 
 Uses feature(s): _autoload_, _bindkey_, _compdef_, _compdump_, _eval_, _read_, _setopt_, _unfunction_, _zle_, _zstyle_
 

--- a/doc/zsdoc/zinit.zsh.adoc
+++ b/doc/zsdoc/zinit.zsh.adoc
@@ -1459,7 +1459,7 @@ ____
  `#compdef <names ...>'
 ____
 
-Has 549 line(s). Doesn't call other functions.
+Has 573 line(s). Doesn't call other functions.
 
 Uses feature(s): _autoload_, _bindkey_, _compdef_, _compdump_, _eval_, _read_, _setopt_, _unfunction_, _zle_, _zstyle_
 

--- a/tests/ices.zunit
+++ b/tests/ices.zunit
@@ -50,3 +50,18 @@
   assert $state equals 0
   assert "$ZPLUGINS/test---make/whatever" is_file
 }
+
+@test 'completions' {
+  run zinit as"null" id-as"test/completions" atclone"touch _whatever" completions for zdharma-continuum/null
+  assert $state equals 0
+  assert "$ZPLUGINS/test---completions/_whatever" is_file
+  assert "$ZINIT[COMPLETIONS_DIR]/_whatever" is_file
+}
+
+# If both are given, the completions wins
+@test 'completions-overwrite' {
+  run zinit as"null" id-as"test/completions-overwrite" atclone"touch _whatever2" nocompletions completions for zdharma-continuum/null
+  assert $state equals 0
+  assert "$ZPLUGINS/test---completions-overwrite/_whatever2" is_file
+  assert "$ZINIT[COMPLETIONS_DIR]/_whatever2" is_file
+}

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -500,7 +500,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     # After additional executions like atclone'' - install completions (1 - plugins)
     local -A OPTS
     OPTS[opt_-q,--quiet]=1
-    [[ 0 = ${+ICE[nocompletions]} && ${ICE[as]} != null && ${+ICE[null]} -eq 0 ]] && \
+    [[ (0 = ${+ICE[nocompletions]} && ${ICE[as]} != null && ${+ICE[null]} -eq 0) || 0 != ${+ICE[completions]} ]] && \
         .zinit-install-completions "$id_as" "" "0"
 
     if [[ -e ${TMPDIR:-/tmp}/zinit.skipped_comps.$$.lst || -e ${TMPDIR:-/tmp}/zinit.installed_comps.$$.lst ]] {
@@ -913,7 +913,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 # FUNCTION: .zinit-download-snippet [[[
 # Downloads snippet
 #   file – with curl, wget, lftp or lynx,
-#   directory, with Subversion – when svn-ICE is active. 
+#   directory, with Subversion – when svn-ICE is active.
 #
 #   Github supports Subversion protocol and allows to clone subdirectories.
 #   This is used to provide a layer of support for Oh-My-Zsh and Prezto.
@@ -1339,7 +1339,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     # After additional executions like atclone'' - install completions (2 - snippets)
     local -A OPTS
     OPTS[opt_-q,--quiet]=1
-    [[ 0 = ${+ICE[nocompletions]} && ${ICE[as]} != null && ${+ICE[null]} -eq 0 ]] && \
+    [[ (0 = ${+ICE[nocompletions]} && ${ICE[as]} != null && ${+ICE[null]} -eq 0) || 0 != ${+ICE[completions]} ]] && \
         .zinit-install-completions "%" "$local_dir/$dirname" 0
 
     if [[ -e ${TMPDIR:-/tmp}/zinit.skipped_comps.$$.lst || -e ${TMPDIR:-/tmp}/zinit.installed_comps.$$.lst ]] {

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -69,7 +69,7 @@ fi
 ZINIT[ice-list]="svn|proto|from|teleid|bindmap|cloneopts|id-as|depth|if|wait|load|\
 unload|blockf|pick|bpick|src|as|ver|silent|lucid|notify|mv|cp|\
 atinit|atclone|atload|atpull|nocd|run-atpull|has|cloneonly|make|\
-service|trackbinds|multisrc|compile|nocompile|nocompletions|\
+service|trackbinds|multisrc|compile|nocompile|completions|nocompletions|\
 reset-prompt|wrap|reset|sh|\!sh|bash|\!bash|ksh|\!ksh|csh|\
 \!csh|aliases|countdown|ps-on-unload|ps-on-update|trigger-load|\
 light-mode|is-snippet|atdelete|pack|git|verbose|on-update-of|\


### PR DESCRIPTION

## Description <!--- Describe your changes in detail -->

Adds a new ice called `completions` which, if set, always triggers completion detection and installation.

This can be used to overwrite `as'null'` which would otherwise not trigger completion detection and installation. It would also overwrite a `nocompletions` ice, if both are set, e.g. via using the default ice annex.

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

I use default ice to set `zinit default-ice --quiet as'null' from"gh-r" lbin'!' lucid nocompile` for my list of gh-r downloads. Unfortunately, this disables the import of completions:

To reproduce:

```
zinit default-ice --quiet as'null' from"gh-r" lbin'!' lucid nocompile
# simple jira command line client
zinit lbin'!gj' pick'gj*.tar.gz' atclone'./gj completion zsh > _gj'  atpull'%atclone' for @rsteube/go-jira-cli
zinit clist | grep _gj # -> no _gj completion
```

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples <!--- Provide examples of intended usage -->

Set default ice
```
zinit default-ice --quiet as'null' from"gh-r" lbin'!' lucid nocompile completions
zinit lbin'!gj' pick'gj*.tar.gz' atclone'./gj completion zsh > _gj'  atpull'%atclone' for @rsteube/go-jira-cli
zinit clist | grep _gj # -> a line with _gj completion is shown
```

set empty ice per zinit call
```
zinit default-ice --quiet as'null' from"gh-r" lbin'!' lucid nocompile
zinit lbin'!gj' pick'gj*.tar.gz' atclone'./gj completion zsh > _gj'  completions atpull'%atclone' for @rsteube/go-jira-cli
zinit clist | grep _gj # -> a line with _gj completion is shown
```

I didn't implement setting a pattern for `compilations'whatever'` as this would have complicated the change: it would need to add (or replace) the default pattern which is searched for.

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

I ran the above two versions locally via 

```
λ  rm -rf ~/.local/share/zinit/completions/_gj ; zi delete -y rsteube/go-jira-cli ; exec zsh
linkbin annex: Removed gj soft link

Done (action executed, exit code: 0)

Downloading rsteube/go-jira-cli…
(Requesting `gj_0.2.5_Darwin_x86_64.tar.gz'…)
[...]
ziextract: Unpacking the files from: `gj_0.2.5_Darwin_x86_64.tar.gz'…
ziextract: Successfully extracted and assigned +x chmod to the file: `gj'.
linkbin annex: Created the gj soft link and set +x on the gj binary
gj*.tar.gz null rsteube/go-jira-cli %atclone ./gj completion zsh > _gj gh-r !gj
Installed 1 completions. They are stored in the $INSTALLED_COMPS array.
```

See the last line which shows that the completions were installed.

There are also two new tests which hopefully pass :-)

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
