### PR TITLE
fix: quote parens so that they aren't used as globs

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -2278,7 +2278,7 @@ because {flag}c{pre} flag given}
         else
             m {error}Error: no {cmd}cmake{error} binary found and \
                 ${${${${#files}:#0}:+its input file exists \
-                   ({file}CMakeLists.txt{error})}:-and {flag}c{error} \
+                   \({file}CMakeLists.txt{error}\)}:-and {flag}c{error} \
                    flag given}! Skipping{…}
         fi
     fi


### PR DESCRIPTION
## Description
There are unquoted parens (…) in the message, causing it to fail.
 
## Motivation and Context <!--- What problem does it solve? -->

Before:
![2023-07-29-002905_1914x237_scrot](https://github.com/zdharma-continuum/zinit/assets/6049288/ae9ce1fb-2cad-4032-81ab-8229644b29aa)

After:
![2023-07-29-003216_1917x233_scrot](https://github.com/zdharma-continuum/zinit/assets/6049288/5f4e0f93-72d9-4c78-9cc1-b6b3fd6621df)

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
