### PR TITLE
feat: Themes support +2 new themes `blue` and `gold`.

### DIFF
--- a/share/themes/blue.zsh
+++ b/share/themes/blue.zsh
@@ -1,0 +1,41 @@
+
+# -*- mode: sh; sh-indentation: 4; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# Copyright (c) 2016-2020 Sebastian Gniazdowski and contributors.
+
+ZINIT+=(
+    col-pname   $'\e[1;38;5;27m' col-uname   $'\e[1;38;5;39m'     col-keyword $'\e[27m'
+    col-note    $'\e[38;5;69m'   col-error   $'\e[1;38;5;9m'       col-p       $'\e[38;5;81m'
+    col-info    $'\e[38;5;39m'   col-info2   $'\e[38;5;227m'       col-profile $'\e[38;5;69m'
+    col-uninst  $'\e[38;5;118m'  col-info3   $'\e[1m\e[38;5;227m'  col-slight  $'\e[38;5;230m'
+    col-failure $'\e[38;5;75m'   col-happy   $'\e[1m\e[38;5;39m'   col-annex   $'\e[38;5;33m'
+    col-id-as   $'\e[1;4;38;5;75m'    col-version $'\e[3;38;5;69m'
+    # The more recent, fresh ones:
+    col-pre  $'\e[38;5;27m'   col-msg   $'\e[0m'       col-msg2  $'\e[38;5;174m'
+    col-obj  $'\e[38;5;208m'  col-obj2  $'\e[38;5;69m' col-file  $'\e[3;38;5;41m'
+    col-dir  $'\e[3;38;5;75m' col-func $'\e[38;5;208m'
+    col-url  $'\e[38;5;75m'   col-meta  $'\e[38;5;69m' col-meta2 $'\e[38;5;39m'
+    col-data $'\e[38;5;33m'   col-data2 $'\e[38;5;117m'   col-hi    $'\e[1m\e[38;5;208m'
+    col-var  $'\e[38;5;81m'   col-glob  $'\e[1;38;5;118m' col-ehi   $'\e[1m\e[38;5;208m'
+    col-cmd  $'\e[38;5;39m'   col-ice   $'\e[38;5;39m'    col-nl    $'\n'
+    col-txt  $'\e[38;5;254m'  col-num  $'\e[3;38;5;155m'  col-term  $'\e[38;5;185m'
+    col-warn $'\e[38;5;208m'  col-ok    $'\e[38;5;220m'   col-time  $'\e[38;5;220m'
+    col-apo $'\e[1;38;5;45m'   col-aps $'\e[38;5;117m'
+    col-quo $'\e[1;38;5;33m'   col-quos    $'\e[1;38;5;204m'
+    col-bapo $'\e[1;38;5;208m' col-baps $'\e[1;38;5;39m'
+    col-faint $'\e[38;5;238m'  col-opt   $'\e[1;38;5;75m'   col-lhi   $'\e[38;5;117m'
+    col-flag  $'\e[1;3;38;5;69m' col-pkg $'\e[1;3;38;5;27m'
+    col-tab  $' \t ' col-msg3  $'\e[38;5;238m'  col-b-lhi $'\e[1m\e[38;5;75m'
+    col-bar  $'\e[38;5;39m'  col-th-bar $'\e[38;5;39m'
+    col-…    "${${${(M)LANG:#*UTF-8*}:+…}:-...}"  col-ndsh  "${${${(M)LANG:#*UTF-8*}:+–}:-}"
+    col-mdsh $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+–}:--}"$'\e[0m'
+    col-mmdsh $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+――}:--}"$'\e[0m'
+    col--…   "${${${(M)LANG:#*UTF-8*}:+⋯⋯}:-···}" col-lr    "${${${(M)LANG:#*UTF-8*}:+↔}:-"«-»"}"
+    col-↔    ${${${(M)LANG:#*UTF-8*}:+$'\e[38;5;39m↔\e[0m'}:-$'\e[38;5;39m«-»\e[0m'}
+    col-rst  $'\e[0m'  col-b      $'\e[1m'          col-nb     $'\e[22m'
+    col-u    $'\e[4m'  col-it     $'\e[3m'          col-st     $'\e[9m'
+    col-nu   $'\e[24m' col-nit    $'\e[23m'         col-nst    $'\e[29m'
+    col-bspc $'\b'     col-b-warn $'\e[1;38;5;214m' col-u-warn $'\e[4;38;5;214m'
+    col-bcmd $'\e[38;5;220m'
+ )
+
+# vim: ft=zsh sw=4 ts=4 et foldmarker=[[[,]]] foldmethod=marker

--- a/share/themes/default.zsh
+++ b/share/themes/default.zsh
@@ -1,0 +1,46 @@
+# -*- mode: sh; sh-indentation: 4; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# Copyright (c) 2016-2020 Sebastian Gniazdowski and contributors.
+
+ZINIT+=(
+    # Old colors: 31m
+    col-pname   $'\e[1;4m\e[32m' col-uname   $'\e[1;4m\e[35m'     col-keyword $'\e[32m'
+    col-note    $'\e[38;5;148m'  col-error   $'\e[1;38;5;9m'     col-p       $'\e[38;5;81m'
+    col-info    $'\e[38;5;82m'   col-info2   $'\e[38;5;227m'      col-profile $'\e[38;5;148m'
+    col-uninst  $'\e[38;5;118m'  col-info3   $'\e[1m\e[38;5;227m' col-slight  $'\e[38;5;230m'
+    col-failure $'\e[38;5;204m'  col-happy   $'\e[1m\e[38;5;82m'  col-annex   $'\e[38;5;153m'
+    col-id-as   $'\e[4;38;5;220m' col-version $'\e[3;38;5;87m'
+    # The more recent, fresh ones:
+    col-pre  $'\e[38;5;135m'  col-msg   $'\e[0m'        col-msg2  $'\e[38;5;172m'
+    col-obj  $'\e[38;5;218m'  col-obj2  $'\e[38;5;118m' col-file  $'\e[3;38;5;117m'
+    col-dir  $'\e[3;38;5;153m' col-func $'\e[38;5;219m'
+    col-url  $'\e[38;5;75m'   col-meta  $'\e[38;5;57m'  col-meta2 $'\e[38;5;147m'
+    col-data $'\e[38;5;82m'   col-data2 $'\e[38;5;117m' col-hi    $'\e[1m\e[38;5;183m'
+    col-var  $'\e[38;5;81m'   col-glob  $'\e[38;5;227m' col-ehi   $'\e[1m\e[38;5;210m'
+    col-cmd  $'\e[38;5;82m'   col-ice   $'\e[38;5;39m'  col-nl    $'\n'
+    col-txt  $'\e[38;5;254m' col-num  $'\e[3;38;5;155m' col-term  $'\e[38;5;185m'
+    col-warn $'\e[38;5;208m' col-ok    $'\e[38;5;220m'  col-time  $'\e[38;5;220m'
+    col-apo $'\e[1;38;5;45m' col-aps $'\e[38;5;117m'
+    col-quo $'\e[1;38;5;33m' col-quos    $'\e[1;38;5;160m'
+    col-bapo $'\e[1;38;5;220m' col-baps $'\e[1;38;5;82m'
+    col-faint $'\e[38;5;238m'  col-opt   $'\e[38;5;219m' col-lhi   $'\e[38;5;81m'
+    col-flag  $'\e[1;3;38;5;79m' col-pkg $'\e[1;3;38;5;27m'
+    col-tab  $' \t '             col-msg3  $'\e[38;5;238m' col-b-lhi $'\e[1m\e[38;5;75m'
+    col-bar  $'\e[38;5;82m'      col-th-bar $'\e[38;5;82m'
+    col-…    "${${${(M)LANG:#*UTF-8*}:+…}:-...}"  col-ndsh  "${${${(M)LANG:#*UTF-8*}:+–}:-}"
+    col-mdsh $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+–}:--}"$'\e[0m'
+    col-mmdsh $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+――}:--}"$'\e[0m'
+    col--…   "${${${(M)LANG:#*UTF-8*}:+⋯⋯}:-···}" col-lr    "${${${(M)LANG:#*UTF-8*}:+↔}:-"«-»"}"
+    col-↔    ${${${(M)LANG:#*UTF-8*}:+$'\e[38;5;82m↔\e[0m'}:-$'\e[38;5;82m«-»\e[0m'}
+    col-rst  $'\e[0m'  col-b      $'\e[1m'          col-nb     $'\e[22m'
+    col-u    $'\e[4m'  col-it     $'\e[3m'          col-st     $'\e[9m'
+    col-nu   $'\e[24m' col-nit    $'\e[23m'         col-nst    $'\e[29m'
+    col-bspc $'\b'     col-b-warn $'\e[1;38;5;214m' col-u-warn $'\e[4;38;5;214m'
+    col-bcmd $'\e[38;5;220m'
+)
+if [[ ( ${+terminfo} -eq 1 && ${terminfo[colors]} -ge 256 ) || \
+   ( ${+termcap} -eq 1 && ${termcap[Co]} -ge 256 )
+]] {
+    ZINIT+=( col-pname $'\e[1;4m\e[38;5;39m' col-uname  $'\e[1;4m\e[38;5;207m' )
+}
+
+# vim: ft=zsh sw=4 ts=4 et foldmarker=[[[,]]] foldmethod=marker

--- a/share/themes/gold.zsh
+++ b/share/themes/gold.zsh
@@ -1,0 +1,41 @@
+# -*- mode: sh; sh-indentation: 4; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# Copyright (c) 2016-2020 Sebastian Gniazdowski and contributors.
+
+# Different shades of gold/yellow (220):
+ZINIT+=(
+    col-pname   $'\e[1;38;5;220m' col-uname   $'\e[1;38;5;178m'  col-keyword $'\e[137m'
+    col-note    $'\e[38;5;220m'   col-error   $'\e[1m\e[38;5;9m' col-p       $'\e[38;5;81m'
+    col-info    $'\e[38;5;178m'   col-info2   $'\e[38;5;227m'    col-profile $'\e[38;5;220m'
+    col-uninst  $'\e[38;5;118m'   col-info3   $'\e[1m\e[38;5;227m'  col-slight  $'\e[38;5;230m'
+    col-failure $'\e[38;5;204m'   col-happy   $'\e[1m\e[38;5;178m' col-annex   $'\e[38;5;33m'
+    col-id-as   $'\e[1;4;38;5;130m'    col-version $'\e[3;38;5;220m'
+    # The more recent, fresh ones:
+    col-pre  $'\e[38;5;41m'    col-msg   $'\e[0m'        col-msg2  $'\e[38;5;174m'
+    col-obj  $'\e[38;5;178m'   col-obj2  $'\e[38;5;220m' col-file  $'\e[3;38;5;41m'
+    col-dir  $'\e[3;38;5;204m' col-func $'\e[38;5;208m'
+    col-url  $'\e[38;5;130m'   col-meta  $'\e[38;5;220m' col-meta2 $'\e[38;5;178m'
+    col-data $'\e[38;5;33m'    col-data2 $'\e[38;5;117m' col-hi    $'\e[1m\e[38;5;208m'
+    col-var  $'\e[38;5;81m'    col-glob  $'\e[1;38;5;118m' col-ehi   $'\e[1m\e[38;5;208m'
+    col-cmd  $'\e[38;5;178m'    col-ice   $'\e[38;5;178m'  col-nl    $'\n'
+    col-txt  $'\e[38;5;254m'   col-num  $'\e[3;38;5;155m'  col-term  $'\e[38;5;185m'
+    col-warn $'\e[38;5;204m'   col-ok    $'\e[38;5;220m'   col-time  $'\e[38;5;220m'
+    col-apo $'\e[1;38;5;130m'  col-aps $'\e[38;5;117m'
+    col-quo $'\e[1;38;5;33m'   col-quos    $'\e[1;38;5;204m'
+    col-bapo $'\e[1;38;5;208m' col-baps $'\e[1;38;5;178m'
+    col-faint $'\e[38;5;238m'  col-opt   $'\e[1;38;5;130m' col-lhi   $'\e[38;5;117m'
+    col-flag  $'\e[1;3;38;5;220m' col-pkg $'\e[1;3;38;5;137m'
+    col-tab  $' \t '            col-msg3  $'\e[38;5;238m'  col-b-lhi $'\e[1m\e[38;5;75m'
+    col-bar  $'\e[38;5;178m'    col-th-bar $'\e[38;5;178m'
+    col-…    "${${${(M)LANG:#*UTF-8*}:+…}:-...}"  col-ndsh  "${${${(M)LANG:#*UTF-8*}:+–}:-}"
+    col-mdsh $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+–}:--}"$'\e[0m'
+    col-mmdsh $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+――}:--}"$'\e[0m'
+    col--…   "${${${(M)LANG:#*UTF-8*}:+⋯⋯}:-···}" col-lr    "${${${(M)LANG:#*UTF-8*}:+↔}:-"«-»"}"
+    col-↔    ${${${(M)LANG:#*UTF-8*}:+$'\e[38;5;178m↔\e[0m'}:-$'\e[38;5;178m«-»\e[0m'}
+    col-rst  $'\e[0m'        col-b     $'\e[1m'        col-nb     $'\e[22m'
+    col-u    $'\e[4m'        col-it    $'\e[3m'        col-st     $'\e[9m'
+    col-nu   $'\e[24m'       col-nit   $'\e[23m'       col-nst    $'\e[29m'
+    col-bspc $'\b'        col-b-warn $'\e[1;38;5;214m' col-u-warn $'\e[4;38;5;214m'
+    col-bcmd $'\e[38;5;220m'
+ )
+
+# vim: ft=zsh sw=4 ts=4 et foldmarker=[[[,]]] foldmethod=marker

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1731,7 +1731,7 @@ ziextract() {
     .zinit-extract-wrapper() {
         local file="$1" fun="$2" retval
         (( !OPTS[opt_-q,--quiet] )) && \
-            +zinit-message "{info}[{pre}ziextract{info}]{rst} Unpacking the files from: \`{obj}$file{msg}'{…}{rst}"
+            +zinit-message "{info}[{pre}ziextract{info}]{rst} Unpacking the files from: \`{file}$file{msg}'{…}"
         $fun; retval=$?
         if (( retval == 0 )) {
             local -a files
@@ -1880,7 +1880,7 @@ ziextract() {
         command chmod a+x "${execs[@]}"
         if (( !OPTS[opt_-q,--quiet] )) {
             if (( ${#execs} == 1 )); then
-                    +zinit-message "{info}[{pre}ziextract{info}]{rst} Successfully extracted and assigned +x chmod to the file: {obj}${execs[1]}{rst}."
+                    +zinit-message "{info}[{pre}ziextract{info}]{rst} Successfully extracted and assigned +x chmod to the file: {file}${execs[1]}{rst}."
             else
                 local sep="$ZINIT[col-rst],$ZINIT[col-obj] "
                 if (( ${#execs} > 7 )) {

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -26,7 +26,7 @@ unset ZPLGM
 ZINIT[ZERO]="${ZERO:-${${0:#$ZSH_ARGZERO}:-${(%):-%N}}}"
 [[ ! -o functionargzero || ${options[posixargzero]} = on || ${ZINIT[ZERO]} != */* ]] && ZINIT[ZERO]="${(%):-%N}"
 
-: ${ZINIT[BIN_DIR]:="${ZINIT[ZERO]:h}"}
+: ${ZINIT[BIN_DIR]:=${ZINIT[ZERO]:h}}
 [[ ${ZINIT[BIN_DIR]} = \~* ]] && ZINIT[BIN_DIR]=${~ZINIT[BIN_DIR]}
 
 # Make ZINIT[BIN_DIR] path absolute.
@@ -136,6 +136,8 @@ typeset -g ZPFX
 : ${ZPFX:=${ZINIT[HOME_DIR]}/polaris}
 : ${ZINIT[ALIASES_OPT]::=${${options[aliases]:#off}:+1}}
 : ${ZINIT[MAN_DIR]:=${ZPFX}/man}
+: ${ZINIT[THEME_DIR]:=$ZINIT[BIN_DIR]/share/themes}
+: ${ZITHEME:=default}
 
 ZINIT[PLUGINS_DIR]=${~ZINIT[PLUGINS_DIR]}   ZINIT[COMPLETIONS_DIR]=${~ZINIT[COMPLETIONS_DIR]}
 ZINIT[SNIPPETS_DIR]=${~ZINIT[SNIPPETS_DIR]} ZINIT[SERVICES_DIR]=${~ZINIT[SERVICES_DIR]}
@@ -192,47 +194,8 @@ zmodload zsh/termcap 2>/dev/null
 if [[ -z $SOURCED && ( ${+terminfo} -eq 1 && -n ${terminfo[colors]} ) || \
       ( ${+termcap} -eq 1 && -n ${termcap[Co]} )
 ]] {
-    ZINIT+=(
-        # Old colors: 31m
-        col-pname   $'\e[1;4m\e[32m'     col-uname   $'\e[1;4m\e[35m'     col-keyword $'\e[32m'
-        col-note    $'\e[38;5;148m'       col-error   $'\e[1m\e[38;5;204m' col-p       $'\e[38;5;81m'
-        col-info    $'\e[38;5;82m'       col-info2   $'\e[38;5;227m'      col-profile $'\e[38;5;148m'
-        col-uninst  $'\e[38;5;118m'      col-info3   $'\e[1m\e[38;5;227m' col-slight  $'\e[38;5;230m'
-        col-failure $'\e[38;5;204m'      col-happy   $'\e[1m\e[38;5;82m'  col-annex   $'\e[38;5;153m'
-        col-id-as   $'\e[4;38;5;220m'    col-version $'\e[3;38;5;87m'
-        # The more recent, fresh ones:
-        col-pre  $'\e[38;5;135m'  col-msg   $'\e[0m'        col-msg2  $'\e[38;5;172m'
-        col-obj  $'\e[38;5;218m'  col-obj2  $'\e[38;5;118m' col-file  $'\e[3;38;5;117m'
-        col-dir  $'\e[3;38;5;153m' col-func $'\e[38;5;219m'
-        col-url  $'\e[38;5;75m'   col-meta  $'\e[38;5;57m'  col-meta2 $'\e[38;5;147m'
-        col-data $'\e[38;5;82m'   col-data2 $'\e[38;5;117m' col-hi    $'\e[1m\e[38;5;183m'
-        col-var  $'\e[38;5;81m'   col-glob  $'\e[38;5;227m' col-ehi   $'\e[1m\e[38;5;210m'
-        col-cmd  $'\e[38;5;82m'   col-ice   $'\e[38;5;39m'  col-nl    $'\n'
-        col-txt  $'\e[38;5;254m' col-num  $'\e[3;38;5;155m' col-term  $'\e[38;5;185m'
-        col-warn $'\e[38;5;214m' col-ok    $'\e[38;5;220m'  col-time  $'\e[38;5;220m'
-        col-apo $'\e[1;38;5;45m' col-aps $'\e[38;5;117m'
-        col-quo $'\e[1;38;5;33m' col-quos    $'\e[1;38;5;160m'
-        col-bapo $'\e[1;38;5;220m'  col-baps $'\e[1;38;5;82m'
-        col-faint $'\e[38;5;238m' col-opt   $'\e[38;5;219m' col-lhi   $'\e[38;5;81m'
-        col-flag  $'\e[1;3;38;5;79m' col-pkg $'\e[1;3;38;5;27m'
-        col-tab  $' \t '            col-msg3  $'\e[38;5;238m' col-b-lhi $'\e[1m\e[38;5;75m'
-        col-bar  $'\e[38;5;82m'  col-th-bar $'\e[38;5;82m'
-        col-…    "${${${(M)LANG:#*UTF-8*}:+…}:-...}"  col-ndsh  "${${${(M)LANG:#*UTF-8*}:+–}:-}"
-        col-mdsh $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+–}:--}"$'\e[0m'
-        col-mmdsh $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+――}:--}"$'\e[0m'
-        col--…   "${${${(M)LANG:#*UTF-8*}:+⋯⋯}:-···}" col-lr    "${${${(M)LANG:#*UTF-8*}:+↔}:-"«-»"}"
-        col-↔    ${${${(M)LANG:#*UTF-8*}:+$'\e[38;5;82m↔\e[0m'}:-$'\e[38;5;82m«-»\e[0m'}
-        col-rst  $'\e[0m'        col-b     $'\e[1m'        col-nb     $'\e[22m'
-        col-u    $'\e[4m'        col-it    $'\e[3m'        col-st     $'\e[9m'
-        col-nu   $'\e[24m'       col-nit   $'\e[23m'       col-nst    $'\e[29m'
-        col-bspc $'\b'        col-b-warn $'\e[1;38;5;214m' col-u-warn $'\e[4;38;5;214m'
-        col-bcmd $'\e[38;5;220m'
-    )
-    if [[ ( ${+terminfo} -eq 1 && ${terminfo[colors]} -ge 256 ) || \
-          ( ${+termcap} -eq 1 && ${termcap[Co]} -ge 256 )
-    ]] {
-        ZINIT+=( col-pname $'\e[1;4m\e[38;5;39m' col-uname  $'\e[1;4m\e[38;5;207m' )
-    }
+        [[ -f $ZINIT[THEME_DIR]/$ZITHEME.zsh ]] && \
+            source $ZINIT[THEME_DIR]/$ZITHEME.zsh
 }
 
 # Hooks


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->
I thought it would be good to support different color themes. 
## Motivation and Context <!--- Why is this change required? What problem does it solve? -->
The function `+zinit-message` allows easy theming via the `col-file`, etc.  ZINIT hash fields. I've extracted the block of code that assigns them into a separate file `share/themes/default.zsh` and added two new files: `…/blue.zsh` with a new, different blue shades color setting and  `…/gold.zsh`, different gold shades color setting.

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples <!--- Provide examples of intended usage -->

```zsh
ZITHEME=blue
…… sourcing of zinit.zsh ……
```

With `gold` theme:

![the-2022-12-24-101926_1894x356_scrot](https://user-images.githubusercontent.com/6049288/209429874-be0da0c0-181f-41ac-bcab-c7ccfbb9e725.png)

With `blue` theme:

![2022-12-24-102347_1893x354_scrot](https://user-images.githubusercontent.com/6049288/209429590-fafdb0a1-49aa-4329-ace2-578240b862ed.png)

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
