### PR TITLE
feat: build container with zsh 5.9

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -16,6 +16,7 @@ jobs:
           - 5.6.2
           - 5.7.1
           - 5.8
+          - 5.9
     steps:
       - name: check out repository code
         uses: actions/checkout@v3


### PR DESCRIPTION
## Description

This PR builds an OCI image with zsh 5.9

Note: this depends on https://github.com/zdharma-continuum/zinit-packages/pull/13

## Related Issue(s)

<!--- If it fixes an open issue, add a link the issue -->

*N/A*

## Motivation and Context <!--- What problem does it solve? -->

## Usage examples

```zsh
podman run ghcr.io/zdharma-continuum/zinit:zsh-5.9
```

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [x] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
