### PR TITLE
fix: delete multiple plugins at once

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -30,7 +30,7 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY # this is a blank line
           if ! git --no-pager diff --exit-code; then
             echo "::error:: Z-shelldocs are out-of-date." >> $GITHUB_STEP_SUMMARY
-            echo "To regenerate, run `make doc`" >> $GITHUB_STEP_SUMMARY
+            echo 'To regenerate, run `make doc`' >> $GITHUB_STEP_SUMMARY
             exit 1
           else
             echo "::notice:: Z-shelldocs are up-to-date." >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -61,6 +61,9 @@ jobs:
       - name: "annexes"
         run: zunit run tests/annexes.zunit
 
+      - name: "commands"
+        run: zunit run tests/commands.zunit
+
       - name: "gh-r"
         run: zunit run --fail-fast --verbose tests/gh-r.zunit
 

--- a/_zinit
+++ b/_zinit
@@ -210,7 +210,7 @@ _zinit_delete(){
     '--quiet[Turn off messages from the operation]' \
     '--yes[Automatically confirm any yes/no prompts]' \
     + '(operation)' \
-      '1:installed:__zinit_installed' \
+      '*::installed:__zinit_installed' \
       {-a,--all}'[Delete all plugins and snippets]' \
       {-c,--clean}'[Delete only the currently-not loaded plugins and snippets]'
 } # ]]]

--- a/doc/zsdoc/zinit-autoload.zsh.adoc
+++ b/doc/zsdoc/zinit-autoload.zsh.adoc
@@ -52,6 +52,7 @@ FUNCTIONS
  .zinit-module
  .zinit-pager
  .zinit-prepare-readlink
+ .zinit-prompt
  .zinit-recall
  .zinit-recently
  .zinit-restore-extendedglob
@@ -398,9 +399,7 @@ Has 17 line(s). Calls functions:
 
 Uses feature(s): _eval_, _read_
 
-Called by:
-
- .zinit-delete
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 .zinit-create
 ~~~~~~~~~~~~~
@@ -431,26 +430,24 @@ Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ____
  
