### PR TITLE
fix: pin `fclones` gh-r test version to v0.30.0

### DIFF
--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -226,7 +226,7 @@
 }
 @test 'fclones' { # Efficient duplicate file Finder
   [[ $OSTYPE =~ 'darwin*' ]] && skip "on $os_type"
-  run zinit  for @pkolaczk/fclones; assert $state equals 0
+  run zinit ver'0.30.0' for @pkolaczk/fclones; assert $state equals 0
   local fclones="$ZBIN/fclones"; assert "$fclones" is_executable
   run "$fclones" --help; assert $state equals 0
 }


### PR DESCRIPTION
## Description

Pin gh-r test for [pkolaczk/fclones](https://github.com/pkolaczk/fclones) due to latest release missing assets.

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [X] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
