### PR TITLE
fix: jq has moved from stedolan/jq to jqlang/jq

### DIFF
--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -437,7 +437,7 @@
   $joincap --version; assert $state equals 0
 }
 @test 'jq' { # Command-line JSON processor
-  run zinit lbin'!* -> jq' for stedolan/jq; assert $state equals 0
+  run zinit lbin'!* -> jq' for jqlang/jq; assert $state equals 0
   local jq="$ZBIN/jq"; assert "$jq" is_executable
   $jq --version; assert $state equals 0
 }

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -15,7 +15,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 
     +zinit-message "{error}❌ ERROR: jq binary not found" \
         "{nl}{u-warn}Please install jq:{rst}" \
-        "https://github.com/stedolan/jq" \
+        "https://github.com/jqlang/jq" \
         "{nl}{u-warn}To do so with zinit, please refer to:{rst}" \
         "https://github.com/zdharma-continuum/zinit/wiki/%F0%9F%A7%8A-Recommended-ices#jq"
     return 1


### PR DESCRIPTION
## Description

The details of the move are here:

https://github.com/jqlang/jq/issues/2594

## Related Issue(s)

<!--- If it fixes an open issue, add a link the issue -->

## Motivation and Context <!--- What problem does it solve? -->

## Usage examples

```zsh
zinit as"command" from"gh-r" for jqlang/jq
```

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [x] All new and existing tests passed.
- [x] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
