### PR TITLE
[DNM] feat: delete multiple plugins at once

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,4 +1,5 @@
 ci/cd: ['.github/**/*']
+completion: ['_zinit']
 docker: ['docker/*']
 docs: ['*.md', 'doc/**/*']
 scripts: ['scripts/*']

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -61,6 +61,9 @@ jobs:
       - name: "annexes"
         run: zunit run tests/annexes.zunit
 
+      - name: "commands"
+        run: zunit run tests/commands.zunit
+
       - name: "gh-r"
         run: zunit run --fail-fast --verbose tests/gh-r.zunit
 

--- a/doc/zsdoc/zinit-autoload.zsh.adoc
+++ b/doc/zsdoc/zinit-autoload.zsh.adoc
@@ -438,7 +438,7 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 103 line(s). Calls functions:
+Has 105 line(s). Calls functions:
 
  .zinit-delete
  `-- zinit.zsh/+zinit-message

--- a/doc/zsdoc/zinit-autoload.zsh.adoc
+++ b/doc/zsdoc/zinit-autoload.zsh.adoc
@@ -52,6 +52,7 @@ FUNCTIONS
  .zinit-module
  .zinit-pager
  .zinit-prepare-readlink
+ .zinit-prompt
  .zinit-recall
  .zinit-recently
  .zinit-restore-extendedglob
@@ -398,9 +399,7 @@ Has 17 line(s). Calls functions:
 
 Uses feature(s): _eval_, _read_
 
-Called by:
-
- .zinit-delete
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-create
 ~~~~~~~~~~~~~
@@ -439,18 +438,16 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 99 line(s). Calls functions:
+Has 103 line(s). Calls functions:
 
  .zinit-delete
- |-- zinit-side.zsh/.zinit-compute-ice
- |-- zinit.zsh/+zinit-message
- |-- zinit.zsh/+zinit-prehelp-usage-message
- |-- zinit.zsh/.zinit-any-to-user-plugin
- `-- zinit.zsh/.zinit-parse-opts
+ `-- zinit.zsh/+zinit-message
 
-Uses feature(s): _setopt_
+Uses feature(s): _setopt_, _zmodload_, _zparseopts_
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-diff-env-compute
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -885,6 +882,20 @@ Called by:
  .zinit-cenable
  .zinit-clear-completions
  .zinit-show-completions
+
+.zinit-prompt
+~~~~~~~~~~~~~
+
+____
+ 
+ Prompt user to confirm
+____
+
+Has 3 line(s). Doesn't call other functions.
+
+Uses feature(s): _read_
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-recall
 ~~~~~~~~~~~~~

--- a/doc/zsdoc/zinit-autoload.zsh.adoc
+++ b/doc/zsdoc/zinit-autoload.zsh.adoc
@@ -438,7 +438,7 @@ ____
  $2 - plugin (only when $1 - i.e. user - given)
 ____
 
-Has 105 line(s). Calls functions:
+Has 108 line(s). Calls functions:
 
  .zinit-delete
  `-- zinit.zsh/+zinit-message
@@ -895,7 +895,9 @@ Has 3 line(s). Doesn't call other functions.
 
 Uses feature(s): _read_
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ .zinit-delete
 
 .zinit-recall
 ~~~~~~~~~~~~~

--- a/doc/zsdoc/zinit-side.zsh.adoc
+++ b/doc/zsdoc/zinit-side.zsh.adoc
@@ -110,7 +110,6 @@ Uses feature(s): _setopt_
 
 Called by:
 
- zinit-autoload.zsh/.zinit-delete
  zinit-autoload.zsh/.zinit-edit
  zinit-autoload.zsh/.zinit-recall
  zinit-autoload.zsh/.zinit-update-or-status-snippet