- Deletes plugin's or snippet's directory (in Zinit's home directory).
+ Deletes a plugin or snippet and related files and hooks.
  
- User-action entry point.
- 
- $1 - snippet URL or plugin spec (4 formats: user---plugin, user/plugin, user, plugin)
- $2 - plugin (only when $1 - i.e. user - given)
+ $1 - snippet url or plugin
 ____
 
-Has 99 line(s). Calls functions:
+Has 107 line(s). Calls functions:
 
  .zinit-delete
  |-- zinit-side.zsh/.zinit-compute-ice
  |-- zinit.zsh/+zinit-message
- |-- zinit.zsh/+zinit-prehelp-usage-message
  |-- zinit.zsh/.zinit-any-to-user-plugin
- `-- zinit.zsh/.zinit-parse-opts
+ `-- zinit.zsh/zinit
 
-Uses feature(s): _setopt_
+Uses feature(s): _setopt_, _zmodload_, _zparseopts_
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ zinit.zsh/zinit
 
 .zinit-diff-env-compute
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -886,6 +883,26 @@ Called by:
  .zinit-clear-completions
  .zinit-show-completions
 
+.zinit-prompt
+~~~~~~~~~~~~~
+
+____
+ 
+ Prompt user to confirm
+ 
+ $1 - prompt
+ 
+ $REPLY - 0 or 1
+____
+
+Has 4 line(s). Doesn't call other functions.
+
+Uses feature(s): _read_
+
+Called by:
+
+ .zinit-delete
+
 .zinit-recall
 ~~~~~~~~~~~~~
 
@@ -949,7 +966,9 @@ Has 17 line(s). Calls functions:
 
 Uses feature(s): _eval_
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ .zinit-delete
 
 .zinit-save-set-extendedglob
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1428,7 +1447,5 @@ Has 2 line(s). Calls functions:
  zi::version
  `-- zinit.zsh/+zinit-message
 
-Called by:
-
- zinit.zsh/zinit
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 

--- a/doc/zsdoc/zinit-autoload.zsh.adoc
+++ b/doc/zsdoc/zinit-autoload.zsh.adoc
@@ -1447,5 +1447,7 @@ Has 2 line(s). Calls functions:
  zi::version
  `-- zinit.zsh/+zinit-message
 
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+Called by:
+
+ zinit.zsh/zinit
 

--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -800,7 +800,7 @@ ____
  `#compdef <names ...>'
 ____
 
-Has 573 line(s). Doesn't call other functions.
+Has 549 line(s). Doesn't call other functions.
 
 Uses feature(s): _autoload_, _bindkey_, _compdef_, _compdump_, _eval_, _read_, _setopt_, _unfunction_, _zle_, _zstyle_
 

--- a/doc/zsdoc/zinit.zsh.adoc
+++ b/doc/zsdoc/zinit.zsh.adoc
@@ -93,7 +93,7 @@ DETAILS
 Script Body
 ~~~~~~~~~~~
 
-Has 252 line(s). Calls functions:
+Has 244 line(s). Calls functions:
 
  Script-Body
  |-- +zinit-message
@@ -115,6 +115,7 @@ Has 252 line(s). Calls functions:
  |   |-- zinit-autoload.zsh/.zinit-clear-completions
  |   |-- zinit-autoload.zsh/.zinit-compile-uncompile-all
  |   |-- zinit-autoload.zsh/.zinit-compiled
+ |   |-- zinit-autoload.zsh/.zinit-delete
  |   |-- zinit-autoload.zsh/.zinit-help
  |   |-- zinit-autoload.zsh/.zinit-list-bindkeys
  |   |-- zinit-autoload.zsh/.zinit-list-compdef-replay
@@ -229,7 +230,6 @@ Has 38 line(s). Calls functions:
 Called by:
 
  zinit
- zinit-autoload.zsh/.zinit-delete
 
 -zinit_scheduler_add_sh
 ~~~~~~~~~~~~~~~~~~~~~~~
@@ -749,7 +749,6 @@ Has 2 line(s). Doesn't call other functions.
 Called by:
 
  zinit
- zinit-autoload.zsh/.zinit-delete
 
 .zinit-prepare-home
 ~~~~~~~~~~~~~~~~~~~
@@ -1104,7 +1103,6 @@ Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
 ____
  
- ]]]
  Registers the z-annex inside Zinit – i.e. an Zinit extension
 ____
 
@@ -1292,7 +1290,7 @@ ____
  and completion.
 ____
 
-Has 564 line(s). Calls functions:
+Has 568 line(s). Calls functions:
 
  zinit
  |-- +zinit-message
@@ -1308,6 +1306,7 @@ Has 564 line(s). Calls functions:
  |-- zinit-autoload.zsh/.zinit-clear-completions
  |-- zinit-autoload.zsh/.zinit-compile-uncompile-all
  |-- zinit-autoload.zsh/.zinit-compiled
+ |-- zinit-autoload.zsh/.zinit-delete
  |-- zinit-autoload.zsh/.zinit-help
  |-- zinit-autoload.zsh/.zinit-list-bindkeys
  |-- zinit-autoload.zsh/.zinit-list-compdef-replay
@@ -1340,6 +1339,7 @@ Called by:
 
  Script-Body
  zplugin
+ zinit-autoload.zsh/.zinit-delete
 
 zpcdclear
 ~~~~~~~~~
@@ -1398,6 +1398,7 @@ Has 1 line(s). Calls functions:
      |-- zinit-autoload.zsh/.zinit-clear-completions
      |-- zinit-autoload.zsh/.zinit-compile-uncompile-all
      |-- zinit-autoload.zsh/.zinit-compiled
+     |-- zinit-autoload.zsh/.zinit-delete
      |-- zinit-autoload.zsh/.zinit-help
      |-- zinit-autoload.zsh/.zinit-list-bindkeys
      |-- zinit-autoload.zsh/.zinit-list-compdef-replay
@@ -1461,7 +1462,7 @@ ____
  Note that some terminals do not support all combinations.
 ____
 
-Has 120 line(s). Doesn't call other functions.
+Has 117 line(s). Doesn't call other functions.
 
 Called by:
 
@@ -1484,7 +1485,7 @@ ____
  `#compdef <names ...>'
 ____
 
-Has 573 line(s). Doesn't call other functions.
+Has 549 line(s). Doesn't call other functions.
 
 Uses feature(s): _autoload_, _bindkey_, _compdef_, _compdump_, _eval_, _read_, _setopt_, _unfunction_, _zle_, _zstyle_
 

--- a/tests/commands.zunit
+++ b/tests/commands.zunit
@@ -1,0 +1,38 @@
+#!/usr/bin/env zunit
+#
+# zdharma-continuum/zinit/tests/commands.zunit
+# Copyright (c) 2016-2021 Sebastian Gniazdowski
+# Copyright (c) 2021-2023 zdharma-continuum
+# Homepage: https://github.com/zdharma-continuum/zinit
+# License: MIT License
+#
+
+@setup {
+  ZBIN="${ZPFX}/bin"
+}
+@test 'delete --help' {
+  run zinit delete --help
+  assert $output contains 'zinit delete [options] [plugins...]'
+  assert $state equals 0
+}
+@test 'delete --all' {
+  run zinit as'completion' is-snippet for @'https://github.com/docker/cli/blob/master/contrib/completion/zsh/_docker'
+  assert $state equals 0
+}
+@test 'delete a snippet' {
+  run zinit id-as'git.zsh' is-snippet for @'OMZL::git.zsh'
+  run zinit delete --yes 'git.zsh'
+  assert $state equals 0
+}
+@test 'delete a plugin' {
+    run zinit from'gh-r' as'program' id-as mv'shfmt* -> shfmt' for @'mvdan/sh'
+    run zinit delete --yes sh
+    assert $state equals 0
+}
+@test 'delete a program' {
+    run zinit as'program' cp'wd.sh->wd' mv'_wd.sh->_wd' pick'wd' for @'mfaerevaag/wd'
+    run zinit delete --yes mfaerevaag/wd
+    assert $state equals 0
+}
+
+# vim:ft=zsh:sw=2:sts=2:et:foldmarker={,}:foldmethod=marker

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -1,5 +1,11 @@
-# -*- mode: sh; sh-indentation: 4; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
-# Copyright (c) 2016-2020 Sebastian Gniazdowski and contributors.
+#!/usr/bin/env zsh
+#
+# zdharma-continuum/zinit/zinit-autoload.zsh
+# Copyright (c) 2016-2021 Sebastian Gniazdowski
+# Copyright (c) 2021-2023 zdharma-continuum
+# Homepage: https://github.com/zdharma-continuum/zinit
+# License: MIT License
+#
 
 builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || { builtin print -P "${ZINIT[col-error]}ERROR:%f%b Couldn't find ${ZINIT[col-obj]}zinit-side.zsh%f%b."; return 1; }
 
@@ -2691,136 +2697,130 @@ ZINIT[EXTENDED_GLOB]=""
     done
 } # ]]]
 # FUNCTION: .zinit-delete [[[
