### PR TITLE
New {file} formatter 

### DIFF
--- a/share/themes/blue.zsh
+++ b/share/themes/blue.zsh
@@ -3,11 +3,10 @@
 
  ZINIT+=(
     col-annex   $'\e[38;5;57m'         col-faint   $'\e[38;5;238m'         col-msg2    $'\e[38;5;172m'      col-quo     $'\e[1;38;5;33m'
-    col-apo     $'\e[1;38;5;27m'        col-file    $'\e[3;38;5;69m'       col-msg3    $'\e[38;5;238m'      col-quos    $'\e[1;38;5;160m'
+    col-apo     $'\e[1;38;5;27m'        col-file    $'\e[1;3;38;5;69m'       col-msg3    $'\e[38;5;238m'      col-quos    $'\e[1;38;5;160m'
     col-aps     $'\e[38;5;57m'         col-flag    $'\e[1;3;38;5;69m'      col-nb      $'\e[22m'            col-rst     $'\e[0m'
     col-b       $'\e[1m'                col-func    $'\e[38;5;69m'         col-nit     $'\e[23m'            col-slight  $'\e[38;5;230m'
-    col-b-lhi   $'\e[1;38;5;69m'     col-glob    $'\e[38;5;45m'
-     col-nl      $'\n'                col-st      $'\e[9m'
+    col-b-lhi   $'\e[1;38;5;69m'     col-glob    $'\e[38;5;45m'            col-nl      $'\n'                col-st      $'\e[9m'
     col-b-warn  $'\e[1;38;5;105m'       col-happy   $'\e[1m\e[38;5;82m'     col-note    $'\e[38;5;33m'      col-tab     $' \t '
     col-bapo    $'\e[1;38;5;220m'       col-hi      $'\e[1m\e[38;5;183m'    col-nst     $'\e[29m'            col-term    $'\e[38;5;39m'
     col-baps    $'\e[1;38;5;27m'        col-ice     $'\e[38;5;33m'          col-nu      $'\e[24m'            col-th-bar  $'\e[38;5;82m'
@@ -16,7 +15,7 @@
     col-bspc    $'\b'                   col-info2   $'\e[38;5;39m'         col-obj2    $'\e[38;5;33m'      col-u       $'\e[4m'
     col-cmd     $'\e[38;5;45m'          col-info3   $'\e[1m\e[38;5;69m'    col-ok      $'\e[38;5;220m'      col-u-warn  $'\e[4;38;5;214m'
     col-data    $'\e[38;5;69m'          col-it      $'\e[3m'                col-opt     $'\e[38;5;219m'      col-uname   $'\e[1;4m\e[33m'
-    col-data2   $'\e[38;5;45m'         col-keyword $'\e[1;38;5;174m'               col-p       $'\e[236;5;69m'       col-uninst  $'\e[38;5;45m'
+    col-data2   $'\e[38;5;45m'         col-keyword $'\e[1;38;5;174m'        col-p       $'\e[236;5;69m'       col-uninst  $'\e[38;5;45m'
     col-dir     $'\e[3;38;5;69m'       col-lhi     $'\e[38;5;81m'          col-pkg     $'\e[1;3;38;5;27m'   col-url     $'\e[38;5;27m'
     col-ehi     $'\e[1m\e[38;5;153m'    col-meta    $'\e[38;5;57m'          col-pname   $'\e[1;4;32m'     col-var     $'\e[38;5;57m'
     col-error   $'\e[1m\e[38;5;204m'    col-meta2   $'\e[38;5;57m'         col-pre     $'\e[38;5;27m'      col-version $'\e[3;38;5;57m'
@@ -32,6 +31,8 @@
     col-mmdsh $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+――}:--}"$'\e[0m'
 
     col-↔     ${${${(M)LANG:#*UTF-8*}:+$'\e[38;5;82m↔\e[0m'}:-$'\e[38;5;82m«-»\e[0m'}
+
+    col-ext   $'\e[1;38;5;41m'
 )
 if [[ -z $SOURCED && ( $+terminfo -eq 1 && \
                         $terminfo[colors] -ge 256) || \

--- a/share/themes/blue.zsh
+++ b/share/themes/blue.zsh
@@ -1,0 +1,43 @@
+# -*- mode: sh; sh-indentation: 4; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# Copyright (c) 2016-2020 Sebastian Gniazdowski and contributors.
+
+ ZINIT+=(
+    col-annex   $'\e[38;5;57m'         col-faint   $'\e[38;5;238m'         col-msg2    $'\e[38;5;172m'      col-quo     $'\e[1;38;5;33m'
+    col-apo     $'\e[1;38;5;27m'        col-file    $'\e[3;38;5;69m'       col-msg3    $'\e[38;5;238m'      col-quos    $'\e[1;38;5;160m'
+    col-aps     $'\e[38;5;57m'         col-flag    $'\e[1;3;38;5;69m'      col-nb      $'\e[22m'            col-rst     $'\e[0m'
+    col-b       $'\e[1m'                col-func    $'\e[38;5;69m'         col-nit     $'\e[23m'            col-slight  $'\e[38;5;230m'
+    col-b-lhi   $'\e[1;38;5;69m'     col-glob    $'\e[38;5;45m'
+     col-nl      $'\n'                col-st      $'\e[9m'
+    col-b-warn  $'\e[1;38;5;105m'       col-happy   $'\e[1m\e[38;5;82m'     col-note    $'\e[38;5;33m'      col-tab     $' \t '
+    col-bapo    $'\e[1;38;5;220m'       col-hi      $'\e[1m\e[38;5;183m'    col-nst     $'\e[29m'            col-term    $'\e[38;5;39m'
+    col-baps    $'\e[1;38;5;27m'        col-ice     $'\e[38;5;33m'          col-nu      $'\e[24m'            col-th-bar  $'\e[38;5;82m'
+    col-bar     $'\e[38;5;33m'          col-id-as   $'\e[4;38;5;33m'       col-num     $'\e[3;38;5;39m'    col-time    $'\e[38;5;27m'
+    col-bcmd    $'\e[38;5;27m'         col-info    $'\e[38;5;82m'          col-obj     $'\e[38;5;27m'      col-txt     $'\e[38;5;254m'
+    col-bspc    $'\b'                   col-info2   $'\e[38;5;39m'         col-obj2    $'\e[38;5;33m'      col-u       $'\e[4m'
+    col-cmd     $'\e[38;5;45m'          col-info3   $'\e[1m\e[38;5;69m'    col-ok      $'\e[38;5;220m'      col-u-warn  $'\e[4;38;5;214m'
+    col-data    $'\e[38;5;69m'          col-it      $'\e[3m'                col-opt     $'\e[38;5;219m'      col-uname   $'\e[1;4m\e[33m'
+    col-data2   $'\e[38;5;45m'         col-keyword $'\e[1;38;5;174m'               col-p       $'\e[236;5;69m'       col-uninst  $'\e[38;5;45m'
+    col-dir     $'\e[3;38;5;69m'       col-lhi     $'\e[38;5;81m'          col-pkg     $'\e[1;3;38;5;27m'   col-url     $'\e[38;5;27m'
+    col-ehi     $'\e[1m\e[38;5;153m'    col-meta    $'\e[38;5;57m'          col-pname   $'\e[1;4;32m'     col-var     $'\e[38;5;57m'
+    col-error   $'\e[1m\e[38;5;204m'    col-meta2   $'\e[38;5;57m'         col-pre     $'\e[38;5;27m'      col-version $'\e[3;38;5;57m'
+    col-failure $'\e[38;5;204m'         col-msg     $'\e[0m'                col-profile $'\e[38;5;57m'      col-warn    $'\e[38;5;99m'
+
+    col-i $'\e[1m\e[38;5;57m'"==>"$'\e[0m' col-e $'\e[1;38;5;204m'"Error: "$'\e[0m'
+    col-m $'\e[1;38;5;33m'"==>"$'\e[0m' col-w $'\e[1;38;5;99m'"Warning: "$'\e[0m'
+
+    col--…   "${${${(M)LANG:#*UTF-8*}:+⋯⋯}:-···}"    col-lr "${${${(M)LANG:#*UTF-8*}:+↔}:-"«-»"}"
+    col-ndsh "${${${(M)LANG:#*UTF-8*}:+–}:-}"        col-…  "${${${(M)LANG:#*UTF-8*}:+…}:-...}"
+
+    col-mdsh  $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+–}:--}"$'\e[0m'
+    col-mmdsh $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+――}:--}"$'\e[0m'
+
+    col-↔     ${${${(M)LANG:#*UTF-8*}:+$'\e[38;5;82m↔\e[0m'}:-$'\e[38;5;82m«-»\e[0m'}
+)
+if [[ -z $SOURCED && ( $+terminfo -eq 1 && \
+                        $terminfo[colors] -ge 256) || \
+      ( $+termcap -eq 1 && $termcap[Co] -ge 256 ) ]]
+then
+    ZINIT+=( col-pname $'\e[1;4;38;5;28m' col-uname  $'\e[1;4;38;5;57m' )
+fi
+
+# vim: ft=zsh sw=4 ts=4 et foldmarker=[[[,]]] foldmethod=marker

--- a/share/themes/default.zsh
+++ b/share/themes/default.zsh
@@ -1,0 +1,45 @@
+# -*- mode: sh; sh-indentation: 4; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# Copyright (c) 2016-2020 Sebastian Gniazdowski and contributors.
+
+ ZINIT+=(
+    col-annex   $'\e[38;5;153m'         col-faint   $'\e[38;5;238m'         col-msg2    $'\e[38;5;172m'      col-quo     $'\e[1;38;5;33m'
+    col-apo     $'\e[1;38;5;45m'        col-file    $'\e[3;38;5;117m'       col-msg3    $'\e[38;5;238m'      col-quos    $'\e[1;38;5;160m'
+    col-aps     $'\e[38;5;117m'         col-flag    $'\e[1;3;38;5;79m'      col-nb      $'\e[22m'            col-rst     $'\e[0m'
+    col-b       $'\e[1m'                col-func    $'\e[38;5;219m'         col-nit     $'\e[23m'            col-slight  $'\e[38;5;230m'
+    col-b-lhi   $'\e[1m\e[38;5;75m'     col-glob    $'\e[38;5;227m'         col-nl      $'\n'                col-st      $'\e[9m'
+    col-b-warn  $'\e[1;38;5;214m'       col-happy   $'\e[1m\e[38;5;82m'     col-note    $'\e[38;5;148m'      col-tab     $' \t '
+    col-bapo    $'\e[1;38;5;220m'       col-hi      $'\e[1m\e[38;5;183m'    col-nst     $'\e[29m'            col-term    $'\e[38;5;185m'
+    col-baps    $'\e[1;38;5;82m'        col-ice     $'\e[38;5;39m'          col-nu      $'\e[24m'            col-th-bar  $'\e[38;5;82m'
+    col-bar     $'\e[38;5;82m'          col-id-as   $'\e[4;38;5;220m'       col-num     $'\e[3;38;5;155m'    col-time    $'\e[38;5;220m'
+    col-bcmd    $'\e[38;5;220m'         col-info    $'\e[38;5;82m'          col-obj     $'\e[38;5;218m'      col-txt     $'\e[38;5;254m'
+    col-bspc    $'\b'                   col-info2   $'\e[38;5;227m'         col-obj2    $'\e[38;5;118m'      col-u       $'\e[4m'
+    col-cmd     $'\e[38;5;82m'          col-info3   $'\e[1m\e[38;5;227m'    col-ok      $'\e[38;5;220m'      col-u-warn  $'\e[4;38;5;214m'
+    col-data    $'\e[38;5;82m'          col-it      $'\e[3m'                col-opt     $'\e[38;5;219m'      col-uname   $'\e[1;4m\e[35m'
+    col-data2   $'\e[38;5;117m'         col-keyword $'\e[32m'               col-p       $'\e[38;5;81m'       col-uninst  $'\e[38;5;118m'
+    col-dir     $'\e[3;38;5;153m'       col-lhi     $'\e[38;5;81m'          col-pkg     $'\e[1;3;38;5;27m'   col-url     $'\e[38;5;75m'
+    col-ehi     $'\e[1m\e[38;5;210m'    col-meta    $'\e[38;5;57m'          col-pname   $'\e[1;4m\e[32m'     col-var     $'\e[38;5;81m'
+    col-error   $'\e[1m\e[38;5;204m'    col-meta2   $'\e[38;5;147m'         col-pre     $'\e[38;5;135m'      col-version $'\e[3;38;5;87m'
+    col-failure $'\e[38;5;204m'         col-msg     $'\e[0m'                col-profile $'\e[38;5;148m'      col-warn    $'\e[38;5;214m'
+
+    col-i $'\e[1m\e[38;5;82m'"==>"$'\e[0m' col-e $'\e[1m\e[38;5;204m'"Error: "$'\e[0m'
+    col-m $'\e[1m\e[38;5;135m'"==>"$'\e[0m' col-w $'\e[1;38;5;214m'"Warning: "$'\e[0m'
+
+    col--…   "${${${(M)LANG:#*UTF-8*}:+⋯⋯}:-···}"    col-lr "${${${(M)LANG:#*UTF-8*}:+↔}:-"«-»"}"
+    col-ndsh "${${${(M)LANG:#*UTF-8*}:+–}:-}"        col-…  "${${${(M)LANG:#*UTF-8*}:+…}:-...}"
+
+    col-mdsh  $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+–}:--}"$'\e[0m'
+    col-mmdsh $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+――}:--}"$'\e[0m'
+
+    col-↔     ${${${(M)LANG:#*UTF-8*}:+$'\e[38;5;82m↔\e[0m'}:-$'\e[38;5;82m«-»\e[0m'}
+)
+
+# Conmditionally allow 256 color codes for base handlers
+if [[ -z $SOURCED && ( $+terminfo -eq 1 && \
+                        $terminfo[colors] -ge 256) || \
+      ( $+termcap -eq 1 && $termcap[Co] -ge 256 ) ]]
+then
+
+    ZINIT+=( col-pname $'\e[1;4;38;5;39m' col-uname  $'\e[1;4;38;5;207m' )
+fi
+
+# vim: ft=zsh sw=4 ts=4 et foldmarker=[[[,]]] foldmethod=marker

--- a/share/themes/default.zsh
+++ b/share/themes/default.zsh
@@ -3,7 +3,7 @@
 
  ZINIT+=(
     col-annex   $'\e[38;5;153m'         col-faint   $'\e[38;5;238m'         col-msg2    $'\e[38;5;172m'      col-quo     $'\e[1;38;5;33m'
-    col-apo     $'\e[1;38;5;45m'        col-file    $'\e[3;38;5;117m'       col-msg3    $'\e[38;5;238m'      col-quos    $'\e[1;38;5;160m'
+    col-apo     $'\e[1;38;5;45m'        col-file    $'\e[3;38;5;27m'       col-msg3    $'\e[38;5;238m'      col-quos    $'\e[1;38;5;160m'
     col-aps     $'\e[38;5;117m'         col-flag    $'\e[1;3;38;5;79m'      col-nb      $'\e[22m'            col-rst     $'\e[0m'
     col-b       $'\e[1m'                col-func    $'\e[38;5;219m'         col-nit     $'\e[23m'            col-slight  $'\e[38;5;230m'
     col-b-lhi   $'\e[1m\e[38;5;75m'     col-glob    $'\e[38;5;227m'         col-nl      $'\n'                col-st      $'\e[9m'
@@ -18,7 +18,7 @@
     col-data2   $'\e[38;5;117m'         col-keyword $'\e[32m'               col-p       $'\e[38;5;81m'       col-uninst  $'\e[38;5;118m'
     col-dir     $'\e[3;38;5;153m'       col-lhi     $'\e[38;5;81m'          col-pkg     $'\e[1;3;38;5;27m'   col-url     $'\e[38;5;75m'
     col-ehi     $'\e[1m\e[38;5;210m'    col-meta    $'\e[38;5;57m'          col-pname   $'\e[1;4m\e[32m'     col-var     $'\e[38;5;81m'
-    col-error   $'\e[1m\e[38;5;204m'    col-meta2   $'\e[38;5;147m'         col-pre     $'\e[38;5;135m'      col-version $'\e[3;38;5;87m'
+    col-error   $'\e[1m\e[38;5;204m'    col-meta2   $'\e[38;5;147m'         col-pre     $'\e[38;5;135m'      col-version $'\e[3;38;5;57m'
     col-failure $'\e[38;5;204m'         col-msg     $'\e[0m'                col-profile $'\e[38;5;148m'      col-warn    $'\e[38;5;214m'
 
     col-i $'\e[1m\e[38;5;82m'"==>"$'\e[0m' col-e $'\e[1m\e[38;5;204m'"Error: "$'\e[0m'
@@ -31,6 +31,8 @@
     col-mmdsh $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+――}:--}"$'\e[0m'
 
     col-↔     ${${${(M)LANG:#*UTF-8*}:+$'\e[38;5;82m↔\e[0m'}:-$'\e[38;5;82m«-»\e[0m'}
+
+    col-ext   $'\e[1;38;5;41m'
 )
 
 # Conmditionally allow 256 color codes for base handlers

--- a/share/themes/gold.zsh
+++ b/share/themes/gold.zsh
@@ -32,6 +32,8 @@
     col-mmdsh $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+――}:--}"$'\e[0m'
 
     col-↔     ${${${(M)LANG:#*UTF-8*}:+$'\e[38;5;82m↔\e[0m'}:-$'\e[38;5;82m«-»\e[0m'}
+
+    col-ext   $'\e[1;38;5;41m'
 )
 if [[ -z $SOURCED && ( $+terminfo -eq 1 && \
                         $terminfo[colors] -ge 256) || \

--- a/share/themes/gold.zsh
+++ b/share/themes/gold.zsh
@@ -1,0 +1,43 @@
+# -*- mode: sh; sh-indentation: 4; indent-tabs-mode: nil; sh-basic-offset: 4; -*-
+# Copyright (c) 2016-2020 Sebastian Gniazdowski and contributors.
+
+ ZINIT+=(
+    col-annex   $'\e[38;5;57m'         col-faint   $'\e[38;5;238m'         col-msg2    $'\e[38;5;172m'      col-quo     $'\e[1;38;5;172m'
+    col-apo     $'\e[1;38;5;178m'        col-file    $'\e[3;38;5;178m'       col-msg3    $'\e[38;5;238m'      col-quos    $'\e[1;38;5;160m'
+    col-aps     $'\e[38;5;57m'         col-flag    $'\e[1;3;38;5;178m'      col-nb      $'\e[22m'            col-rst     $'\e[0m'
+    col-b       $'\e[1m'                col-func    $'\e[38;5;178m'         col-nit     $'\e[23m'            col-slight  $'\e[38;5;230m'
+    col-b-lhi   $'\e[1;38;5;178m'     col-glob    $'\e[38;5;137m'
+     col-nl      $'\n'                col-st      $'\e[9m'
+    col-b-warn  $'\e[1;38;5;105m'       col-happy   $'\e[1m\e[38;5;82m'     col-note    $'\e[38;5;172m'      col-tab     $' \t '
+    col-bapo    $'\e[1;38;5;220m'       col-hi      $'\e[1m\e[38;5;183m'    col-nst     $'\e[29m'            col-term    $'\e[38;5;172m'
+    col-baps    $'\e[1;38;5;178m'        col-ice     $'\e[38;5;172m'          col-nu      $'\e[24m'            col-th-bar  $'\e[38;5;82m'
+    col-bar     $'\e[38;5;172m'          col-id-as   $'\e[4;38;5;172m'       col-num     $'\e[3;38;5;172m'    col-time    $'\e[38;5;178m'
+    col-bcmd    $'\e[38;5;178m'         col-info    $'\e[38;5;82m'          col-obj     $'\e[38;5;178m'      col-txt     $'\e[38;5;254m'
+    col-bspc    $'\b'                   col-info2   $'\e[38;5;172m'         col-obj2    $'\e[38;5;172m'      col-u       $'\e[4m'
+    col-cmd     $'\e[38;5;172m'          col-info3   $'\e[1m\e[38;5;178m'    col-ok      $'\e[38;5;220m'      col-u-warn  $'\e[4;38;5;214m'
+    col-data    $'\e[38;5;178m'          col-it      $'\e[3m'                col-opt     $'\e[38;5;219m'      col-uname   $'\e[1;4m\e[33m'
+    col-data2   $'\e[38;5;137m'         col-keyword $'\e[1;38;5;172m'               col-p       $'\e[38;5;178m'       col-uninst  $'\e[38;5;137m'
+    col-dir     $'\e[3;38;5;178m'       col-lhi     $'\e[1;38;5;220m'          col-pkg     $'\e[1;3;38;5;178m'   col-url     $'\e[38;5;178m'
+    col-ehi     $'\e[1m\e[38;5;153m'    col-meta    $'\e[38;5;57m'          col-pname   $'\e[1;4;32m'     col-var     $'\e[38;5;57m'
+    col-error   $'\e[1m\e[38;5;204m'    col-meta2   $'\e[38;5;57m'         col-pre     $'\e[38;5;178m'      col-version $'\e[3;38;5;57m'
+    col-failure $'\e[38;5;204m'         col-msg     $'\e[0m'                col-profile $'\e[38;5;57m'      col-warn    $'\e[38;5;57m'
+
+    col-i $'\e[1m\e[38;5;57m'"==>"$'\e[0m' col-e $'\e[1;38;5;204m'"Error: "$'\e[0m'
+    col-m $'\e[1;38;5;172m'"==>"$'\e[0m' col-w $'\e[1;38;5;57m'"Warning: "$'\e[0m'
+
+    col--…   "${${${(M)LANG:#*UTF-8*}:+⋯⋯}:-···}"    col-lr "${${${(M)LANG:#*UTF-8*}:+↔}:-"«-»"}"
+    col-ndsh "${${${(M)LANG:#*UTF-8*}:+–}:-}"        col-…  "${${${(M)LANG:#*UTF-8*}:+…}:-...}"
+
+    col-mdsh  $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+–}:--}"$'\e[0m'
+    col-mmdsh $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+――}:--}"$'\e[0m'
+
+    col-↔     ${${${(M)LANG:#*UTF-8*}:+$'\e[38;5;82m↔\e[0m'}:-$'\e[38;5;82m«-»\e[0m'}
+)
+if [[ -z $SOURCED && ( $+terminfo -eq 1 && \
+                        $terminfo[colors] -ge 256) || \
+      ( $+termcap -eq 1 && $termcap[Co] -ge 256 ) ]]
+then
+    ZINIT+=( col-pname $'\e[1;4;38;5;178m' col-uname  $'\e[1;4;38;5;220m' )
+fi
+
+# vim: ft=zsh sw=4 ts=4 et foldmarker=[[[,]]] foldmethod=marker

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1690,7 +1690,7 @@ ziextract() {
     .zinit-extract-wrapper() {
         local file="$1" fun="$2" retval
         (( !OPTS[opt_-q,--quiet] )) && \
-            +zinit-message "{info}[{pre}ziextract{info}]{rst} Unpacking the files from: \`{obj}$file{msg}'{…}{rst}"
+            +zinit-message "{info}[{pre}ziextract{info}]{rst} Unpacking the files from: \`{file}$file{msg}'{…}"
         $fun; retval=$?
         if (( retval == 0 )) {
             local -a files
@@ -1839,7 +1839,7 @@ ziextract() {
         command chmod a+x "${execs[@]}"
         if (( !OPTS[opt_-q,--quiet] )) {
             if (( ${#execs} == 1 )); then
-                    +zinit-message "{info}[{pre}ziextract{info}]{rst} Successfully extracted and assigned +x chmod to the file: {obj}${execs[1]}{rst}."
+                    +zinit-message "{info}[{pre}ziextract{info}]{rst} Successfully extracted and assigned +x chmod to the file: {file}${execs[1]}{rst}."
             else
                 local sep="$ZINIT[col-rst],$ZINIT[col-obj] "
                 if (( ${#execs} > 7 )) {

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -143,6 +143,8 @@ typeset -g ZPFX
 : ${ZPFX:=${ZINIT[HOME_DIR]}/polaris}
 : ${ZINIT[ALIASES_OPT]::=${${options[aliases]:#off}:+1}}
 : ${ZINIT[MAN_DIR]:=${ZPFX}/man}
+: ${ZINIT[THEME_DIR]:=$ZINIT[BIN_DIR]/share/themes}
+: ${ZITHEME:=default}
 
 ZINIT[PLUGINS_DIR]=${~ZINIT[PLUGINS_DIR]}   ZINIT[COMPLETIONS_DIR]=${~ZINIT[COMPLETIONS_DIR]}
 ZINIT[SNIPPETS_DIR]=${~ZINIT[SNIPPETS_DIR]} ZINIT[SERVICES_DIR]=${~ZINIT[SERVICES_DIR]}
@@ -196,42 +198,17 @@ zmodload zsh/parameter || { builtin print -P "%F{196}zsh/parameter module is req
 zmodload zsh/term{cap,info} 2>/dev/null
 autoload -Uz colors && colors
 
-if [[ -z $SOURCED && ( ${+terminfo} -eq 1 && -n ${terminfo[colors]} ) || ( ${+termcap} -eq 1 && -n ${termcap[Co]} ) ]]; then
-  ZINIT+=(
-    col-annex   $'\e[38;5;153m'         col-faint   $'\e[38;5;238m'         col-msg2    $'\e[38;5;172m'      col-quo     $'\e[1;38;5;33m'
-    col-apo     $'\e[1;38;5;45m'        col-file    $'\e[3;38;5;117m'       col-msg3    $'\e[38;5;238m'      col-quos    $'\e[1;38;5;160m'
-    col-aps     $'\e[38;5;117m'         col-flag    $'\e[1;3;38;5;79m'      col-nb      $'\e[22m'            col-rst     $'\e[0m'
-    col-b       $'\e[1m'                col-func    $'\e[38;5;219m'         col-nit     $'\e[23m'            col-slight  $'\e[38;5;230m'
-    col-b-lhi   $'\e[1m\e[38;5;75m'     col-glob    $'\e[38;5;227m'         col-nl      $'\n'                col-st      $'\e[9m'
-    col-b-warn  $'\e[1;38;5;214m'       col-happy   $'\e[1m\e[38;5;82m'     col-note    $'\e[38;5;148m'      col-tab     $' \t '
-    col-bapo    $'\e[1;38;5;220m'       col-hi      $'\e[1m\e[38;5;183m'    col-nst     $'\e[29m'            col-term    $'\e[38;5;185m'
-    col-baps    $'\e[1;38;5;82m'        col-ice     $'\e[38;5;39m'          col-nu      $'\e[24m'            col-th-bar  $'\e[38;5;82m'
-    col-bar     $'\e[38;5;82m'          col-id-as   $'\e[4;38;5;220m'       col-num     $'\e[3;38;5;155m'    col-time    $'\e[38;5;220m'
-    col-bcmd    $'\e[38;5;220m'         col-info    $'\e[38;5;82m'          col-obj     $'\e[38;5;218m'      col-txt     $'\e[38;5;254m'
-    col-bspc    $'\b'                   col-info2   $'\e[38;5;227m'         col-obj2    $'\e[38;5;118m'      col-u       $'\e[4m'
-    col-cmd     $'\e[38;5;82m'          col-info3   $'\e[1m\e[38;5;227m'    col-ok      $'\e[38;5;220m'      col-u-warn  $'\e[4;38;5;214m'
-    col-data    $'\e[38;5;82m'          col-it      $'\e[3m'                col-opt     $'\e[38;5;219m'      col-uname   $'\e[1;4m\e[35m'
-    col-data2   $'\e[38;5;117m'         col-keyword $'\e[32m'               col-p       $'\e[38;5;81m'       col-uninst  $'\e[38;5;118m'
-    col-dir     $'\e[3;38;5;153m'       col-lhi     $'\e[38;5;81m'          col-pkg     $'\e[1;3;38;5;27m'   col-url     $'\e[38;5;75m'
-    col-ehi     $'\e[1m\e[38;5;210m'    col-meta    $'\e[38;5;57m'          col-pname   $'\e[1;4m\e[32m'     col-var     $'\e[38;5;81m'
-    col-error   $'\e[1m\e[38;5;204m'    col-meta2   $'\e[38;5;147m'         col-pre     $'\e[38;5;135m'      col-version $'\e[3;38;5;87m'
-    col-failure $'\e[38;5;204m'         col-msg     $'\e[0m'                col-profile $'\e[38;5;148m'      col-warn    $'\e[38;5;214m'
-
-    col-i $'\e[1m\e[38;5;82m'"==>"$'\e[0m' col-e $'\e[1m\e[38;5;204m'"Error: "$'\e[0m'
-    col-m $'\e[1m\e[38;5;135m'"==>"$'\e[0m' col-w $'\e[1;38;5;214m'"Warning: "$'\e[0m'
-
-    col--…   "${${${(M)LANG:#*UTF-8*}:+⋯⋯}:-···}"    col-lr "${${${(M)LANG:#*UTF-8*}:+↔}:-"«-»"}"
-    col-ndsh "${${${(M)LANG:#*UTF-8*}:+–}:-}"        col-…  "${${${(M)LANG:#*UTF-8*}:+…}:-...}"
-
-    col-mdsh  $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+–}:--}"$'\e[0m'
-    col-mmdsh $'\e[1;38;5;220m'"${${${(M)LANG:#*UTF-8*}:+――}:--}"$'\e[0m'
-
-    col-↔     ${${${(M)LANG:#*UTF-8*}:+$'\e[38;5;82m↔\e[0m'}:-$'\e[38;5;82m«-»\e[0m'}
-  )
-  if [[ ( ${+terminfo} -eq 1 && ${terminfo[colors]} -ge 256 ) || ( ${+termcap} -eq 1 && ${termcap[Co]} -ge 256 ) ]]; then
-    ZINIT+=( col-pname $'\e[1;4m\e[38;5;39m' col-uname  $'\e[1;4m\e[38;5;207m' )
-  fi
-fi
+if [[ -z $SOURCED && ( $+terminfo -eq 1 && -n $terminfo[colors] ) || \
+      ( $+termcap -eq 1 && -n $termcap[Co] )
+]] {
+        ZINIT[TMP]=0
+        if [[ -f $ZINIT[THEME_DIR]/$ZITHEME.zsh ]];then
+            source $ZINIT[THEME_DIR]/$ZITHEME.zsh && ZINIT[TMP]=1
+        fi
+        ((ZINIT[TMP]))||print -r -P -- %F{203}Warning:%f problem \
+                loading color theme: %F{57}$ZITHEME%f \(from: \
+                    %F{33}$ZINIT[THEME_DIR]%f\)
+}
 
 # Hooks
 typeset -gAH ZINIT_ZLE_HOOKS_LIST

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -1949,6 +1949,23 @@ builtin setopt noaliases
     builtin zle -F "$THEFD" +zinit-deploy-message
 } # ]]]
 
+# FUNCTION: .zinit-formatter-file [[[
+.zinit-formatter-file() {
+    builtin emulate -L zsh -o extendedglob
+    local -a match mbegin mend
+    REPLY=$1
+    if [[ $REPLY = (#b)([^.]#)-((#B)(|v|V|ver|VER)[0-9.]##).(?##) ]]; then
+        REPLY=$ZINIT[col-file]$match[1]$ZINIT[col-rst]\
+$ZINIT[col-dot]-$ZINIT[col-version]$match[2]$ZINIT[col-rst]\
+$ZINIT[col-dot].$ZINIT[col-ext]$match[3]$ZINIT[col-rst]
+    elif [[ $REPLY = (#b)([^.]#).(*) ]]; then
+        REPLY=$ZINIT[col-file]$match[1]$ZINIT[col-rst]\
+$ZINIT[col-dot].$ZINIT[col-ext]$match[2]$ZINIT[col-rst]
+    else
+        REPLY=$ZINIT[col-file]$REPLY$ZINIT[col-rst]
+    fi
+}
+
 # FUNCTION: .zinit-formatter-dbg [[[
 .zinit-formatter-dbg() {
     builtin emulate -L zsh -o extendedglob


### PR DESCRIPTION
## Description
I'm refreshing the old pr #421 taking into account @vladdoster's objections about  the number of colors used to highlight (now there is `1` color for extensions instead of `2`). Also, a new feature – highlighting of the version number (like e.g. `v1.5`). Furthermore, I'm submitting a branch that's on top of #550 , after merging this PR the commits will disappear from this PR.

## Related Issue(s)

#421 

<!--- If it fixes an open issue, add a link the issue -->

## Motivation and Context <!--- What problem does it solve? -->
The flexibility behind `+zinit-message` allows for sophisticated highlighters. Here the `{file}` style gets a private function-highlighter to color file extensions and version automatically with a distinct  color.

## Usage examples

Default theme:
![2023-07-30-154441_1901x252_scrot](https://github.com/zdharma-continuum/zinit/assets/6049288/7d7cd94d-bcca-4f83-b47e-d720b17218f5)

Blue  theme:
![2023-07-30-154422_1895x231_scrot](https://github.com/zdharma-continuum/zinit/assets/6049288/b008052f-e8de-489b-ab30-d467417077b9)

Gold theme:
![2023-07-30-154502_1894x249_scrot](https://github.com/zdharma-continuum/zinit/assets/6049288/c28c13da-5767-4aba-8bcf-91876d7769ae)

## How Has This Been Tested?
Via the above invocations of `+zinit-message` interactively.

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [x] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
