### PR TITLE
feat: Add {file} formatter

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1880,7 +1880,7 @@ ziextract() {
         command chmod a+x "${execs[@]}"
         if (( !OPTS[opt_-q,--quiet] )) {
             if (( ${#execs} == 1 )); then
-                    +zinit-message "{info}[{pre}ziextract{info}]{rst} Successfully extracted and assigned +x chmod to the file: {obj}${execs[1]}{rst}."
+                    +zinit-message "{info}[{pre}ziextract{info}]{rst} Successfully extracted and assigned +x chmod to the file: {file}${execs[1]}{rst}."
             else
                 local sep="$ZINIT[col-rst],$ZINIT[col-obj] "
                 if (( ${#execs} > 7 )) {

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -164,15 +164,15 @@ if [[ -z $SOURCED && ( ${+terminfo} -eq 1 && -n ${terminfo[colors]} ) || \
         col-id-as   $'\e[4;38;5;220m'    col-version $'\e[3;38;5;87m'
         # The more recent, fresh ones:
         col-pre  $'\e[38;5;135m'  col-msg   $'\e[0m'        col-msg2  $'\e[38;5;172m'
-        col-obj  $'\e[38;5;218m'  col-obj2  $'\e[38;5;118m' col-file  $'\e[3;38;5;117m'
-        col-dir  $'\e[3;38;5;153m' col-func $'\e[38;5;219m'
+        col-obj  $'\e[38;5;218m'  col-obj2  $'\e[38;5;118m' col-file  $'\e[1;3;38;5;208m'
+        col-dir  $'\e[3;38;5;153m' col-func $'\e[38;5;219m' col-ext  $'\e[1;3;38;5;41m'
         col-url  $'\e[38;5;75m'   col-meta  $'\e[38;5;57m'  col-meta2 $'\e[38;5;147m'
         col-data $'\e[38;5;82m'   col-data2 $'\e[38;5;117m' col-hi    $'\e[1m\e[38;5;183m'
         col-var  $'\e[38;5;81m'   col-glob  $'\e[38;5;227m' col-ehi   $'\e[1m\e[38;5;210m'
         col-cmd  $'\e[38;5;82m'   col-ice   $'\e[38;5;39m'  col-nl    $'\n'
         col-txt  $'\e[38;5;254m' col-num  $'\e[3;38;5;155m' col-term  $'\e[38;5;185m'
         col-warn $'\e[38;5;214m' col-ok    $'\e[38;5;220m'  col-time  $'\e[38;5;220m'
-        col-apo $'\e[1;38;5;45m' col-aps $'\e[38;5;117m'
+        col-apo $'\e[1;38;5;45m' col-aps $'\e[38;5;117m'    col-dot $'\e[38;5;220m'
         col-quo $'\e[1;38;5;33m' col-quos    $'\e[1;38;5;160m'
         col-bapo $'\e[1;38;5;220m'  col-baps $'\e[1;38;5;82m'
         col-faint $'\e[38;5;238m' col-opt   $'\e[38;5;219m' col-lhi   $'\e[38;5;81m'
@@ -1936,6 +1936,23 @@ builtin setopt noaliases
     command true # workaround a Zsh bug, see: https://www.zsh.org/mla/workers/2018/msg00966.html
     builtin zle -F "$THEFD" +zinit-deploy-message
 } # ]]]
+
+# FUNCTION: .zinit-formatter-file [[[
+.zinit-formatter-file() {
+    builtin emulate -L zsh -o extendedglob
+    local -a match mbegin mend
+    REPLY=$1
+    if [[ $REPLY = (#b)(*).(*).(*) ]]; then
+        REPLY=$ZINIT[col-file]$match[1]$ZINIT[col-rst]\
+$ZINIT[col-dot].$'\e[1;3;38;5;39m'$match[2]$ZINIT[col-rst]\
+$ZINIT[col-dot].$ZINIT[col-ext]$match[3]
+    elif [[ $REPLY = (#b)(*).(*) ]]; then
+        REPLY=$ZINIT[col-file]$match[1]$ZINIT[col-rst]\
+$ZINIT[col-dot].$ZINIT[col-ext]$match[2]$ZINIT[col-rst]
+    else
+        REPLY=$ZINIT[col-file]$REPLY$ZINIT[col-rst]
+    fi
+}
 
 # FUNCTION: .zinit-formatter-dbg [[[
 .zinit-formatter-dbg() {

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -3293,6 +3293,7 @@ typeset -g REPLY
 
 # a searchable menu of tags for current directory
 zinit null light-mode autoload'zi-browse-symbol' for %$ZINIT[BIN_DIR]
+ZINIT_REGISTERED_PLUGINS[-1]=()
 zle -N zi-browse-symbol
 zle -N zi-browse-symbol-backwards zi-browse-symbol
 zle -N zi-browse-symbol-pbackwards zi-browse-symbol


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->
A new formatter function to allow pretty printing of file names with extension.

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->
I wanted to have extension of a file colorized without complex expressions like `{file}$q:r{ext}$q:e`. The new formatter handles this automatically, via `{file}$q`, and handles up to two extensions with different colors.


## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples <!--- Provide examples of intended usage -->

Before:
![2022-11-09-162249_1911x510_scrot](https://user-images.githubusercontent.com/6049288/200871700-f32385c9-86d4-48d3-9eff-a979d51bddd0.png)

After:
![2022-11-09-162154_1918x538_scrot](https://user-images.githubusercontent.com/6049288/200871609-e0890a42-c54f-408d-92f5-b44b506ff8d0.png)

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->
I've run `checkmake` github release installation and `+zinit-message {file}somefile.tar.gz` function.

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
