### PR TITLE
ci: commit generated docs

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -18,20 +18,21 @@ jobs:
 
       - name: checkout repository
         uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
 
       - name: re-generate documentation
         run: |
           make doc/container
           sudo chown -R "$(id -u):$(id -g)" .
 
-      - name: check for out-of-date documentation
-        run: |
-          echo "### Documentation summary" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY # this is a blank line
-          if ! git --no-pager diff --exit-code; then
-            echo "::error:: Z-shelldocs are out-of-date." >> $GITHUB_STEP_SUMMARY
-            echo 'To regenerate, run `make doc`' >> $GITHUB_STEP_SUMMARY
-            exit 1
-          else
-            echo "::notice:: Z-shelldocs are up-to-date." >> $GITHUB_STEP_SUMMARY
-          fi
+      - name: commit changes to the current branch
+        uses: EndBug/add-and-commit@v9
+        with:
+          add: 'doc'
+          author_name: GitHub Actions
+          author_email: actions@github.com
+          commit: --signoff
+          message: 'docs: generate'
+          push: true

--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -226,7 +226,7 @@
 }
 @test 'fclones' { # Efficient duplicate file Finder
   [[ $OSTYPE =~ 'darwin*' ]] && skip "on $os_type"
-  run zinit  for @pkolaczk/fclones; assert $state equals 0
+  run zinit ver'0.30.0' for @pkolaczk/fclones; assert $state equals 0
   local fclones="$ZBIN/fclones"; assert "$fclones" is_executable
   run "$fclones" --help; assert $state equals 0
 }

--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -226,7 +226,7 @@
 }
 @test 'fclones' { # Efficient duplicate file Finder
   [[ $OSTYPE =~ 'darwin*' ]] && skip "on $os_type"
-  run zinit ver'0.30.0' for @pkolaczk/fclones; assert $state equals 0
+  run zinit ver'0.31.0' for @pkolaczk/fclones; assert $state equals 0
   local fclones="$ZBIN/fclones"; assert "$fclones" is_executable
   run "$fclones" --help; assert $state equals 0
 }

--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -226,7 +226,7 @@
 }
 @test 'fclones' { # Efficient duplicate file Finder
   [[ $OSTYPE =~ 'darwin*' ]] && skip "on $os_type"
-  run zinit ver'0.31.0' for @pkolaczk/fclones; assert $state equals 0
+  run zinit ver'v0.31.0' for @pkolaczk/fclones; assert $state equals 0
   local fclones="$ZBIN/fclones"; assert "$fclones" is_executable
   run "$fclones" --help; assert $state equals 0
 }


### PR DESCRIPTION
## Description

This makes the pipeline **commit** the generated docs to the current branch.

Should make it easier for people w/o docker (@psprint) to contribute.

⚠️ To verify that this works I altered `zinit.zsh`, this file needs to be reset before we merge this in!

## Related Issue(s)

<!--- If it fixes an open issue, add a link the issue -->

## Motivation and Context <!--- What problem does it solve? -->

## Usage examples

```zsh
print 'N/A'
```

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [x] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [x] All new and existing tests passed.
- [x] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
