### PR TITLE
fix: use correct return code in zinit-confirm

### DIFF
--- a/doc/zsdoc/zinit-autoload.zsh.adoc
+++ b/doc/zsdoc/zinit-autoload.zsh.adoc
@@ -391,7 +391,7 @@ ____
  $2 - expression
 ____
 
-Has 18 line(s). Calls functions:
+Has 17 line(s). Calls functions:
 
  .zinit-confirm
  `-- zinit.zsh/+zinit-message

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -2829,18 +2829,17 @@ builtin print -Pr \"\$ZINIT[col-obj]Done (with the exit code: \$_retval).%f%b\""
 # $1 - question
 # $2 - expression
 .zinit-confirm() {
+    integer retval
     if (( OPTS[opt_-y,--yes] )); then
-        integer retval
         builtin eval "${2}"; retval=$?
-        (( OPTS[opt_-q,--quiet] )) || +zinit-message -lrP "{log-msg} Action executed (exit code: {num}${?}{rst})"
+        (( OPTS[opt_-q,--quiet] )) || +zinit-message -lrP "{log-msg} Action executed (exit code: {num}${retval}{rst})"
     else
       local choice prompt
-      builtin print -D -v prompt "$(+zinit-message '{log-info} Press [{opt}Y{rst}/{opt}y{rst}] to continue: ')"
+      builtin print -D -v prompt "$(+zinit-message '{log-info} Press [{opt}Y{rst}/{opt}y{rst}] to continue: {nl}')"
       +zinit-message "${1}"
       if builtin read -qs "choice?${prompt}"; then
-        builtin print
-        builtin eval "${2}"
-        +zinit-message "{log-msg} Action executed (exit code: {num}${?}{rst})"
+        builtin eval "${2}"; retval=$?
+        +zinit-message "{log-msg} Action executed (exit code: {num}${retval}{rst})"
         return 0
       else
         +zinit-message "{log-msg} No action executed ('{opt}${choice}{rst}' not 'Y' or 'y')"


### PR DESCRIPTION
Fix bug introduced in #474

### before

<img width="767" alt="Screenshot 2023-02-12 at 19 03 50" src="https://user-images.githubusercontent.com/10052309/218348988-9a33d248-16de-4dfa-a8a5-a8aa04b0bfc2.png">

### after

<img width="637" alt="Screenshot 2023-02-12 at 19 01 43" src="https://user-images.githubusercontent.com/10052309/218348889-fe7ca558-5d28-4b90-bee8-429f15ea981e.png">

Signed-off-by: Vladislav Doster <mvdoster@gmail.com>