### PR TITLE
fix: compile and completion log messages

### DIFF
--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -94,7 +94,7 @@ ____
 
 ____
 
-Has 87 line(s). Calls functions:
+Has 83 line(s). Calls functions:
 
  .zinit-compile-plugin
  |-- zinit-side.zsh/.zinit-compute-ice
@@ -349,7 +349,7 @@ ____
 
 ____
 
-Has 61 line(s). Calls functions:
+Has 62 line(s). Calls functions:
 
  .zinit-install-completions
  |-- .zinit-compinit
@@ -850,7 +850,7 @@ ____
 
 ____
 
-Has 573 line(s). Doesn't call other functions.
+Has 549 line(s). Doesn't call other functions.
 
 Uses feature(s): _autoload_, _bindkey_, _compdef_, _compdump_, _eval_, _read_, _setopt_, _unfunction_, _zle_, _zstyle_
 

--- a/doc/zsdoc/zinit.zsh.adoc
+++ b/doc/zsdoc/zinit.zsh.adoc
@@ -1891,7 +1891,7 @@ ____
 
 ____
 
-Has 134 line(s). Doesn't call other functions.
+Has 117 line(s). Doesn't call other functions.
 
 Called by:
 
@@ -1914,7 +1914,7 @@ ____
 
 ____
 
-Has 573 line(s). Doesn't call other functions.
+Has 549 line(s). Doesn't call other functions.
 
 Uses feature(s): _autoload_, _bindkey_, _compdef_, _compdump_, _eval_, _read_, _setopt_, _unfunction_, _zle_, _zstyle_
 

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -217,8 +217,8 @@ if [[ -z $SOURCED && ( ${+terminfo} -eq 1 && -n ${terminfo[colors]} ) || ( ${+te
     col-error   $'\e[1m\e[38;5;204m'    col-meta2   $'\e[38;5;147m'         col-pre     $'\e[38;5;135m'      col-version $'\e[3;38;5;87m'
     col-failure $'\e[38;5;204m'         col-msg     $'\e[0m'                col-profile $'\e[38;5;148m'      col-warn    $'\e[38;5;214m'
 
-    col-i $'\e[0;32m'"==>"$'\e[0m' col-e $'\e[1;91m'"Error: "$'\e[0m'
-    col-m $'\e[0;35m'"==>"$'\e[0m' col-w $'\e[0;33m'"Warning: "$'\e[0m'
+    col-i $'\e[1m\e[38;5;82m'"==>"$'\e[0m' col-e $'\e[1m\e[38;5;204m'"Error: "$'\e[0m'
+    col-m $'\e[1m\e[38;5;135m'"==>"$'\e[0m' col-w $'\e[1;38;5;214m'"Warning: "$'\e[0m'
 
     col--…   "${${${(M)LANG:#*UTF-8*}:+⋯⋯}:-···}"    col-lr "${${${(M)LANG:#*UTF-8*}:+↔}:-"«-»"}"
     col-ndsh "${${${(M)LANG:#*UTF-8*}:+–}:-}"        col-…  "${${${(M)LANG:#*UTF-8*}:+…}:-...}"


### PR DESCRIPTION
## Description

Update completion and compile log messages.

<img width="393" alt="Screenshot 2023-05-04 at 06 07 10" src="https://user-images.githubusercontent.com/10052309/236193150-21c0eefa-914d-46d6-bbac-6b7b9d77e01e.png">

## Usage examples

<img width="490" alt="Screenshot 2023-05-04 at 06 40 32" src="https://user-images.githubusercontent.com/10052309/236193563-56e3943a-da95-48e6-a7e3-92a424d06418.png">

<img width="585" alt="Screenshot 2023-05-04 at 06 40 27" src="https://user-images.githubusercontent.com/10052309/236193566-f1736c9d-1b76-416f-b5aa-49072a390b69.png">

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [X] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