--- a/doc/zsdoc/zinit.zsh.adoc
+++ b/doc/zsdoc/zinit.zsh.adoc
@@ -115,6 +115,7 @@ Has 252 line(s). Calls functions:
  |   |-- zinit-autoload.zsh/.zinit-clear-completions
  |   |-- zinit-autoload.zsh/.zinit-compile-uncompile-all
  |   |-- zinit-autoload.zsh/.zinit-compiled
+ |   |-- zinit-autoload.zsh/.zinit-delete
  |   |-- zinit-autoload.zsh/.zinit-help
  |   |-- zinit-autoload.zsh/.zinit-list-bindkeys
  |   |-- zinit-autoload.zsh/.zinit-list-compdef-replay
@@ -229,7 +230,6 @@ Has 38 line(s). Calls functions:
 Called by:
 
  zinit
- zinit-autoload.zsh/.zinit-delete
 
 -zinit_scheduler_add_sh
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -324,7 +324,6 @@ Called by:
  zinit-autoload.zsh/.zinit-compile-uncompile-all
  zinit-autoload.zsh/.zinit-compiled
  zinit-autoload.zsh/.zinit-create
- zinit-autoload.zsh/.zinit-delete
  zinit-autoload.zsh/.zinit-find-completions-of-plugin
  zinit-autoload.zsh/.zinit-glance
  zinit-autoload.zsh/.zinit-show-report
@@ -749,7 +748,6 @@ Has 2 line(s). Doesn't call other functions.
 Called by:
 
  zinit
- zinit-autoload.zsh/.zinit-delete
 
 .zinit-prepare-home
 ~~~~~~~~~~~~~~~~~~~
@@ -1292,7 +1290,7 @@ ____
  and completion.
 ____
 
-Has 564 line(s). Calls functions:
+Has 568 line(s). Calls functions:
 
  zinit
  |-- +zinit-message
@@ -1308,6 +1306,7 @@ Has 564 line(s). Calls functions:
  |-- zinit-autoload.zsh/.zinit-clear-completions
  |-- zinit-autoload.zsh/.zinit-compile-uncompile-all
  |-- zinit-autoload.zsh/.zinit-compiled
+ |-- zinit-autoload.zsh/.zinit-delete
  |-- zinit-autoload.zsh/.zinit-help
  |-- zinit-autoload.zsh/.zinit-list-bindkeys
  |-- zinit-autoload.zsh/.zinit-list-compdef-replay
@@ -1398,6 +1397,7 @@ Has 1 line(s). Calls functions:
      |-- zinit-autoload.zsh/.zinit-clear-completions
      |-- zinit-autoload.zsh/.zinit-compile-uncompile-all
      |-- zinit-autoload.zsh/.zinit-compiled
+     |-- zinit-autoload.zsh/.zinit-delete
      |-- zinit-autoload.zsh/.zinit-help
      |-- zinit-autoload.zsh/.zinit-list-bindkeys
      |-- zinit-autoload.zsh/.zinit-list-compdef-replay

--- a/tests/commands.zunit
+++ b/tests/commands.zunit
@@ -1,4 +1,11 @@
 #!/usr/bin/env zunit
