### PR TITLE
fix: the starship example does not work properly

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,9 +210,12 @@ zinit ice pick"async.zsh" src"pure.zsh" # with zsh-async library that's bundled 
 zinit light sindresorhus/pure
 
 # Load starship theme
-zinit ice as"command" from"gh-r" \ # `starship` binary as command, from github release
-          atclone"./starship init zsh > init.zsh; ./starship completions zsh > _starship" \ # starship setup at clone(create init.zsh, completion)
-          atpull"%atclone" src"init.zsh" # pull behavior same as clone, source init.zsh
+# line 1: `starship` binary as command, from github release
+# line 2: starship setup at clone(create init.zsh, completion)
+# line 3: pull behavior same as clone, source init.zsh
+zinit ice as"command" from"gh-r" \
+          atclone"./starship init zsh > init.zsh; ./starship completions zsh > _starship" \
+          atpull"%atclone" src"init.zsh"
 zinit light starship/starship
 ```
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
The error may be caused by the space after the backslash, and `sh` requires that the character after the backslash should be `\n` to be regarded as a continuation line

> A backslash preserves the literal meaning of the following	character, with the exception of the newline character	(`\n'). A backslash preceding a newline is treated as a line continuation.

refer to https://man.freebsd.org/cgi/man.cgi?query=sh

## Description <!--- Describe your changes in detail -->
Fixed wrong starship example in `README.md`

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->
This PR addresses the unfixed issues raised by https://github.com/zdharma-continuum/zinit/issues/271, and makes the starship example work fine

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->
https://github.com/zdharma-continuum/zinit/issues/271

## Usage examples <!--- Provide examples of intended usage -->
Same as the original usage

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
