### PR TITLE
fix: pin `ggsrun` version in gh-r z-unit test

### DIFF
--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -231,7 +231,7 @@
   $gf --version; assert $state equals 0
 }
 @test 'ggsrun' { # This is a CLI tool to execute Google Apps Script (GAS) at own terminal on local PC. Also this CLI tool can be used for managing files in Google Drive for OAuth2 and Service Account
-  run zinit lbin'!* -> ggsrun' for @tanaikech/ggsrun; assert $state equals 0
+  run zinit lbin'!* -> ggsrun' ver'v2.0.0' for @tanaikech/ggsrun; assert $state equals 0
   local git_sizer="$ZBIN/ggsrun"; assert "$git_sizer" is_executable
   $git_sizer --version; assert $state equals 0
 }


### PR DESCRIPTION
Latest version `[v2.0.1](https://github.com/tanaikech/ggsrun/releases/tag/v2.0.1)` has no assets.

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
