### PR TITLE
fix: update `pygmentize` flags in glance subcommand

### DIFF
--- a/doc/zsdoc/zinit-autoload.zsh.adoc
+++ b/doc/zsdoc/zinit-autoload.zsh.adoc
@@ -765,6 +765,7 @@ Has 39 line(s). Calls functions:
  .zinit-glance
  |-- zinit-side.zsh/.zinit-exists-physically-message
  |-- zinit-side.zsh/.zinit-first
+ |-- zinit.zsh/+zinit-message
  `-- zinit.zsh/.zinit-any-to-user-plugin
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).

--- a/doc/zsdoc/zinit.zsh.adoc
+++ b/doc/zsdoc/zinit.zsh.adoc
@@ -189,6 +189,7 @@ Called by:
  zinit-autoload.zsh/.zinit-cd
  zinit-autoload.zsh/.zinit-confirm
  zinit-autoload.zsh/.zinit-delete
+ zinit-autoload.zsh/.zinit-glance
  zinit-autoload.zsh/.zinit-self-update
  zinit-autoload.zsh/.zinit-show-zstatus
  zinit-autoload.zsh/.zinit-uninstall-completions

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -3048,7 +3048,7 @@ EOF
     .zinit-exists-physically-message "$user" "$plugin" || return 1
 
     .zinit-first "$1" "$2" || {
-        builtin print "${ZINIT[col-error]}No source file found, cannot glance${ZINIT[col-rst]}"
+       +zinit-message '{log-err} No source file found, cannot glance'
         return 1
     }
 
@@ -3059,17 +3059,17 @@ EOF
 
     {
         if (( ${+commands[pygmentize]} )); then
-            builtin print "Glancing with ${ZINIT[col-info]}pygmentize${ZINIT[col-rst]}"
-            pygmentize -l bash -g "$fname"
+            +zinit-message "{log-info} Inspecting via {cmd}pygmentize{rst}"
+            pygmentize -l 'bash' "$fname"
         elif (( ${+commands[highlight]} )); then
-            builtin print "Glancing with ${ZINIT[col-info]}highlight${ZINIT[col-rst]}"
+            +zinit-message "{log-info} Inspecting via {cmd}highlight{rst}"
             if (( has_256_colors )); then
-                highlight -q --force -S sh -O xterm256 "$fname"
+                highlight --force --output-format xterm256 --quiet --syntax sh "$fname"
             else
-                highlight -q --force -S sh -O ansi "$fname"
+                highlight --force --output-format ansi --quiet --syntax sh "$fname"
             fi
         elif (( ${+commands[source-highlight]} )); then
-            builtin print "Glancing with ${ZINIT[col-info]}source-highlight${ZINIT[col-rst]}"
+            +zinit-message "{log-info} Inspecting via {cmd}source-highlight{rst}"
             source-highlight -fesc --failsafe -s zsh -o STDOUT -i "$fname"
         else
             cat "$fname"


### PR DESCRIPTION
## Description <!--- Describe your changes in detail -->

- Update set of options that are passed to Pygmentizea 
- Use consistent logging style
- Use long flags to improve grokability

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

The `glances` subcommand works again.

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

<img width="567" alt="Screenshot 2023-03-25 at 23 24 06" src="https://user-images.githubusercontent.com/10052309/227755593-fc7df805-12f7-4714-9aed-9743bacf9144.png">

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.