### PR TITLE
[maint]: append "${ZPFX}/lib/pkg-config" to $PKG_CONFIG_PATH plus others

### DIFF
--- a/share/config.site
+++ b/share/config.site
@@ -1,0 +1,4 @@
+# Prepend directories carrying libs and headers to appropriate vars
+export CPPFLAGS="-I$ZPFX/include $CPPFLAGS"
+export LDFLAGS="-L$ZPFX/lib -L$ZPFX/lib64 $LDFLAGS"
+ 

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -3302,6 +3302,7 @@ zle -N zi-browse-symbol
 zle -N zi-browse-symbol-backwards zi-browse-symbol
 zle -N zi-browse-symbol-pbackwards zi-browse-symbol
 zle -N zi-browse-symbol-pforwards zi-browse-symbol
+
 zstyle -s ':zinit:browse-symbol' key ZINIT_TMP || ZINIT_TMP='\eQ'
 [[ -n $ZINIT_TMP ]] && bindkey $ZINIT_TMP zi-browse-symbol
 


### PR DESCRIPTION
## Description
I think that this PR is important so I'm refreshing it (old: #333). I think that to be able to easily compile things under $ZPFX is an important feature. When building with zinit's configure''/make'' ices the environment should point the build systems to $ZPFX directory as the location of headers and libraries.

## Motivation and Context <!--- What problem does it solve? -->
I've once installed a library (pcre2-8) to $ZPFX and then tried to also install a dependent program (universal,-ctags) and I've noticed that the library wasn't found. After investigation it was pkg-config to blame, with a solution of prepending $ZPFX library dir to $PKG_CONFIG_PATH.


## How Has This Been Tested?
A few builds of a few apps, like libpcre2, universal-ctags, weechat.

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [x] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
