### PR TITLE
fix: assign to functions hash to make %x work

### DIFF
--- a/zinit.zsh
+++ b/zinit.zsh
@@ -395,11 +395,11 @@ builtin setopt noaliases
                         retval=$?
                     }
                 } else {
-                    eval "function ${(q)func} {
+                    functions[$func]="
                         local -a fpath
                         fpath=( ${(qqq)PLUGIN_DIR} ${(qqq@)fpath_elements} ${(qqq@)fpath} )
                         builtin autoload -X ${(j: :)${(q-)opts[@]}}
-                    }"
+                    "
                     retval=$?
                 }
             else


### PR DESCRIPTION
The useful %x prompt expansion can be used to get path to the executed script: `0=${(%):-%x}`

<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->

It is always the correct, expected value, even for autoloaded functions. However, it currently doesn't work with Zinit special fpath-pollution free autoload. This patch fixes this.

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->
It is comfortable to get correct `$0` even for autoloaded functions with:
```zsh
0=${(%):-%x}
```

However to make it fully work under Zinit, it has to define its emulated autoload function with:

```zsh
functions[func]="…"
```
instead of:
```zsh
eval "function func { …"
```
because the eval method returns wrong path at first function execution (returns path to `name.plugin.zsh` instead). That's the change of this PR.

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->
The change has to work, it's very isolated.

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