+#
+# zdharma-continuum/zinit/zinit.zsh
+# Copyright (c) 2016-2021 Sebastian Gniazdowski
+# Copyright (c) 2021-2023 zdharma-continuum
+# Homepage: https://github.com/zdharma-continuum/zinit
+# License: MIT License
+#
 
 @setup {
   zinit default-ice --quiet from'gh-r' nocompile lbin'!'

--- a/tests/commands.zunit
+++ b/tests/commands.zunit
@@ -1,0 +1,15 @@
+#!/usr/bin/env zunit
+
+@setup {
+  zinit default-ice --quiet from'gh-r' nocompile lbin'!'
+  ZBIN="${ZPFX}/bin"
+  zinit for @nektos/act; assert $state equals 0
+  local act="$ZBIN/act"; assert "$act" is_executable
+  $act --version; assert $state equals 0
+}
+
+@test 'delete' { # zinit delete subcommand
+  zinit from'gh-r' nocompile lbin'!' for @sharkdp/bat @nektos/act
+  run zinit delete --yes sharkdp/bar nektos/act
+  assert $state equals 0
+}

--- a/tests/commands.zunit
+++ b/tests/commands.zunit
@@ -3,13 +3,16 @@
 @setup {
   zinit default-ice --quiet from'gh-r' nocompile lbin'!'
   ZBIN="${ZPFX}/bin"
-  zinit for @nektos/act; assert $state equals 0
-  local act="$ZBIN/act"; assert "$act" is_executable
-  $act --version; assert $state equals 0
 }
 
-@test 'delete' { # zinit delete subcommand
-  zinit from'gh-r' nocompile lbin'!' for @sharkdp/bat @nektos/act
-  run zinit delete --yes sharkdp/bar nektos/act
-  assert $state equals 0
+@test 'zinit delete' { # zinit delete subcommand
+  # --help
+  run zinit delete --help;  assert $state equals 0
+  # --all --yes
+  run zinit from'gh-r' id-as nocompile lbin'!' for @nektos/act; assert $state equals 0
+  local act_bin="$ZBIN/act"; assert "$act_bin" is_executable
+  bin_dir="$(ls $ZBIN)"; assert "$bin_dir" is_not_empty
+  $act_bin --version; assert $state equals 0
+  run zinit delete --all --yes; assert $state equals 0
+  bin_dir="$(ls $ZBIN)"; assert "$bin_dir" is_empty
 }

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -2735,7 +2735,7 @@ ZINIT[EXTENDED_GLOB]=""
             command rm -rf -- ${(@)all_installed}
             command rm -rf -- $ZINIT[HOME_DIR]/**/*(-@)
             rc=$?
-            +zinit-message "finished with return code {num}${rc}{rst}"
+            +zinit-message "deleted all completed with return code {num}${rc}{rst}"
             return $rc
         fi
         print -- ''

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -1,5 +1,10 @@
-# -*- mode: sh; sh-indentation: 4; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
-# Copyright (c) 2016-2020 Sebastian Gniazdowski and contributors.
+#
+# zdharma-continuum/zinit/tests/commands.zunit
+# Copyright (c) 2016-2020 Sebastian Gniazdowski
+# Copyright (c) 2016-2023 zdharma-continuum
+# Homepage: https://github.com/zdharma-continuum/zinit
+# License: MIT License
+#
 
 builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || { builtin print -P "${ZINIT[col-error]}ERROR:%f%b Couldn't find ${ZINIT[col-obj]}zinit-side.zsh%f%b."; return 1; }
 

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -2727,8 +2727,11 @@ ZINIT[EXTENDED_GLOB]=""
     (( $#o_clean && $#o_all )) && { print -l -- "choose either --all or --clean"; return 0 }
 
     if (( $#o_all && !$#o_clean )); then
-        local -a all_installed=(${${ZINIT[COMPLETIONS_DIR]}%%[/[:space:]]##}/*~*_zinit(/ND) ${${ZINIT[PLUGINS_DIR]}%%[/[:space:]]##}/*~*/_local---zinit(/ND) ${${ZINIT[SNIPPETS_DIR]}%%[/[:space:]]##}/*~*/plugins(/ND))
-        if (( $#o_yes )) || ( -zinit-prompt "delete all plugins and snippets (${#all_installed} total)" ); then
+        local -a all_installed=(
+          ${${ZINIT[PLUGINS_DIR]}%%[/[:space:]]##}/*~*/_local---zinit(/ND)
+          ${${ZINIT[SNIPPETS_DIR]}%%[/[:space:]]##}/*~*/plugins(/ND)
+        )
+        if (( $#o_yes )) || ( .zinit-prompt "delete all plugins and snippets (${#all_installed} total)" ); then
             command rm -rf -- ${(@)all_installed}
             command rm -rf -- $ZINIT[HOME_DIR]/**/*(-@)
             rc=$?
@@ -2738,7 +2741,7 @@ ZINIT[EXTENDED_GLOB]=""
         print -- ''
         return 1
     fi
-    (( $# == 0 )) && { +zinit-message "ERROR: must supply atleast one plugin to delete"; return 0 }
+    (( !$# )) && { +zinit-message "ERROR: must supply atleast one plugin to delete"; return 0 }
     local -a failed=()
     for i in $@; do
         local the_id="${${i:#(%|/)*}}" local_dir filename is_snippet
@@ -2759,7 +2762,7 @@ ZINIT[EXTENDED_GLOB]=""
         if (( is_snippet )); then
             if [[ "${+ICE2[svn]}" = "1" ]]; then
                 if [[ -e "$local_dir" ]]; then
-                    if (( $#o_yes )) || ( -zinit-prompt "delete $i snippet (${(#)files} files)" ); then
+                    if (( $#o_yes )) || ( .zinit-prompt "delete $i snippet (${(#)files} files)" ); then
                         .zinit-run-delete-hooks snippet "${ICE2[teleid]}" "" "$the_id" "$local_dir"
                         command rm -rf -- ${(q)${${local_dir:#[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/abcYZX321}}
                         command rm -rf -- $ZINIT[HOME_DIR]/**/*(-@)
@@ -2773,7 +2776,7 @@ ZINIT[EXTENDED_GLOB]=""
                 fi
             else
                 if [[ -e "$local_dir" ]]; then
-                    if (( $#o_yes )) || ( -zinit-prompt "delete $i (${(#)files} files)" ); then
+                    if (( $#o_yes )) || ( .zinit-prompt "delete $i (${(#)files} files)" ); then
                         .zinit-run-delete-hooks snippet "${ICE2[teleid]}" "" "$the_id" "$local_dir"
                         command rm -rf -- ${(q)${${local_dir:#[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/abcYZX321}}
                         command rm -rf -- $ZINIT[HOME_DIR]/**/*(-@)
@@ -2789,7 +2792,7 @@ ZINIT[EXTENDED_GLOB]=""
         else
             .zinit-any-to-user-plugin "${ICE2[teleid]}"
             if [[ -e "$local_dir" ]]; then
-                if (( $#o_yes )) || ( -zinit-prompt "delete $i (${(#)files} files)" ); then
+                if (( $#o_yes )) || ( .zinit-prompt "delete $i (${(#)files} files)" ); then
                     .zinit-run-delete-hooks plugin "${reply[-2]}" "${reply[-1]}" "$the_id" "$local_dir"
                     command rm -rf -- ${(q)${${local_dir:#[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/abcYZX321}}
                     command rm -rf -- $ZINIT[HOME_DIR]/**/*(-@)

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -2730,7 +2730,7 @@ ZINIT[EXTENDED_GLOB]=""
         local -a all_installed=(${${ZINIT[COMPLETIONS_DIR]}%%[/[:space:]]##}/*~*_zinit(/ND) ${${ZINIT[PLUGINS_DIR]}%%[/[:space:]]##}/*~*/_local---zinit(/ND) ${${ZINIT[SNIPPETS_DIR]}%%[/[:space:]]##}/*~*/plugins(/ND))
         if (( $#o_yes )) || ( -zinit-prompt "delete all plugins and snippets (${#all_installed} total)" ); then
             command rm -rf -- ${(@)all_installed}
-            command rm -rf -- **/*(-@)
+            command rm -rf -- $ZINIT[HOME_DIR]/**/*(-@)
             rc=$?
             +zinit-message "finished with return code {num}${rc}{rst}"
             return $rc
@@ -2762,7 +2762,7 @@ ZINIT[EXTENDED_GLOB]=""
                     if (( $#o_yes )) || ( -zinit-prompt "delete $i snippet (${(#)files} files)" ); then
                         .zinit-run-delete-hooks snippet "${ICE2[teleid]}" "" "$the_id" "$local_dir"
                         command rm -rf -- ${(q)${${local_dir:#[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/abcYZX321}}
-                        command rm -rf -- **/*(-@)
+                        command rm -rf -- $ZINIT[HOME_DIR]/**/*(-@)
                     else
                         continue
                     fi
@@ -2776,6 +2776,7 @@ ZINIT[EXTENDED_GLOB]=""
                     if (( $#o_yes )) || ( -zinit-prompt "delete $i (${(#)files} files)" ); then
                         .zinit-run-delete-hooks snippet "${ICE2[teleid]}" "" "$the_id" "$local_dir"
                         command rm -rf -- ${(q)${${local_dir:#[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/abcYZX321}}
+                        command rm -rf -- $ZINIT[HOME_DIR]/**/*(-@)
                     else
                         continue
                     fi
@@ -2791,6 +2792,7 @@ ZINIT[EXTENDED_GLOB]=""
                 if (( $#o_yes )) || ( -zinit-prompt "delete $i (${(#)files} files)" ); then
                     .zinit-run-delete-hooks plugin "${reply[-2]}" "${reply[-1]}" "$the_id" "$local_dir"
                     command rm -rf -- ${(q)${${local_dir:#[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/abcYZX321}}
+                    command rm -rf -- $ZINIT[HOME_DIR]/**/*(-@)
                 fi
                 continue
             else

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -2698,7 +2698,6 @@ ZINIT[EXTENDED_GLOB]=""
 #
 # $1 - snippet URL or plugin spec (4 formats: user---plugin, user/plugin, user, plugin)
 # $2 - plugin (only when $1 - i.e. user - given)
-
 .zinit-delete () {
     builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob warncreateglobal typesetsilent

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -1,4 +1,10 @@
-# Copyright (c) 2016-2020 Sebastian Gniazdowski and contributors.
+#
+# zdharma-continuum/zinit/zinit.zsh
+# Copyright (c) 2016-2021 Sebastian Gniazdowski
+# Copyright (c) 2021-2023 zdharma-continuum
+# Homepage: https://github.com/zdharma-continuum/zinit
+# License: MIT License
+#
 
 #
 # Main state variables.

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -2925,7 +2925,7 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                     ;;
                 (delete)
                     shift
-                    .zinit-delete
+                    .zinit-delete "$@"
                     ;;
                 (times)
                     .zinit-show-times "${@[2-correct,-1]}"

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -2602,7 +2602,7 @@ zinit() {
 
     cmd="$1"
     if [[ $cmd == (times|unload|env-whitelist|update|snippet|load|light|cdreplay|\
-cdclear|delete) ]]; then
+cdclear) ]]; then
         if (( $@[(I)-*] || OPTS[opt_-h,--help] )); then
             .zinit-parse-opts "$cmd" "$@"
             if (( OPTS[opt_-h,--help] )); then
@@ -2923,6 +2923,10 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                 (zstatus)
                     .zinit-show-zstatus
                     ;;
+                (delete)
+                    shift
+                    .zinit-delete
+                    ;;
                 (times)
                     .zinit-show-times "${@[2-correct,-1]}"
                     ;;
@@ -3092,7 +3096,7 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                 (cdlist)
                     .zinit-list-compdef-replay
                     ;;
-                (cd|delete|recall|edit|glance|changes|create|stress)
+                (cd|recall|edit|glance|changes|create|stress)
                     .zinit-"$1" "${@[2-correct,-1]%%(///|//|/)}"; ___retval=$?
                     ;;
                 (recently)


### PR DESCRIPTION
## Description <!--- Describe your changes in detail -->

- `zinit delete` command can delete multiple plugins at once
- remove broken symlinks after deleting a plugin
- improve option parsing (i.e., `--all` and `--clean` are mutually exclusive, don't default to deleting snippets)
- track number of failed deletions

## Motivation and Context <!--- Why is this change required? What problem does it solve? -->

Increase usability and reduce duplicate tasks.

Closes #239

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

## Usage examples <!--- Provide examples of intended usage -->

```zsh

```

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
