### PR TITLE
ci: fix repo for hub (github -> mislav)

### DIFF
--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -282,7 +282,7 @@
   $gh_cli --version; assert $state equals 0
 }
 @test 'gh-hub' { # A command-line tool that makes git easier to use with GitHub
-  run zinit cp"hub-*/etc/hub.zsh_completion -> _hub" for @github/hub; assert $state equals 0
+  run zinit cp"hub-*/etc/hub.zsh_completion -> _hub" for @mislav/hub; assert $state equals 0
   local hub="$ZBIN/hub"; assert "$hub" is_executable
   $hub --version; assert $state equals 0
 }


### PR DESCRIPTION
## Description

## Related Issue(s)

Fixes rhe gh-r test for hub (formerly github/hub, now mislav/hub).

See the redirect happening here: https://github.com/github/hub

## Motivation and Context <!--- What problem does it solve? -->

## Usage examples

```zsh
zinit from"gh-r" nocompile lbin'!' cp"hub-*/etc/hub.zsh_completion -> _hub" for @mislav/hub
```

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [x] All new and existing tests passed.
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
