### PR TITLE
feat: call make uninstall when removing a plugin/snippet

### DIFF
--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -1698,6 +1698,17 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
 } # ]]]
 # FUNCTION: .zinit-run-delete-hooks [[[
 .zinit-run-delete-hooks() {
+    # Call make uninstall if it's available
+    local make_path=$5/Makefile mfest_path=$5/_build-zinit/install_manifest.txt
+    [[ -f $make_path ]] && \
+        grep '^uninstall:' $make_path &>/dev/null && \
+        { +zinit-message {pre}Running {cmd}make uninstall{pre}{…}
+            make -C "$make_path:h" uninstall;}
+    [[ -f $mfest_path ]] && \
+        { +zinit-message {pre}Removing files from:{file} \
+            $mfest_path:t{pre}{…}
+            command xargs rm -f <$mfest_path
+        }
     if [[ -n ${ICE[atdelete]} ]]; then
         .zinit-countdown "atdelete" && ( (( ${+ICE[nocd]} == 0 )) && \
                 { builtin cd -q "$5" && eval "${ICE[atdelete]}"; ((1)); } || \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description <!--- Describe your changes in detail -->
If the `uninstall` target is there in the `Makefile` of the removed plugin/snippet, it'll be run as: `make -C {plugin/snippet dir} uninstall` before removing the dir (with `zinit delete`).

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

@vladdoster mentioned (#333) that `--prefix=$ZPFX` installed plugins aren't cleaned up lik `--prefix=$PWD` ones, so I added `make uninstall` support.


## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

#333 

## Usage examples <!--- Provide examples of intended usage -->

```zsh
# Will first uninstall ctags from the --prefix=($ZPFX,$PWD,etc.) path
zinit delete -y unversal-ctags/ctags
```
![2023-01-29-122000_1901x884_scrot](https://user-images.githubusercontent.com/6049288/215323128-34647ae8-f301-44aa-9310-dd5f8c89963d.png)

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
