### PR TITLE
fix: creinstall cmd `--quiet` & `--force` flags

### DIFF
--- a/_zinit
+++ b/_zinit
@@ -194,7 +194,12 @@ _zinit_create(){
 } # ]]]
 # FUNCTION: _zinit_creinstall [[[
 _zinit_creinstall(){
-  _arguments - plugin '1::plugin:__zinit_installed_plugins' && ret=0
+  _arguments -A \
+    {-f,--force}'[Force new download of the snippet file]' \
+    {-h,--help}'[Show this help message]' \
+    {-q,--quiet}'[Turn off messages from the operation]' \
+    '1::plugin:__zinit_installed_plugins' \
+  && ret=0
 } # ]]]
 # FUNCTION: _zinit_csearch [[[
 _zinit_csearch(){
@@ -223,14 +228,15 @@ _zinit_debug(){
 _zinit_edit(){
   _arguments \
     - installed '*::plugin:__zinit_installed_plugins' \
-    - snippet '*::snippet:__zinit_installed_snippets' && ret=0
+    - snippet '*::snippet:__zinit_installed_snippets' \
+  && ret=0
 } # ]]]
 # FUNCTION: _zinit_env_whitelist [[[
 _zinit_env_whitelist(){
   _arguments -A \
     '(-h --help)'{-h,--help}'[Show this help message]' \
     '(-v --verbose)'{-v,--verbose}'[Make some output more verbose]' \
-    && ret=0
+  && ret=0
 } # ]]]
 # FUNCTION: _zinit_glance [[[
 _zinit_glance(){
@@ -269,7 +275,8 @@ _zinit_report(){
 _zinit_run(){
   _arguments \
     - installed '1:installed:__zinit_installed' \
-    '2:command to run:' && ret=0
+    '2:command to run:' \
+  && ret=0
 } # ]]]
 # FUNCTION: _zinit_self_update [[[
 _zinit_self_update(){
@@ -312,7 +319,8 @@ _zinit_unload(){
   _arguments -A \
     '(-h --help)'{-h,--help}'[Show this help message]' \
     '(-q --quiet)'{-q,--quiet}'[Turn off messages from the operation]' \
-    - installed '*:installed:__zinit_installed'
+    - installed '*:installed:__zinit_installed' \
+  && ret=0
 } # ]]]
 # FUNCTION: _zinit_update [[[
 _zinit_update(){
@@ -326,7 +334,8 @@ _zinit_update(){
       '--parallel[Turn on concurrent, multi-thread update (of all objects)]' \
       '(-a --all)'{-a,--all}'[Update all plugins and snippets]' \
   - set2 \
-      '1:installed:__zinit_installed'
+      '1:installed:__zinit_installed' \
+  && ret=0
 } # ]]]
 # FUNCTION: _zunit_load [[[
 _zinit_load() {

--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -204,11 +204,8 @@ Has 377 line(s). Calls functions:
  |   |   |-- .zinit-forget-completion
  |   |   |-- compinit
  |   |   `-- zinit.zsh/+zinit-message
- |   |-- .zinit-forget-completion
- |   |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- |   |-- zinit-side.zsh/.zinit-exists-physically-message
- |   |-- zinit.zsh/+zinit-message
- |   `-- zinit.zsh/.zinit-any-to-user-plugin
+ |   |-- zinit.zsh/+zi-log
+ |   `-- zinit.zsh/+zinit-message
  |-- .zinit-mirror-using-svn
  |-- zinit-side.zsh/.zinit-store-ices
  |-- zinit.zsh/+zinit-message
@@ -254,7 +251,6 @@ Uses feature(s): _setopt_, _unfunction_
 Called by:
 
  .zinit-compinit
- .zinit-install-completions
  zinit-autoload.zsh/.zinit-uninstall-completions
  zinit.zsh/zinit
 
@@ -338,37 +334,32 @@ Called by:
 
 ____
  
- Installs all completions of given plugin. After that they are
- visible to 'compinit'. Visible completions can be selectively
- disabled and enabled. User can access completion data with
- 'clist' or 'completions' subcommand.
+ Installs plugin completions.
  
  $1 - plugin spec (4 formats: user---plugin, user/plugin, user, plugin)
  $2 - plugin if $1 (i.e., user) given
  $3 - if 1, then reinstall, otherwise only install completions that are not present
+ 
 
 ____
 
-Has 62 line(s). Calls functions:
+Has 76 line(s). Calls functions:
 
  .zinit-install-completions
  |-- .zinit-compinit
  |   |-- .zinit-forget-completion
  |   |-- compinit
  |   `-- zinit.zsh/+zinit-message
- |-- .zinit-forget-completion
- |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- |-- zinit-side.zsh/.zinit-exists-physically-message
- |-- zinit.zsh/+zinit-message
- `-- zinit.zsh/.zinit-any-to-user-plugin
+ |-- zinit.zsh/+zi-log
+ `-- zinit.zsh/+zinit-message
 
-Uses feature(s): _setopt_
+Uses feature(s): _setopt_, _zparseopts_
 
 Called by:
 
  .zinit-download-snippet
  .zinit-setup-plugin-dir
- zinit.zsh/zinit
+ zinit.zsh/+zi-cmp-reinstall
 
 ==== .zinit-jq-check
 
@@ -487,11 +478,8 @@ Has 214 line(s). Calls functions:
  |   |   |-- .zinit-forget-completion
  |   |   |-- compinit
  |   |   `-- zinit.zsh/+zinit-message
- |   |-- .zinit-forget-completion
- |   |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- |   |-- zinit-side.zsh/.zinit-exists-physically-message
- |   |-- zinit.zsh/+zinit-message
- |   `-- zinit.zsh/.zinit-any-to-user-plugin
+ |   |-- zinit.zsh/+zi-log
+ |   `-- zinit.zsh/+zinit-message
  |-- ziextract
  |   `-- zinit.zsh/+zinit-message
  |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
@@ -534,11 +522,8 @@ Has 76 line(s). Calls functions:
  |   |   |   |-- .zinit-forget-completion
  |   |   |   |-- compinit
  |   |   |   `-- zinit.zsh/+zinit-message
- |   |   |-- .zinit-forget-completion
- |   |   |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- |   |   |-- zinit-side.zsh/.zinit-exists-physically-message
- |   |   |-- zinit.zsh/+zinit-message
- |   |   `-- zinit.zsh/.zinit-any-to-user-plugin
+ |   |   |-- zinit.zsh/+zi-log
+ |   |   `-- zinit.zsh/+zinit-message
  |   |-- .zinit-mirror-using-svn
  |   |-- zinit-side.zsh/.zinit-store-ices
  |   |-- zinit.zsh/+zinit-message
@@ -850,7 +835,7 @@ ____
 
 ____
 
-Has 549 line(s). Doesn't call other functions.
+Has 573 line(s). Doesn't call other functions.
 
 Uses feature(s): _autoload_, _bindkey_, _compdef_, _compdump_, _eval_, _read_, _setopt_, _unfunction_, _zle_, _zstyle_
 

--- a/doc/zsdoc/zinit-side.zsh.adoc
+++ b/doc/zsdoc/zinit-side.zsh.adoc
@@ -60,7 +60,6 @@ Called by:
  zinit-autoload.zsh/.zinit-update-all-parallel
  zinit-autoload.zsh/.zinit-update-or-status-all
  zinit-autoload.zsh/.zinit-update-or-status
- zinit-install.zsh/.zinit-install-completions
  zinit-install.zsh/.zinit-setup-plugin-dir
  zinit.zsh/.zinit-formatter-pid
 
@@ -205,7 +204,6 @@ Called by:
  zinit-autoload.zsh/.zinit-glance
  zinit-autoload.zsh/.zinit-stress
  zinit-autoload.zsh/.zinit-update-or-status
- zinit-install.zsh/.zinit-install-completions
 
 ==== .zinit-first
 

--- a/doc/zsdoc/zinit.zsh.adoc
+++ b/doc/zsdoc/zinit.zsh.adoc
@@ -6,6 +6,7 @@ zinit.zsh - a shell script
 Documentation automatically generated with `zshelldoc'
 
 == FUNCTIONS
+ +zi-cmp-reinstall
  +zi-log
  +zinit-deploy-message
  +zinit-message
@@ -89,6 +90,7 @@ Has 244 line(s). Calls functions:
 
  Script-Body
  |-- +zinit-message
+ |   `-- +zi-log
  |-- .zinit-get-mtime-into
  |-- .zinit-prepare-home
  |   |-- zinit-autoload.zsh/.zinit-clear-completions
@@ -98,15 +100,22 @@ Has 244 line(s). Calls functions:
  |-- colors
  |-- is-at-least
  |-- zinit
+ |   |-- +zi-cmp-reinstall
+ |   |   |-- compinit
+ |   |   `-- zinit-install.zsh/.zinit-install-completions
  |   |-- +zinit-message
+ |   |   `-- +zi-log
  |   |-- +zinit-prehelp-usage-message
  |   |   `-- +zinit-message
+ |   |       `-- +zi-log
  |   |-- .zinit-add-fpath
  |   |   `-- .zinit-any-to-user-plugin
  |   |-- .zinit-compdef-clear
  |   |   `-- +zinit-message
+ |   |       `-- +zi-log
  |   |-- .zinit-compdef-replay
  |   |   `-- +zinit-message
+ |   |       `-- +zi-log
  |   |-- .zinit-get-object-path
  |   |   `-- .zinit-any-to-user-plugin
  |   |-- .zinit-ice
@@ -130,12 +139,14 @@ Has 244 line(s). Calls functions:
  |   |   |   |   |-- .zinit-tmp-subst-on
  |   |   |   |   `-- :zinit-tmp-subst-autoload
  |   |   |   |       |-- +zinit-message
+ |   |   |   |       |   `-- +zi-log
  |   |   |   |       |-- .zinit-add-report
  |   |   |   |       |-- .zinit-any-to-user-plugin
  |   |   |   |       `-- is-at-least
  |   |   |   |-- .zinit-load-snippet
  |   |   |   |   |-- +zinit-deploy-message
  |   |   |   |   |-- +zinit-message
+ |   |   |   |   |   `-- +zi-log
  |   |   |   |   |-- .zinit-add-report
  |   |   |   |   |-- .zinit-find-other-matches
  |   |   |   |   |-- .zinit-get-object-path
@@ -143,19 +154,23 @@ Has 244 line(s). Calls functions:
  |   |   |   |   |-- .zinit-pack-ice
  |   |   |   |   |-- .zinit-set-m-func
  |   |   |   |   |   `-- +zinit-message
+ |   |   |   |   |       `-- +zi-log
  |   |   |   |   |-- .zinit-setup-params
  |   |   |   |   `-- zinit-install.zsh/.zinit-download-snippet
  |   |   |   |-- .zinit-pack-ice
  |   |   |   |-- .zinit-register-plugin
  |   |   |   |   `-- +zinit-message
+ |   |   |   |       `-- +zi-log
  |   |   |   |-- .zinit-set-m-func
  |   |   |   |   `-- +zinit-message
+ |   |   |   |       `-- +zi-log
  |   |   |   |-- .zinit-setup-params
  |   |   |   |-- zinit-install.zsh/.zinit-get-package
  |   |   |   `-- zinit-install.zsh/.zinit-setup-plugin-dir
  |   |   `-- .zinit-load-snippet
  |   |       |-- +zinit-deploy-message
  |   |       |-- +zinit-message
+ |   |       |   `-- +zi-log
  |   |       |-- .zinit-add-report
  |   |       |-- .zinit-find-other-matches
  |   |       |-- .zinit-get-object-path
@@ -163,11 +178,13 @@ Has 244 line(s). Calls functions:
  |   |       |-- .zinit-pack-ice
  |   |       |-- .zinit-set-m-func
  |   |       |   `-- +zinit-message
+ |   |       |       `-- +zi-log
  |   |       |-- .zinit-setup-params
  |   |       `-- zinit-install.zsh/.zinit-download-snippet
  |   |-- .zinit-parse-opts
  |   |-- .zinit-run
  |   |   |-- +zinit-message
+ |   |   |   `-- +zi-log
  |   |   |-- .zinit-any-to-user-plugin
  |   |   `-- .zinit-get-object-path
  |   |       `-- .zinit-any-to-user-plugin
@@ -202,15 +219,14 @@ Has 244 line(s). Calls functions:
  |   |-- zinit-autoload.zsh/zi::version
  |   |-- zinit-install.zsh/.zinit-compile-plugin
  |   |-- zinit-install.zsh/.zinit-compinit
- |   |-- zinit-install.zsh/.zinit-forget-completion
- |   `-- zinit-install.zsh/.zinit-install-completions
+ |   `-- zinit-install.zsh/.zinit-forget-completion
  `-- zinit-autoload.zsh/.zinit-module
 
 Uses feature(s): _add-zsh-hook_, _alias_, _autoload_, _bindkey_, _colors_, _export_, _is-at-least_, _setopt_, _source_, _zle_, _zmodload_, _zstyle_
 
 _Exports (environment):_ PMSPEC [big]*//* ZPFX [big]*//* ZSH_CACHE_DIR
 
-==== +zi-log
+==== +zi-cmp-reinstall
 
 ____
  
@@ -218,13 +234,31 @@ ____
 
 ____
 
-Has 1 line(s). Calls functions:
+Has 5 line(s). Calls functions:
 
- +zi-log
- `-- +zinit-message
+ +zi-cmp-reinstall
+ |-- compinit
+ `-- zinit-install.zsh/.zinit-install-completions
+
+Uses feature(s): _autoload_, _compinit_, _source_
 
 Called by:
 
+ zinit
+
+==== +zi-log
+
+____
+ 
+ Logging function
+
+____
+
+Has 16 line(s). Doesn't call other functions.
+
+Called by:
+
+ +zinit-message
  zinit-additional.zsh/.zinit-debug-clear
  zinit-additional.zsh/.zinit-debug-report
  zinit-additional.zsh/.zinit-debug-revert
@@ -233,6 +267,7 @@ Called by:
  zinit-additional.zsh/.zinit-debug-stop
  zinit-additional.zsh/:zinit-tmp-subst-source
  zinit-autoload.zsh/.zinit-unload
+ zinit-install.zsh/.zinit-install-completions
 
 ==== +zinit-deploy-message
 
@@ -257,15 +292,17 @@ Called by:
 
 ____
  
- Logging function
+ Wrapper function for +zinit-message until migrated to +zi-log
 
 ____
 
-Has 16 line(s). Doesn't call other functions.
+Has 1 line(s). Calls functions:
+
+ +zinit-message
+ `-- +zi-log
 
 Called by:
 
- +zi-log
  +zinit-prehelp-usage-message
  .zinit-compdef-clear
  .zinit-compdef-replay
@@ -316,6 +353,7 @@ Has 38 line(s). Calls functions:
 
  +zinit-prehelp-usage-message
  `-- +zinit-message
+     `-- +zi-log
 
 Called by:
 
@@ -425,7 +463,6 @@ Called by:
  zinit-autoload.zsh/.zinit-update-all-parallel
  zinit-autoload.zsh/.zinit-update-or-status-all
  zinit-autoload.zsh/.zinit-update-or-status
- zinit-install.zsh/.zinit-install-completions
  zinit-side.zsh/.zinit-any-colorify-as-uspl2
  zinit-side.zsh/.zinit-compute-ice
  zinit-side.zsh/.zinit-exists-physically-message
@@ -444,6 +481,7 @@ Has 3 line(s). Calls functions:
 
  .zinit-compdef-clear
  `-- +zinit-message
+     `-- +zi-log
 
 Called by:
 
@@ -463,6 +501,7 @@ Has 17 line(s). Calls functions:
 
  .zinit-compdef-replay
  `-- +zinit-message
+     `-- +zi-log
 
 Uses feature(s): _compdef_
 
@@ -727,12 +766,14 @@ Has 95 line(s). Calls functions:
  |   |-- .zinit-tmp-subst-on
  |   `-- :zinit-tmp-subst-autoload
  |       |-- +zinit-message
+ |       |   `-- +zi-log
  |       |-- .zinit-add-report
  |       |-- .zinit-any-to-user-plugin
  |       `-- is-at-least
  |-- .zinit-load-snippet
  |   |-- +zinit-deploy-message
  |   |-- +zinit-message
+ |   |   `-- +zi-log
  |   |-- .zinit-add-report
  |   |-- .zinit-find-other-matches
  |   |-- .zinit-get-object-path
@@ -740,13 +781,16 @@ Has 95 line(s). Calls functions:
  |   |-- .zinit-pack-ice
  |   |-- .zinit-set-m-func
  |   |   `-- +zinit-message
+ |   |       `-- +zi-log
  |   |-- .zinit-setup-params
  |   `-- zinit-install.zsh/.zinit-download-snippet
  |-- .zinit-pack-ice
  |-- .zinit-register-plugin
  |   `-- +zinit-message
+ |       `-- +zi-log
  |-- .zinit-set-m-func
  |   `-- +zinit-message
+ |       `-- +zi-log
  |-- .zinit-setup-params
  |-- zinit-install.zsh/.zinit-get-package
  `-- zinit-install.zsh/.zinit-setup-plugin-dir
@@ -792,12 +836,14 @@ Has 12 line(s). Calls functions:
  |   |   |-- .zinit-tmp-subst-on
  |   |   `-- :zinit-tmp-subst-autoload
  |   |       |-- +zinit-message
+ |   |       |   `-- +zi-log
  |   |       |-- .zinit-add-report
  |   |       |-- .zinit-any-to-user-plugin
  |   |       `-- is-at-least
  |   |-- .zinit-load-snippet
  |   |   |-- +zinit-deploy-message
  |   |   |-- +zinit-message
+ |   |   |   `-- +zi-log
  |   |   |-- .zinit-add-report
  |   |   |-- .zinit-find-other-matches
  |   |   |-- .zinit-get-object-path
@@ -805,19 +851,23 @@ Has 12 line(s). Calls functions:
  |   |   |-- .zinit-pack-ice
  |   |   |-- .zinit-set-m-func
  |   |   |   `-- +zinit-message
+ |   |   |       `-- +zi-log
  |   |   |-- .zinit-setup-params
  |   |   `-- zinit-install.zsh/.zinit-download-snippet
  |   |-- .zinit-pack-ice
  |   |-- .zinit-register-plugin
  |   |   `-- +zinit-message
+ |   |       `-- +zi-log
  |   |-- .zinit-set-m-func
  |   |   `-- +zinit-message
+ |   |       `-- +zi-log
  |   |-- .zinit-setup-params
  |   |-- zinit-install.zsh/.zinit-get-package
  |   `-- zinit-install.zsh/.zinit-setup-plugin-dir
  `-- .zinit-load-snippet
      |-- +zinit-deploy-message
      |-- +zinit-message
+     |   `-- +zi-log
      |-- .zinit-add-report
      |-- .zinit-find-other-matches
      |-- .zinit-get-object-path
@@ -825,6 +875,7 @@ Has 12 line(s). Calls functions:
      |-- .zinit-pack-ice
      |-- .zinit-set-m-func
      |   `-- +zinit-message
+     |       `-- +zi-log
      |-- .zinit-setup-params
      `-- zinit-install.zsh/.zinit-download-snippet
 
@@ -859,6 +910,7 @@ Has 128 line(s). Calls functions:
  |-- .zinit-tmp-subst-on
  `-- :zinit-tmp-subst-autoload
      |-- +zinit-message
+     |   `-- +zi-log
      |-- .zinit-add-report
      |-- .zinit-any-to-user-plugin
      `-- is-at-least
@@ -884,6 +936,7 @@ Has 203 line(s). Calls functions:
  .zinit-load-snippet
  |-- +zinit-deploy-message
  |-- +zinit-message
+ |   `-- +zi-log
  |-- .zinit-add-report
  |-- .zinit-find-other-matches
  |-- .zinit-get-object-path
@@ -891,6 +944,7 @@ Has 203 line(s). Calls functions:
  |-- .zinit-pack-ice
  |-- .zinit-set-m-func
  |   `-- +zinit-message
+ |       `-- +zi-log
  |-- .zinit-setup-params
  `-- zinit-install.zsh/.zinit-download-snippet
 
@@ -974,6 +1028,7 @@ Has 23 line(s). Calls functions:
 
  .zinit-register-plugin
  `-- +zinit-message
+     `-- +zi-log
 
 Called by:
 
@@ -992,6 +1047,7 @@ Has 24 line(s). Calls functions:
 
  .zinit-run
  |-- +zinit-message
+ |   `-- +zi-log
  |-- .zinit-any-to-user-plugin
  `-- .zinit-get-object-path
      `-- .zinit-any-to-user-plugin
@@ -1039,12 +1095,14 @@ Has 47 line(s). Calls functions:
  |   |   |-- .zinit-tmp-subst-on
  |   |   `-- :zinit-tmp-subst-autoload
  |   |       |-- +zinit-message
+ |   |       |   `-- +zi-log
  |   |       |-- .zinit-add-report
  |   |       |-- .zinit-any-to-user-plugin
  |   |       `-- is-at-least
  |   |-- .zinit-load-snippet
  |   |   |-- +zinit-deploy-message
  |   |   |-- +zinit-message
+ |   |   |   `-- +zi-log
  |   |   |-- .zinit-add-report
  |   |   |-- .zinit-find-other-matches
  |   |   |-- .zinit-get-object-path
@@ -1052,19 +1110,23 @@ Has 47 line(s). Calls functions:
  |   |   |-- .zinit-pack-ice
  |   |   |-- .zinit-set-m-func
  |   |   |   `-- +zinit-message
+ |   |   |       `-- +zi-log
  |   |   |-- .zinit-setup-params
  |   |   `-- zinit-install.zsh/.zinit-download-snippet
  |   |-- .zinit-pack-ice
  |   |-- .zinit-register-plugin
  |   |   `-- +zinit-message
+ |   |       `-- +zi-log
  |   |-- .zinit-set-m-func
  |   |   `-- +zinit-message
+ |   |       `-- +zi-log
  |   |-- .zinit-setup-params
  |   |-- zinit-install.zsh/.zinit-get-package
  |   `-- zinit-install.zsh/.zinit-setup-plugin-dir
  |-- .zinit-load-snippet
  |   |-- +zinit-deploy-message
  |   |-- +zinit-message
+ |   |   `-- +zi-log
  |   |-- .zinit-add-report
  |   |-- .zinit-find-other-matches
  |   |-- .zinit-get-object-path
@@ -1072,6 +1134,7 @@ Has 47 line(s). Calls functions:
  |   |-- .zinit-pack-ice
  |   |-- .zinit-set-m-func
  |   |   `-- +zinit-message
+ |   |       `-- +zi-log
  |   |-- .zinit-setup-params
  |   `-- zinit-install.zsh/.zinit-download-snippet
  `-- zinit-autoload.zsh/.zinit-unload
@@ -1095,6 +1158,7 @@ Has 17 line(s). Calls functions:
 
  .zinit-set-m-func
  `-- +zinit-message
+     `-- +zi-log
 
 Uses feature(s): _setopt_
 
@@ -1243,6 +1307,7 @@ Has 111 line(s). Calls functions:
 
  :zinit-tmp-subst-autoload
  |-- +zinit-message
+ |   `-- +zi-log
  |-- .zinit-add-report
  |-- .zinit-any-to-user-plugin
  `-- is-at-least
@@ -1338,6 +1403,7 @@ Has 4 line(s). Calls functions:
  @autoload
  `-- :zinit-tmp-subst-autoload
      |-- +zinit-message
+     |   `-- +zi-log
      |-- .zinit-add-report
      |-- .zinit-any-to-user-plugin
      `-- is-at-least
@@ -1415,12 +1481,14 @@ Has 75 line(s). *Is a precmd hook*. Calls functions:
  |   |   |   |-- .zinit-tmp-subst-on
  |   |   |   `-- :zinit-tmp-subst-autoload
  |   |   |       |-- +zinit-message
+ |   |   |       |   `-- +zi-log
  |   |   |       |-- .zinit-add-report
  |   |   |       |-- .zinit-any-to-user-plugin
  |   |   |       `-- is-at-least
  |   |   |-- .zinit-load-snippet
  |   |   |   |-- +zinit-deploy-message
  |   |   |   |-- +zinit-message
+ |   |   |   |   `-- +zi-log
  |   |   |   |-- .zinit-add-report
  |   |   |   |-- .zinit-find-other-matches
  |   |   |   |-- .zinit-get-object-path
@@ -1428,19 +1496,23 @@ Has 75 line(s). *Is a precmd hook*. Calls functions:
  |   |   |   |-- .zinit-pack-ice
  |   |   |   |-- .zinit-set-m-func
  |   |   |   |   `-- +zinit-message
+ |   |   |   |       `-- +zi-log
  |   |   |   |-- .zinit-setup-params
  |   |   |   `-- zinit-install.zsh/.zinit-download-snippet
  |   |   |-- .zinit-pack-ice
  |   |   |-- .zinit-register-plugin
  |   |   |   `-- +zinit-message
+ |   |   |       `-- +zi-log
  |   |   |-- .zinit-set-m-func
  |   |   |   `-- +zinit-message
+ |   |   |       `-- +zi-log
  |   |   |-- .zinit-setup-params
  |   |   |-- zinit-install.zsh/.zinit-get-package
  |   |   `-- zinit-install.zsh/.zinit-setup-plugin-dir
  |   |-- .zinit-load-snippet
  |   |   |-- +zinit-deploy-message
  |   |   |-- +zinit-message
+ |   |   |   `-- +zi-log
  |   |   |-- .zinit-add-report
  |   |   |-- .zinit-find-other-matches
  |   |   |-- .zinit-get-object-path
@@ -1448,6 +1520,7 @@ Has 75 line(s). *Is a precmd hook*. Calls functions:
  |   |   |-- .zinit-pack-ice
  |   |   |-- .zinit-set-m-func
  |   |   |   `-- +zinit-message
+ |   |   |       `-- +zi-log
  |   |   |-- .zinit-setup-params
  |   |   `-- zinit-install.zsh/.zinit-download-snippet
  |   `-- zinit-autoload.zsh/.zinit-unload
@@ -1514,6 +1587,7 @@ Has 15 line(s). Calls functions:
  `-- .zinit-load-snippet
      |-- +zinit-deploy-message
      |-- +zinit-message
+     |   `-- +zi-log
      |-- .zinit-add-report
      |-- .zinit-find-other-matches
      |-- .zinit-get-object-path
@@ -1521,6 +1595,7 @@ Has 15 line(s). Calls functions:
      |-- .zinit-pack-ice
      |-- .zinit-set-m-func
      |   `-- +zinit-message
+     |       `-- +zi-log
      |-- .zinit-setup-params
      `-- zinit-install.zsh/.zinit-download-snippet
 
@@ -1542,6 +1617,7 @@ Has 1 line(s). Calls functions:
  zicdclear
  `-- .zinit-compdef-clear
      `-- +zinit-message
+         `-- +zi-log
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1559,6 +1635,7 @@ Has 1 line(s). Calls functions:
  zicdreplay
  `-- .zinit-compdef-replay
      `-- +zinit-message
+         `-- +zi-log
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1603,18 +1680,25 @@ ____
 
 ____
 
-Has 553 line(s). Calls functions:
+Has 519 line(s). Calls functions:
 
  zinit
+ |-- +zi-cmp-reinstall
+ |   |-- compinit
+ |   `-- zinit-install.zsh/.zinit-install-completions
  |-- +zinit-message
+ |   `-- +zi-log
  |-- +zinit-prehelp-usage-message
  |   `-- +zinit-message
+ |       `-- +zi-log
  |-- .zinit-add-fpath
  |   `-- .zinit-any-to-user-plugin
  |-- .zinit-compdef-clear
  |   `-- +zinit-message
+ |       `-- +zi-log
  |-- .zinit-compdef-replay
  |   `-- +zinit-message
+ |       `-- +zi-log
  |-- .zinit-get-object-path
  |   `-- .zinit-any-to-user-plugin
  |-- .zinit-ice
@@ -1638,12 +1722,14 @@ Has 553 line(s). Calls functions:
  |   |   |   |-- .zinit-tmp-subst-on
  |   |   |   `-- :zinit-tmp-subst-autoload
  |   |   |       |-- +zinit-message
+ |   |   |       |   `-- +zi-log
  |   |   |       |-- .zinit-add-report
  |   |   |       |-- .zinit-any-to-user-plugin
  |   |   |       `-- is-at-least
  |   |   |-- .zinit-load-snippet
  |   |   |   |-- +zinit-deploy-message
  |   |   |   |-- +zinit-message
+ |   |   |   |   `-- +zi-log
  |   |   |   |-- .zinit-add-report
  |   |   |   |-- .zinit-find-other-matches
  |   |   |   |-- .zinit-get-object-path
@@ -1651,19 +1737,23 @@ Has 553 line(s). Calls functions:
  |   |   |   |-- .zinit-pack-ice
  |   |   |   |-- .zinit-set-m-func
  |   |   |   |   `-- +zinit-message
+ |   |   |   |       `-- +zi-log
  |   |   |   |-- .zinit-setup-params
  |   |   |   `-- zinit-install.zsh/.zinit-download-snippet
  |   |   |-- .zinit-pack-ice
  |   |   |-- .zinit-register-plugin
  |   |   |   `-- +zinit-message
+ |   |   |       `-- +zi-log
  |   |   |-- .zinit-set-m-func
  |   |   |   `-- +zinit-message
+ |   |   |       `-- +zi-log
  |   |   |-- .zinit-setup-params
  |   |   |-- zinit-install.zsh/.zinit-get-package
  |   |   `-- zinit-install.zsh/.zinit-setup-plugin-dir
  |   `-- .zinit-load-snippet
  |       |-- +zinit-deploy-message
  |       |-- +zinit-message
+ |       |   `-- +zi-log
  |       |-- .zinit-add-report
  |       |-- .zinit-find-other-matches
  |       |-- .zinit-get-object-path
@@ -1671,11 +1761,13 @@ Has 553 line(s). Calls functions:
  |       |-- .zinit-pack-ice
  |       |-- .zinit-set-m-func
  |       |   `-- +zinit-message
+ |       |       `-- +zi-log
  |       |-- .zinit-setup-params
  |       `-- zinit-install.zsh/.zinit-download-snippet
  |-- .zinit-parse-opts
  |-- .zinit-run
  |   |-- +zinit-message
+ |   |   `-- +zi-log
  |   |-- .zinit-any-to-user-plugin
  |   `-- .zinit-get-object-path
  |       `-- .zinit-any-to-user-plugin
@@ -1710,8 +1802,7 @@ Has 553 line(s). Calls functions:
  |-- zinit-autoload.zsh/zi::version
  |-- zinit-install.zsh/.zinit-compile-plugin
  |-- zinit-install.zsh/.zinit-compinit
- |-- zinit-install.zsh/.zinit-forget-completion
- `-- zinit-install.zsh/.zinit-install-completions
+ `-- zinit-install.zsh/.zinit-forget-completion
 
 Uses feature(s): _autoload_, _compinit_, _eval_, _setopt_, _source_
 
@@ -1728,6 +1819,7 @@ Has 1 line(s). Calls functions:
  zpcdclear
  `-- .zinit-compdef-clear
      `-- +zinit-message
+         `-- +zi-log
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1738,6 +1830,7 @@ Has 1 line(s). Calls functions:
  zpcdreplay
  `-- .zinit-compdef-replay
      `-- +zinit-message
+         `-- +zi-log
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1764,15 +1857,22 @@ Has 1 line(s). Calls functions:
 
  zplugin
  `-- zinit
+     |-- +zi-cmp-reinstall
+     |   |-- compinit
+     |   `-- zinit-install.zsh/.zinit-install-completions
      |-- +zinit-message
+     |   `-- +zi-log
      |-- +zinit-prehelp-usage-message
      |   `-- +zinit-message
+     |       `-- +zi-log
      |-- .zinit-add-fpath
      |   `-- .zinit-any-to-user-plugin
      |-- .zinit-compdef-clear
      |   `-- +zinit-message
+     |       `-- +zi-log
      |-- .zinit-compdef-replay
      |   `-- +zinit-message
+     |       `-- +zi-log
      |-- .zinit-get-object-path
      |   `-- .zinit-any-to-user-plugin
      |-- .zinit-ice
@@ -1796,12 +1896,14 @@ Has 1 line(s). Calls functions:
      |   |   |   |-- .zinit-tmp-subst-on
      |   |   |   `-- :zinit-tmp-subst-autoload
      |   |   |       |-- +zinit-message
+     |   |   |       |   `-- +zi-log
      |   |   |       |-- .zinit-add-report
      |   |   |       |-- .zinit-any-to-user-plugin
      |   |   |       `-- is-at-least
      |   |   |-- .zinit-load-snippet
      |   |   |   |-- +zinit-deploy-message
      |   |   |   |-- +zinit-message
+     |   |   |   |   `-- +zi-log
      |   |   |   |-- .zinit-add-report
      |   |   |   |-- .zinit-find-other-matches
      |   |   |   |-- .zinit-get-object-path
@@ -1809,19 +1911,23 @@ Has 1 line(s). Calls functions:
      |   |   |   |-- .zinit-pack-ice
      |   |   |   |-- .zinit-set-m-func
      |   |   |   |   `-- +zinit-message
+     |   |   |   |       `-- +zi-log
      |   |   |   |-- .zinit-setup-params
      |   |   |   `-- zinit-install.zsh/.zinit-download-snippet
      |   |   |-- .zinit-pack-ice
      |   |   |-- .zinit-register-plugin
      |   |   |   `-- +zinit-message
+     |   |   |       `-- +zi-log
      |   |   |-- .zinit-set-m-func
      |   |   |   `-- +zinit-message
+     |   |   |       `-- +zi-log
      |   |   |-- .zinit-setup-params
      |   |   |-- zinit-install.zsh/.zinit-get-package
      |   |   `-- zinit-install.zsh/.zinit-setup-plugin-dir
      |   `-- .zinit-load-snippet
      |       |-- +zinit-deploy-message
      |       |-- +zinit-message
+     |       |   `-- +zi-log
      |       |-- .zinit-add-report
      |       |-- .zinit-find-other-matches
      |       |-- .zinit-get-object-path
@@ -1829,11 +1935,13 @@ Has 1 line(s). Calls functions:
      |       |-- .zinit-pack-ice
      |       |-- .zinit-set-m-func
      |       |   `-- +zinit-message
+     |       |       `-- +zi-log
      |       |-- .zinit-setup-params
      |       `-- zinit-install.zsh/.zinit-download-snippet
      |-- .zinit-parse-opts
      |-- .zinit-run
      |   |-- +zinit-message
+     |   |   `-- +zi-log
      |   |-- .zinit-any-to-user-plugin
      |   `-- .zinit-get-object-path
      |       `-- .zinit-any-to-user-plugin
@@ -1868,8 +1976,7 @@ Has 1 line(s). Calls functions:
      |-- zinit-autoload.zsh/zi::version
      |-- zinit-install.zsh/.zinit-compile-plugin
      |-- zinit-install.zsh/.zinit-compinit
-     |-- zinit-install.zsh/.zinit-forget-completion
-     `-- zinit-install.zsh/.zinit-install-completions
+     `-- zinit-install.zsh/.zinit-forget-completion
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1908,7 +2015,7 @@ ____
 
 ____
 
-Has 117 line(s). Doesn't call other functions.
+Has 120 line(s). Doesn't call other functions.
 
 Called by:
 
@@ -1931,12 +2038,13 @@ ____
 
 ____
 
-Has 549 line(s). Doesn't call other functions.
+Has 573 line(s). Doesn't call other functions.
 
 Uses feature(s): _autoload_, _bindkey_, _compdef_, _compdump_, _eval_, _read_, _setopt_, _unfunction_, _zle_, _zstyle_
 
 Called by:
 
+ +zi-cmp-reinstall
  zicompinit
  zinit
  zpcompinit


### PR DESCRIPTION
## Description

- `-q/--quiet` && `-f/--force` options now work
- update `creinstall` zsh completion with `--quiet, --force, and --help` flags
- move `creinstall` cmd logic to dedicated function

## Related Issue(s)

Closes #518 

## Motivation and Context <!--- What problem does it solve? -->

## Usage examples

<img width="1344" alt="Screenshot 2023-05-14 at 10 54 12" src="https://github.com/zdharma-continuum/zinit/assets/10052309/31565cb7-33a3-4ca5-a971-2fa071ca3d0b">

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [X] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [X] I have updated the documentation accordingly.
