### PR TITLE
ci: only build containers on main branch

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -1,6 +1,10 @@
 name: Container images
 
-on: [push, workflow_dispatch]
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 
 jobs:
   build-containers-with-zsh:

--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    tags:        
+      - v[0-9]+.[0-9]+.[0-9]+
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

The containers should only be built when pushing to main.

## Motivation and Context <!--- What problem does it solve? -->

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [x] All new and existing tests passed.
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