-# Deletes plugin's or snippet's directory (in Zinit's home directory).
+# Deletes a plugin or snippet and related files and hooks.
 #
-# User-action entry point.
-#
-# $1 - snippet URL or plugin spec (4 formats: user---plugin, user/plugin, user, plugin)
-# $2 - plugin (only when $1 - i.e. user - given)
-.zinit-delete() {
-    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-    setopt extendedglob warncreateglobal typesetsilent
-
-    local -a opts match mbegin mend
-    local MATCH; integer MBEGIN MEND _retval
-
-    # Parse options
-    .zinit-parse-opts delete "$@"
-    builtin set -- "${reply[@]}"
-    if (( $@[(I)-*] || OPTS[opt_-h,--help] )) { +zinit-prehelp-usage-message delete $___opt_map[delete] $@; return 1; }
-
-    local the_id="$1${${1:#(%|/)*}:+${2:+/}}$2"
-
-    # -a/--all given?
-    if (( OPTS[opt_-a,--all] )); then
-        .zinit-confirm "Prune all plugins in \`${ZINIT[PLUGINS_DIR]}'"\
-"and snippets in \`${ZINIT[SNIPPETS_DIR]}'?" \
-"command rm -rf ${${ZINIT[PLUGINS_DIR]%%[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/abcEFG312}/*~*/_local---zinit(ND) "\
-"${${ZINIT[SNIPPETS_DIR]%%[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/abcEFG312}/*~*/plugins(ND)"
-        return $?
-    fi
-
-    # -c/--clean given?
-    if (( OPTS[opt_-c,--clean] )) {
-        .zinit-confirm "Prune ${ZINIT[col-info]}CURRENTLY NOT LOADED${ZINIT[col-rst]}"\
-" plugins in $ZINIT[col-file]$ZINIT[PLUGINS_DIR]%f%b"\
-" and snippets in $ZINIT[col-file]$ZINIT[SNIPPETS_DIR]%f%b?" \
-" # Delete unloaded snippets
-local -aU loadedsnips todelete final_todelete
-loadedsnips=( \${\${ZINIT_SNIPPETS[@]% <*>}/(#m)*/\$(.zinit-get-object-path snippet \"\$MATCH\" && builtin print -rn \$REPLY; )} )
-local dir=\${\${ZINIT[SNIPPETS_DIR]%%[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/xyzcba231}
-todelete=( \$dir/*/*/*(ND/) \$dir/*/*(ND/) \$dir/*(ND/) )
-final_todelete=( \${todelete[@]:#*/(\${(~j:|:)loadedsnips}|*/plugins|._backup|._zinit|.svn|.git)(|/*)} )
-final_todelete=( \${final_todelete[@]//(#m)*/\$( .zinit-get-object-path snippet \"\${\${\${MATCH##\${dir}[/[:space:]]#}/(#i)(#b)(http(s|)|ftp(s|)|ssh|rsync)--/\${match[1]##--}://}//--//}\" && builtin print -r -- \$REPLY)} )
-final_todelete=( \${final_todelete[@]:#(\${(~j:|:)loadedsnips}|*/plugins|*/._backup|*/._zinit|*/.svn|*/.git)(|/*)} )
-todelete=( \${\${\${(@)\${(@)final_todelete##\$dir/#}//(#i)(#m)(http(s|)|ftp(s|)|ssh|rsync)--/\${MATCH%--}://}//--//}//(#b)(*)\/([^\/]##)(#e)/\$match[1]/\$ZINIT[col-file]\$match[2]\$ZINIT[col-rst]} )
-todelete=( \${todelete[@]//(#m)(#s)[^\/]##(#e)/\$ZINIT[col-file]\$MATCH\$ZINIT[col-rst]} )
-final_todelete=( \${\${\${(@)\${(@)final_todelete##\$dir/#}//(#i)(#m)(http(s|)|ftp(s|)|ssh|rsync)--/\${MATCH%--}://}//--//}//(#b)(*)\/([^\/]##)(#e)/\$match[1]/\$match[2]} )
-builtin print; print -Prln \"\$ZINIT[col-obj]Deleting the following \"\
-\"\$ZINIT[col-file]\${#todelete}\$ZINIT[col-msg2] UNLOADED\$ZINIT[col-obj] snippets:%f%b\" \
-    \$todelete \"%f%b\"
-sleep 3
-local snip
-for snip ( \$final_todelete ) { zinit delete -q -y \$snip; _retval+=\$?; }
-builtin print -Pr \"\$ZINIT[col-obj]Done (with the exit code: \$_retval).%f%b\"
-
-# Next delete unloaded plugins
-local -a dirs
-dirs=( \${\${ZINIT[PLUGINS_DIR]%%[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/abcEFG312}/*~*/(\${(~j:|:)\${ZINIT_REGISTERED_PLUGINS[@]//\//---}})(ND/) )
-dirs=( \${(@)\${dirs[@]##\$ZINIT[PLUGINS_DIR]/#}//---//} )
-builtin print -Prl \"\" \"\$ZINIT[col-obj]Deleting the following \"\
-\"\$ZINIT[col-file]\${#dirs}\$ZINIT[col-msg2] UNLOADED\$ZINIT[col-obj] plugins:%f%b\" \
-\${\${dirs//(#b)(*)(\/([^\/]##))(#e)/\${\${match[2]:+\$ZINIT[col-uname]\$match[1]\$ZINIT[col-rst]/\$ZINIT[col-pname]\$match[3]\$ZINIT[col-rst]}:-\$ZINIT[col-pname]\$match[1]}}//(#b)(^\$ZINIT[col-uname])(*)/\$ZINIT[col-pname]\$match[1]}
-sleep 3
-for snip ( \$dirs ) { zinit delete -q -y \$snip; _retval+=\$?; }
-builtin print -Pr \"\$ZINIT[col-obj]Done (with the exit code: \$_retval).%f%b\""
-        return _retval
+# $1 - snippet url or plugin
+.zinit-delete () {
+    emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
+    setopt extendedglob noksharrays nokshglob nullglob typesetsilent warncreateglobal
+    local o_all o_clean o_debug o_help o_verbose o_yes rc
+    local -a usage=(
+      'Usage:'
+      '  zinit delete [options] [plugins...]'
+      ' '
+      'Options:'
+      '  -a, --all      Delete all installed plugins, snippets, and completions'
+      '  -c, --clean    Delete unloaded plugins and snippets'
+      '  -h, --help     Show list of command-line options'
+      '  -y, --yes      Don´t prompt for user confirmation'
+    )
+    zmodload zsh/zutil
+    zparseopts -D -F -K -- \
+      {a,-all}=o_all \
+      {c,-clean}=o_clean \
+      {d,-dry-run}=o_debug \
+      {h,-help}=o_help \
+      {y,-yes}=o_yes \
+    || return 1
+    (( $#o_help )) && {
+      print -l -- $usage
+      return 0
     }
+    (( $#o_clean && $#o_all )) && {
+        +zinit-message "{e} Invalid usage: Options --all and --clean are mutually exclusive"
+        return 1
+    }
+    (( $#o_clean )) && {
+      local -a unld_plgns
+      local -aU ld_snips unld_snips del_list
+      local snip plugin _retval dir=${${ZINIT[SNIPPETS_DIR]%%[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/xyzcba231}
 
-    local -A ICE2
-    local local_dir filename is_snippet
-
-    .zinit-compute-ice "$the_id" "pack" \
-        ICE2 local_dir filename is_snippet || return 1
-
-    if [[ "$local_dir" != /* ]]
-    then
-        +zinit-message "{log-error} Obtained a risky, not-absolute path ({dir}$local_dir{rst}), aborting"
+      unld_snips=( $dir/*/*/*(ND/) $dir/*/*(ND/) $dir/*(ND/) )
+      ld_snips=(${${ZINIT_SNIPPETS[@]% <*>}/(#m)*/$(.zinit-get-object-path snippet "$MATCH" && builtin print -rn -- $REPLY; )})
+      del_list=(${unld_snips[@]:#*/(${(~j:|:)ld_snips}|*/plugins|._backup|._zinit|.svn|.git)(|/*)})
+      del_list=(${del_list[@]//(#m)*/$( .zinit-get-object-path snippet "${${${MATCH##${dir}[/[:space:]]#}/(#i)(#b)(http(s|)|ftp(s|)|ssh|rsync)--/${match[1]##--}://}//--//}" && builtin print -r -- $REPLY)})
+      del_list=(${del_list[@]:#(${(~j:|:)ld_snips}|*/plugins|*/._backup|*/._zinit|*/.svn|*/.git)(|/*)})
+      unld_snips=(${${${(@)${(@)del_list##$dir/#}//(#i)(#m)(http(s|)|ftp(s|)|ssh|rsync)--/${MATCH%--}://}//--//}//(#b)(*)\/([^\/]##)(#e)/$match[1]/$ZINIT[col-file]$match[2]$ZINIT[col-rst]})
+      unld_snips=(${unld_snips[@]//(#m)(#s)[^\/]##(#e)/$ZINIT[col-file]$MATCH$ZINIT[col-rst]})
+      del_list=(${${${(@)${(@)del_list##$dir/#}//(#i)(#m)(http(s|)|ftp(s|)|ssh|rsync)--/${MATCH%--}://}//--//}//(#b)(*)\/([^\/]##)(#e)/$match[1]/$match[2]})
+      unld_plgns=(${${ZINIT[PLUGINS_DIR]%%[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/abcEFG312}/*~*/(${(~j:|:)${ZINIT_REGISTERED_PLUGINS[@]//\//---}})(ND/))
+      unld_plgns=(${(@)${unld_plgns[@]##$ZINIT[PLUGINS_DIR]/#}//---//})
+      # delete unloaded snippets & plugins
+      (( $#del_list || $#unld_plgns )) && {
+        +zinit-message "{m} Deleting {num}${#unld_snips}{rst} unloaded snippets:" $unld_snips
+        +zinit-message "{m} Deleting {num}${#unld_plgns}{rst} unloaded plugins:" $unld_plgns
+        if (( $#o_yes )) || ( .zinit-prompt "delete ${#unld_snips} snippets and ${#unld_plgns} plugins?"); then
+          for snip in $del_list $unld_plgns ; do
+            zinit delete --yes "$snip"
+            _retval+=$?
+          done
+          return _retval
+        fi
+      } || {
+        +zinit-message "{m} No unloaded plugins or snippets to delete"
+        return 0
+      }
+    }
+    if (( $#o_all && !$#o_clean )); then
+        local -a all_installed=(${${ZINIT[PLUGINS_DIR]}%%[/[:space:]]##}/*~*/_local---zinit(/ND) ${${ZINIT[SNIPPETS_DIR]}%%[/[:space:]]##}/*~*/plugins(/ND))
+        if (( $#o_yes )) || ( .zinit-prompt "Delete all plugins and snippets (${#all_installed} total)"); then
+            command rm -rf -- ${(@)all_installed}
+            command rm -f -- $ZINIT[HOME_DIR]/**/*(-@N)
+            local rc=$?
+            +zinit-message "{m} Deleted all completed with return code {num}${rc}{rst}"
+            return $rc
+        fi
         return 1
     fi
-
-    ICE2[teleid]="${ICE2[teleid]:-${ICE2[id-as]}}"
-
-    local -a files
-    files=( "$local_dir"/*.(zsh|sh|bash|ksh)(DN:t)
-        "$local_dir"/*(*DN:t) "$local_dir"/*(@DN:t) "$local_dir"/*(.DN:t)
-        "$local_dir"/*~*/.(_zinit|svn|git)(/DN:t) "$local_dir"/*(=DN:t)
-        "$local_dir"/*(pDN:t) "$local_dir"/*(%DN:t)
-    )
-    (( !${#files} )) && files=( "no files?" )
-    files=( ${(@)files[1,4]} ${files[4]+more…} )
-
-    # Make the ices available for the hooks.
-    local -A ICE
-    ICE=( "${(kv)ICE2[@]}" )
-
-    if (( is_snippet )); then
-        if [[ "${+ICE2[svn]}" = "1" ]] {
-            if [[ -e "$local_dir" ]]
-            then
-                .zinit-confirm "Delete {file}$local_dir{rst}? (it holds: ${(j:, :)${(@u)files}})" \
-                    ".zinit-run-delete-hooks snippet \"${ICE2[teleid]}\" \"\" \"$the_id\" \
-                    \"$local_dir\"; \
-                    command rm -rf ${(q)${${local_dir:#[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/abcYZX321}}"
-            else
-                +zinit-message "{log-error} No such snippet"
+    (( !$# )) && {
+        +zinit-message "{e} Invalid usage: This command requires at least 1 plugin or snippet argument."
+        return 0
+    }
+    local i
+    if (( $#o_yes )) || ( .zinit-prompt "Delete ${(j:, :)@}"); then
+        local -A ICE ICE2
+        for i in $@; do
+            local the_id="${${i:#(%|/)*}}" filename is_snippet local_dir
+            .zinit-compute-ice "$the_id" "pack" ICE2 local_dir filename is_snippet || return 1
+            if [[ "$local_dir" != /* ]]; then
+                +zinit-message "{w} No available plugin or snippet with the name '$i'"
                 return 1
             fi
-        } else {
-            if [[ -e "$local_dir" ]]; then
-                .zinit-confirm "Delete ${file}$local_dir{rst}? (it holds: ${(j:, :)${(@u)files}})" \
-                    ".zinit-run-delete-hooks snippet \"${ICE2[teleid]}\" \"\" \"$the_id\" \
-                    \"$local_dir\"; command rm -rf \
-                        ${(q)${${local_dir:#[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/abcYZX321}}"
+            ICE2[teleid]="${ICE2[teleid]:-${ICE2[id-as]}}"
+            local -a files
+            files=("$local_dir"/*(%DN:t) "$local_dir"/*(*DN:t) "$local_dir"/*(.DN:t) "$local_dir"/*(=DN:t) "$local_dir"/*(@DN:t) "$local_dir"/*(pDN:t) "$local_dir"/*.(zsh|sh|bash|ksh)(DN:t) "$local_dir"/*~*/.(_zinit|svn|git)(/DN:t))
+            (( !${#files} )) && files=("no files?")
+            files=(${(@)files[1,4]} ${files[4]+more…})
+            ICE=("${(kv)ICE2[@]}")
+            if [[ -e $local_dir ]]; then
+                (( is_snippet )) && {
+                    .zinit-run-delete-hooks snippet "${ICE2[teleid]}" "" "$the_id" "$local_dir"
+                } || {
+                    .zinit-any-to-user-plugin "${ICE2[teleid]}"
+                    .zinit-run-delete-hooks plugin "${reply[-2]}" "${reply[-1]}" "$the_id" "$local_dir"
+                }
+                command rm -rf -- ${(q)${${local_dir:#[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/abcYZX321}}(N) # delete files
+                command rm -f -- $ZINIT[HOME_DIR]/**/*(-@N) # delete broken symlins
+                +zinit-message "{m} Uninstalled $i"
             else
-                +zinit-message "{log-error} No such snippet"
+                +zinit-message "{w} No available plugin or snippet with the name '$i'"
                 return 1
             fi
-        }
-    else
-        .zinit-any-to-user-plugin "${ICE2[teleid]}"
-        if [[ -e "$local_dir" ]]; then
-            .zinit-confirm "Delete {file}$local_dir{rst}? (it holds: ${(j:, :)${(@u)files}})" \
-                ".zinit-run-delete-hooks plugin \"${reply[-2]}\" \"${reply[-1]}\" \"$the_id\" \
-                \"$local_dir\"; \
-                command rm -rf ${(q)${${local_dir:#[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/abcYZX321}}"
-        else
-            +zinit-message -r "{log-error} No such snippet"
-            return 1
-        fi
+        done
     fi
-
     return 0
+} # ]]]
+# FUNCTION: .zinit-prompt [[[
+# Prompt user to confirm
+#
+# $1 - prompt
+#
+# $REPLY - 0 or 1
+.zinit-prompt () {
+    local REPLY
+    read -q ${(%):-"?%s%F{cyan}==>%f%s ${1}? [y/N]: "} && REPLY=y
+    print ''
+    [[ $REPLY == y ]] && return 0 || return 1
 } # ]]]
 # FUNCTION: .zinit-confirm [[[
 # Prints given question, waits for "y" key, evals
@@ -2832,17 +2832,17 @@ builtin print -Pr \"\$ZINIT[col-obj]Done (with the exit code: \$_retval).%f%b\""
     integer retval
     if (( OPTS[opt_-y,--yes] )); then
         builtin eval "${2}"; retval=$?
-        (( OPTS[opt_-q,--quiet] )) || +zinit-message -lrP "{log-msg} Action executed (exit code: {num}${retval}{rst})"
+        (( OPTS[opt_-q,--quiet] )) || +zinit-message -lrP "{m} Action executed (exit code: {num}${retval}{rst})"
     else
       local choice prompt
-      builtin print -D -v prompt "$(+zinit-message '{log-info} Press [{opt}Y{rst}/{opt}y{rst}] to continue: {nl}')"
+      builtin print -D -v prompt "$(+zinit-message '{i} Press [{opt}Y{rst}/{opt}y{rst}] to continue: {nl}')"
       +zinit-message "${1}"
       if builtin read -qs "choice?${prompt}"; then
         builtin eval "${2}"; retval=$?
-        +zinit-message "{log-msg} Action executed (exit code: {num}${retval}{rst})"
+        +zinit-message "{m} Action executed (exit code: {num}${retval}{rst})"
         return 0
       else
-        +zinit-message "{log-msg} No action executed ('{opt}${choice}{rst}' not 'Y' or 'y')"
+        +zinit-message "{m} No action executed ('{opt}${choice}{rst}' not 'Y' or 'y')"
         return 1
       fi
     fi
@@ -3345,8 +3345,6 @@ EOF
       builtin print $EPOCHSECONDS >! "${ZINIT[MAN_DIR]}/COMPILED_AT"
     )
 } # ]]]
-
-
 # FUNCTION: zi::version [[[
 # Shows usage information.
 #
@@ -3355,7 +3353,6 @@ zi::version() {
 	+zinit-message "zinit{cmd} $(git --git-dir=$(realpath ${ZINIT[BIN_DIR]}/.git) describe --tags) {rst}(${OSTYPE}_${CPUTYPE})"
 	return $?
 } # ]]]
-
 # FUNCTION: .zinit-help [[[
 # Shows usage information.
 #
@@ -3430,10 +3427,4 @@ ice_order=( ${${(s.|.)ZINIT[ice-list]}:#teleid} ${(@)${(@)${(@Akons:|:u)${ZINIT_
 print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
 } # ]]]
 
-# Local Variables:
-# mode: Shell-Script
-# sh-indentation: 2
-# indent-tabs-mode: nil
-# sh-basic-offset: 2
-# End:
-# vim: ft=zsh sw=2 ts=2 et foldmarker=[[[,]]] foldmethod=marker
+# vim: set fenc=utf8 ffs=unix foldmarker=[[[,]]] foldmethod=marker ft=zsh list et sts=2 sw=2 ts=2 tw=100:

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -1,4 +1,10 @@
-# Copyright (c) 2016-2020 Sebastian Gniazdowski and contributors.
+#
+# zdharma-continuum/zinit/zinit.zsh
+# Copyright (c) 2016-2021 Sebastian Gniazdowski
+# Copyright (c) 2021-2023 zdharma-continuum
+# Homepage: https://github.com/zdharma-continuum/zinit
+# License: MIT License
+#
 
 #
 # Main state variables.
@@ -191,47 +197,39 @@ autoload -Uz colors && colors
 
 if [[ -z $SOURCED && ( ${+terminfo} -eq 1 && -n ${terminfo[colors]} ) || ( ${+termcap} -eq 1 && -n ${termcap[Co]} ) ]]; then
   ZINIT+=(
-    col-failure $'\e[38;5;204m'   col-happy   $'\e[1m\e[38;5;82m'  col-annex   $'\e[38;5;153m'
-    col-info    $'\e[38;5;82m'    col-info2   $'\e[38;5;227m'      col-profile $'\e[38;5;148m'
-    col-note    $'\e[38;5;148m'   col-error   $'\e[1m\e[38;5;204m' col-p       $'\e[38;5;81m'
-    col-pname   $'\e[1;4m\e[32m'  col-uname   $'\e[1;4m\e[35m'     col-keyword $'\e[32m'
-    col-uninst  $'\e[38;5;118m'   col-info3   $'\e[1m\e[38;5;227m' col-slight  $'\e[38;5;230m'
-    col-apo     $'\e[1;38;5;45m'  col-aps     $'\e[38;5;117m'      col-quo     $'\e[1;38;5;33m'
-    col-bapo    $'\e[1;38;5;220m' col-baps    $'\e[1;38;5;82m'     col-pkg     $'\e[1;3;38;5;27m'
-    col-bar     $'\e[38;5;82m'    col-th-bar  $'\e[38;5;82m'       col-bcmd    $'\e[38;5;220m'
-    col-bspc    $'\b'             col-b-warn  $'\e[1;38;5;214m'    col-u-warn  $'\e[4;38;5;214m'
-    col-cmd     $'\e[38;5;82m'    col-ice     $'\e[38;5;39m'       col-nl      $'\n'
-    col-data    $'\e[38;5;82m'    col-data2   $'\e[38;5;117m'      col-hi      $'\e[1m\e[38;5;183m'
-    col-dir     $'\e[3;38;5;153m' col-func    $'\e[38;5;219m'      col-flag    $'\e[1;3;38;5;79m'
-    col-faint   $'\e[38;5;238m'   col-opt     $'\e[38;5;219m'      col-lhi     $'\e[38;5;81m'
-    col-id-as   $'\e[4;38;5;220m' col-version $'\e[3;38;5;87m'     col-quos    $'\e[1;38;5;160m'
-    col-nu      $'\e[24m'         col-nit     $'\e[23m'            col-nst     $'\e[29m'
-    col-obj     $'\e[38;5;218m'   col-obj2    $'\e[38;5;118m'      col-file    $'\e[3;38;5;117m'
-    col-pre     $'\e[38;5;135m'   col-msg     $'\e[0m'             col-msg2    $'\e[38;5;172m'
-    col-rst     $'\e[0m'          col-b       $'\e[1m'             col-nb      $'\e[22m'
-    col-tab     $' \t '           col-msg3    $'\e[38;5;238m'      col-b-lhi   $'\e[1m\e[38;5;75m'
-    col-txt     $'\e[38;5;254m'   col-num     $'\e[3;38;5;155m'    col-term    $'\e[38;5;185m'
-    col-u       $'\e[4m'          col-it      $'\e[3m'             col-st      $'\e[9m'
-    col-url     $'\e[38;5;75m'    col-meta    $'\e[38;5;57m'       col-meta2   $'\e[38;5;147m'
-    col-var     $'\e[38;5;81m'    col-glob    $'\e[38;5;227m'      col-ehi     $'\e[1m\e[38;5;210m'
-    col-warn    $'\e[38;5;214m'   col-ok      $'\e[38;5;220m'      col-time    $'\e[38;5;220m'
+    col-annex   $'\e[38;5;153m'         col-faint   $'\e[38;5;238m'         col-msg2    $'\e[38;5;172m'      col-quo     $'\e[1;38;5;33m'
+    col-apo     $'\e[1;38;5;45m'        col-file    $'\e[3;38;5;117m'       col-msg3    $'\e[38;5;238m'      col-quos    $'\e[1;38;5;160m'
+    col-aps     $'\e[38;5;117m'         col-flag    $'\e[1;3;38;5;79m'      col-nb      $'\e[22m'            col-rst     $'\e[0m'
+    col-b       $'\e[1m'                col-func    $'\e[38;5;219m'         col-nit     $'\e[23m'            col-slight  $'\e[38;5;230m'
+    col-b-lhi   $'\e[1m\e[38;5;75m'     col-glob    $'\e[38;5;227m'         col-nl      $'\n'                col-st      $'\e[9m'
+    col-b-warn  $'\e[1;38;5;214m'       col-happy   $'\e[1m\e[38;5;82m'     col-note    $'\e[38;5;148m'      col-tab     $' \t '
+    col-bapo    $'\e[1;38;5;220m'       col-hi      $'\e[1m\e[38;5;183m'    col-nst     $'\e[29m'            col-term    $'\e[38;5;185m'
+    col-baps    $'\e[1;38;5;82m'        col-ice     $'\e[38;5;39m'          col-nu      $'\e[24m'            col-th-bar  $'\e[38;5;82m'
+    col-bar     $'\e[38;5;82m'          col-id-as   $'\e[4;38;5;220m'       col-num     $'\e[3;38;5;155m'    col-time    $'\e[38;5;220m'
+    col-bcmd    $'\e[38;5;220m'         col-info    $'\e[38;5;82m'          col-obj     $'\e[38;5;218m'      col-txt     $'\e[38;5;254m'
+    col-bspc    $'\b'                   col-info2   $'\e[38;5;227m'         col-obj2    $'\e[38;5;118m'      col-u       $'\e[4m'
+    col-cmd     $'\e[38;5;82m'          col-info3   $'\e[1m\e[38;5;227m'    col-ok      $'\e[38;5;220m'      col-u-warn  $'\e[4;38;5;214m'
+    col-data    $'\e[38;5;82m'          col-it      $'\e[3m'                col-opt     $'\e[38;5;219m'      col-uname   $'\e[1;4m\e[35m'
+    col-data2   $'\e[38;5;117m'         col-keyword $'\e[32m'               col-p       $'\e[38;5;81m'       col-uninst  $'\e[38;5;118m'
+    col-dir     $'\e[3;38;5;153m'       col-lhi     $'\e[38;5;81m'          col-pkg     $'\e[1;3;38;5;27m'   col-url     $'\e[38;5;75m'
+    col-ehi     $'\e[1m\e[38;5;210m'    col-meta    $'\e[38;5;57m'          col-pname   $'\e[1;4m\e[32m'     col-var     $'\e[38;5;81m'
+    col-error   $'\e[1m\e[38;5;204m'    col-meta2   $'\e[38;5;147m'         col-pre     $'\e[38;5;135m'      col-version $'\e[3;38;5;87m'
+    col-failure $'\e[38;5;204m'         col-msg     $'\e[0m'                col-profile $'\e[38;5;148m'      col-warn    $'\e[38;5;214m'
 
-    col-log-info $'\e[1m\e[38;5;82m'"==>"$'\e[0m'
-    col-log-msg $'\e[38;5;220m'"==>"$'\e[0m'
-    col-log-err $'\e[1m\e[38;5;204m'"Error: "$'\e[0m'
-    col-log-warn $'\e[1m\e[38;5;214m'"Warning: "$'\e[0m'
+    col-i $'\e[0;32m'"==>"$'\e[0m' col-e $'\e[1;91m'"Error: "$'\e[0m'
+    col-m $'\e[0;35m'"==>"$'\e[0m' col-w $'\e[0;33m'"Warning: "$'\e[0m'
 
-    col--…   "${${${(M)LANG:#*UTF-8*}:+⋯⋯}:-···}" col-lr "${${${(M)LANG:#*UTF-8*}:+↔}:-"«-»"}"
-    col-ndsh "${${${(M)LANG:#*UTF-8*}:+–}:-}"     col-…  "${${${(M)LANG:#*UTF-8*}:+…}:-...}"
+    col--…   "${${${(M)LANG:#*UTF-8*}:+⋯⋯}:-···}"    col-lr "${${${(M)LANG:#*UTF-8*}:+↔}:-"«-»"}"
+    col-ndsh "${${${(M)LANG:#*UTF-8*}:+–}:-}"        col-…  "${${${(M)LANG:#*UTF-8*}:+…}:-...}"
 
     col-mdsh  $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+–}:--}"$'\e[0m'
     col-mmdsh $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+――}:--}"$'\e[0m'
 
     col-↔     ${${${(M)LANG:#*UTF-8*}:+$'\e[38;5;82m↔\e[0m'}:-$'\e[38;5;82m«-»\e[0m'}
   )
-  [[ ( ${+terminfo} -eq 1 && ${terminfo[colors]} -ge 256 ) || ( ${+termcap} -eq 1 && ${termcap[Co]} -ge 256 ) ]] && {
+  if [[ ( ${+terminfo} -eq 1 && ${terminfo[colors]} -ge 256 ) || ( ${+termcap} -eq 1 && ${termcap[Co]} -ge 256 ) ]]; then
     ZINIT+=( col-pname $'\e[1;4m\e[38;5;39m' col-uname  $'\e[1;4m\e[38;5;207m' )
-  }
+  fi
 fi
 
 # Hooks
@@ -1203,8 +1201,7 @@ builtin setopt noaliases
         ___value=${___value//(#m)(%[a-zA-Z0-9]##%|\$ZPFX|\$\{ZPFX\})/${___subst_map[$MATCH]}}
         : ${(P)___var_name::=$___value}
     done
-}
-# ]]]
+} # ]]]
 # FUNCTION: @zinit-register-annex [[[
 # Registers the z-annex inside Zinit – i.e. an Zinit extension
 @zinit-register-annex() {
@@ -2602,7 +2599,7 @@ zinit() {
 
     cmd="$1"
     if [[ $cmd == (times|unload|env-whitelist|update|snippet|load|light|cdreplay|\
-cdclear|delete) ]]; then
+cdclear) ]]; then
         if (( $@[(I)-*] || OPTS[opt_-h,--help] )); then
             .zinit-parse-opts "$cmd" "$@"
             if (( OPTS[opt_-h,--help] )); then
@@ -2923,6 +2920,10 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                 (zstatus)
                     .zinit-show-zstatus
                     ;;
+                (delete)
+                    shift
+                    .zinit-delete "$@"
+                    ;;
                 (times)
                     .zinit-show-times "${@[2-correct,-1]}"
                     ;;
@@ -3092,7 +3093,7 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                 (cdlist)
                     .zinit-list-compdef-replay
                     ;;
-                (cd|delete|recall|edit|glance|changes|create|stress)
+                (cd|recall|edit|glance|changes|create|stress)
                     .zinit-"$1" "${@[2-correct,-1]%%(///|//|/)}"; ___retval=$?
                     ;;
                 (recently)


### PR DESCRIPTION
## Description

- `delete` subcommand can now take multiple arguments
- improved logic for `--all`, `--clean` flags
- improved log output
- now cleans up broken symlinks

```
zinit delete <Plugin> <Plugin> ...
```

Closes https://github.com/zdharma-continuum/zinit/issues/57
Closes https://github.com/zdharma-continuum/zinit/issues/239

## Motivation and Context

Usability

## Related Issue(s) <!--- If it fixes an open issue, please link to the issue here. -->

Closes #239
Closes #57

## Usage examples <!--- Provide examples of intended usage -->

zi delete --help

## How Has This Been Tested? <!--- Please describe in detail how you tested your changes. -->

Left side is proposed changes and right side is current Zinit.


### delete output improved

<img width="1312" alt="Screenshot 2023-04-02 at 04 11 51" src="https://user-images.githubusercontent.com/10052309/229343888-bff62c51-5039-466c-990b-05b2fa8d68ef.png">


<img width="1312" alt="Screenshot 2023-04-02 at 04 12 28" src="https://user-images.githubusercontent.com/10052309/229343889-e1a0a9fe-f7bd-4485-90c8-376bbbc649d7.png">

### clean doesn't run if no unloaded plugins

<img width="1312" alt="Screenshot 2023-04-02 at 04 13 41" src="https://user-images.githubusercontent.com/10052309/229343890-f8054f26-cd13-4d69-884a-7d4e214e1f16.png">

### improved logic

<img width="1312" alt="Screenshot 2023-04-02 at 04 25 52" src="https://user-images.githubusercontent.com/10052309/229344341-e7d5911f-8276-4ac0-a67f-9c8b8b7e49f9.png">

## Types of changes <!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist: <!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
