### PR TITLE
fix: make `gh-r` release version search case-insensitive

### DIFF
--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -454,7 +454,7 @@ ____
  $2 - plugin
 ____
 
-Has 215 line(s). Calls functions:
+Has 214 line(s). Calls functions:
 
  .zinit-setup-plugin-dir
  |-- ziextract

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -357,8 +357,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
         if [[ $site = */releases ]] {
             local tag_version=${ICE[ver]}
             if [[ -z $tag_version ]]; then
-                tag_version="$( { .zinit-download-file-stdout $site/latest || .zinit-download-file-stdout $site/latest 1; } 2>/dev/null | \
-                                  command grep -m1 -o 'href=./'$user'/'$plugin'/releases/tag/[^"]\+')"
+                tag_version="$({.zinit-download-file-stdout $site/latest || .zinit-download-file-stdout $site/latest 1;} 2>/dev/null | command grep -i -m 1 -o 'href=./'$user'/'$plugin'/releases/tag/[^"]\+')"
                 tag_version=${tag_version##*/}
             fi
             local url=$site/expanded_assets/$tag_version
@@ -1548,7 +1547,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
   else
     local url=https://$urlpart
   fi
-  init_list=( ${(@f)"$( { .zinit-download-file-stdout $url || .zinit-download-file-stdout $url 1; } 2>/dev/null | command grep -o 'href=./'$user'/'$plugin'/releases/download/[^"]\+')"} )
+  init_list=( ${(@f)"$( { .zinit-download-file-stdout $url || .zinit-download-file-stdout $url 1; } 2>/dev/null | command grep -i -o 'href=./'$user'/'$plugin'/releases/download/[^"]\+')"} )
   init_list=(${init_list[@]#href=?})
   bpicks=(${(s.;.)ICE[bpick]})
   [[ -z $bpicks ]] && bpicks=("")


### PR DESCRIPTION
## Description <!--- Describe your changes in detail -->

Make `grep` search case-insensitive requirement when using the `gh-r` ice.

### before

<img width="404" alt="Screenshot 2023-02-21 at 07 25 59" src="https://user-images.githubusercontent.com/10052309/220357104-5f952ff0-8b89-47ae-8606-efd598542b05.png">

### after

<img width="1312" alt="Screenshot 2023-02-21 at 07 26 15" src="https://user-images.githubusercontent.com/10052309/220357162-1644ec21-307a-4a1a-a1f0-e7c7c1ef25bc.png">
 
## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

Closes #476

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.