### PR TITLE
fix: `csearch` ignores lua files

### DIFF
--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -1739,7 +1739,7 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
     typeset -a completions
     local pp
     for pp in "${plugin_paths[@]}"; do
-        completions=( "$pp"/**/_[^_.]*~*(*.zwc|*.html|*.txt|*.png|*.jpg|*.jpeg|*.js|*.md|*.yml|*.ri|_zsh_highlight*|/zsdoc/*|*.ps1)(DN^/) )
+        completions=( "$pp"/**/_[^_.]*~*(*.zwc|*.html|*.txt|*.png|*.jpg|*.jpeg|*.js|*.md|*.yml|*.ri|_zsh_highlight*|/zsdoc/*|*.ps1|*.lua)(DN^/) )
         if [[ "${#completions[@]}" -gt 0 ]]; then
             local pd="${pp:t}"
             [[ "${#pd}" -gt "$longest" ]] && longest="${#pd}"
@@ -1750,7 +1750,7 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
 
     local c
     for pp in "${plugin_paths[@]}"; do
-        completions=( "$pp"/**/_[^_.]*~*(*.zwc|*.html|*.txt|*.png|*.jpg|*.jpeg|*.js|*.md|*.yml|*.ri|_zsh_highlight*|/zsdoc/*|*.ps1)(DN^/) )
+        completions=( "$pp"/**/_[^_.]*~*(*.zwc|*.html|*.txt|*.png|*.jpg|*.jpeg|*.js|*.md|*.yml|*.ri|_zsh_highlight*|/zsdoc/*|*.ps1|*.lua)(DN^/) )
 
         if [[ "${#completions[@]}" -gt 0 ]]; then
             # Array of completions, e.g. ( _cp _xauth )


### PR DESCRIPTION
## Description

The `csearch` command now ignores lua files that start with `_`.

## Motivation and Context <!--- What problem does it solve? -->

<img width="1727" alt="Screenshot 2023-05-02 at 05 04 10" src="https://user-images.githubusercontent.com/10052309/235639343-56eef72b-0128-4c14-a5b0-5a5cf4931bd2.png">

## Usage examples

<img width="1728" alt="Screenshot 2023-05-02 at 05 05 15" src="https://user-images.githubusercontent.com/10052309/235639340-adb276cd-16e1-49e5-b04b-7c92916c7ee5.png">

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [X] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
