### PR TITLE
Fix to filter by CPU first

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1524,7 +1524,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
       +zinit-message "{info}[{pre}ziextract{info}]{error} Unsupported CPU: {obj}$_cpu{rst}"
       ;;
   esac
-  echo "${_sys};${_cpu};${_os}"
+  echo "${_cpu};${_sys};${_os}"
 } # ]]]
 # FUNCTION: .zinit-get-latest-gh-r-url-part [[[
 # Gets version string of latest release of given Github


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->

Fixed #456

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

before

```zsh
Downloading BurntSushi/ripgrep…
[gh-r] filters -> (unknown-|)linux-gnu (amd64|x86_64|x64) Linux
[gh-r] filter -> (unknown-|)linux-gnu
 - /BurntSushi/ripgrep/releases/download/13.0.0/ripgrep-13.0.0-arm-unknown-linux-gnueabihf.tar.gz

[gh-r] filter -> (amd64|x86_64|x64)
 - /BurntSushi/ripgrep/releases/download/13.0.0/ripgrep-13.0.0-arm-unknown-linux-gnueabihf.tar.gz

[gh-r] filter -> Linux
 - /BurntSushi/ripgrep/releases/download/13.0.0/ripgrep-13.0.0-arm-unknown-linux-gnueabihf.tar.gz

(Requesting `ripgrep-13.0.0-arm-unknown-linux-gnueabihf.tar.gz'…)
############################################################################################################################################################################### 100.0%
[ziextract] Unpacking the files from: `ripgrep-13.0.0-arm-unknown-linux-gnueabihf.tar.gz'…
[ziextract] Successfully extracted and assigned +x chmod to the file: ripgrep-13.0.0-arm-unknown-linux-gnueabihf/rg.
'ripgrep-13.0.0-arm-unknown-linux-gnueabihf/complete/_rg' -> '_rg'
Installed 2 completions. They are stored in the $INSTALLED_COMPS array.
```

after

```zsh
Downloading BurntSushi/ripgrep…
[gh-r] filters -> (amd64|x86_64|x64) (unknown-|)linux-gnu Linux
[gh-r] filter -> (amd64|x86_64|x64)
 - /BurntSushi/ripgrep/releases/download/13.0.0/ripgrep-13.0.0-x86_64-apple-darwin.tar.gz
 - /BurntSushi/ripgrep/releases/download/13.0.0/ripgrep-13.0.0-x86_64-pc-windows-gnu.zip
 - /BurntSushi/ripgrep/releases/download/13.0.0/ripgrep-13.0.0-x86_64-pc-windows-msvc.zip
 - /BurntSushi/ripgrep/releases/download/13.0.0/ripgrep-13.0.0-x86_64-unknown-linux-musl.tar.gz

[gh-r] filter -> (unknown-|)linux-gnu
 - /BurntSushi/ripgrep/releases/download/13.0.0/ripgrep-13.0.0-x86_64-apple-darwin.tar.gz
 - /BurntSushi/ripgrep/releases/download/13.0.0/ripgrep-13.0.0-x86_64-pc-windows-gnu.zip
 - /BurntSushi/ripgrep/releases/download/13.0.0/ripgrep-13.0.0-x86_64-pc-windows-msvc.zip
 - /BurntSushi/ripgrep/releases/download/13.0.0/ripgrep-13.0.0-x86_64-unknown-linux-musl.tar.gz

[gh-r] filter -> Linux
 - /BurntSushi/ripgrep/releases/download/13.0.0/ripgrep-13.0.0-x86_64-unknown-linux-musl.tar.gz

(Requesting `ripgrep-13.0.0-x86_64-unknown-linux-musl.tar.gz'…)
############################################################################################################################################################################### 100.0%
[ziextract] Unpacking the files from: `ripgrep-13.0.0-x86_64-unknown-linux-musl.tar.gz'…
[ziextract] Successfully extracted and assigned +x chmod to the file: ripgrep-13.0.0-x86_64-unknown-linux-musl/rg.
'ripgrep-13.0.0-x86_64-unknown-linux-musl/complete/_rg' -> '_rg'
Installed 2 completions. They are stored in the $INSTALLED_COMPS array.
```


## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
