### PR TITLE
fix: broken symbolic link after `creinstall .`

### DIFF
--- a/tests/plugins.zunit
+++ b/tests/plugins.zunit
@@ -37,6 +37,12 @@
   local vim="$ZBIN/vim"; assert $vim is_executable
   $vim --version; assert $state equals 0
 }
+@test 'zsh-completions' {
+  run zinit light-mode for zsh-users/zsh-completions
+  zinit cd zsh-users/zsh-completions
+  run zinit creinstall -q .; assert $state equals 0
+  local broken_completions=($(echo "$ZINIT[COMPLETIONS_DIR]"/*(-@))); assert "${#broken_completions[@]}" equals 0
+}
 # @test 'zsh_bin' {
 #   run zinit as'null' sbin'bin/zsh' for @romkatv/zsh-bin
 #   assert $state equals 0

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -563,7 +563,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     # Symlink completions if they are not already there
     # either as completions (_fname) or as backups (fname)
     # OR - if its a reinstall
-    for c in "${completions[@]}"; do
+    for c in "${completions[@]:A}"; do
         cfile="${c:t}"
         bkpfile="${cfile#_}"
         if [[ ( -z ${already_symlinked[(r)*/$cfile]} || $reinstall = 1 ) &&


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->

Run `creinstall .` in the `﻿zsh-users/zsh-completions` plugin folder manually, then the symbolic links in the completions folder are broken.

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

I found this issue when running `zinit update` with the following minimal setup.

```zsh
zinit wait lucid light-mode for
  blockf atpull'zinit creinstall -q .' \
    zsh-users/zsh-completions
```

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples <!--- Provide examples of intended usage -->

```zsh
$ find ~/.local/share/zinit/completions -xtype l | wc -l # no broken symbolic links before creinstall
0
$ pwd
~/.local/share/zinit/plugins/zsh-users---zsh-completions
$ zinit creinstall -q .
Installed 139 completions. They are stored in the $INSTALLED_COMPS array.
$ find ~/.local/share/zinit/completions -xtype l | wc -l # count broken symbolic links
139
$ ls -l ~/.local/share/zinit/completions
total 560
lrwxrwxrwx 1 miles miles 11 Jan  7 11:14 _afew -> ./src/_afew # broken symbolic link due to relative path
...
```

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
