### PR TITLE
refactor: rename `+zinit-message` to `+zi-log`

### DIFF
--- a/doc/zsdoc/zinit-autoload.zsh.adoc
+++ b/doc/zsdoc/zinit-autoload.zsh.adoc
@@ -126,7 +126,7 @@ Has 39 line(s). Calls functions:
 
  .zinit-build-module
  |-- .zinit-module
- `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/+zi-log
 
 Uses feature(s): _setopt_, _trap_
 
@@ -152,7 +152,7 @@ Has 15 line(s). Calls functions:
  .zinit-cd
  |-- .zinit-get-path
  |   `-- zinit.zsh/.zinit-get-object-path
- `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/+zi-log
 
 Uses feature(s): _setopt_
 
@@ -405,7 +405,7 @@ ____
 Has 17 line(s). Calls functions:
 
  .zinit-confirm
- `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/+zi-log
 
 Uses feature(s): _eval_, _read_
 
@@ -452,7 +452,7 @@ Has 111 line(s). Calls functions:
  |-- .zinit-run-delete-hooks
  |   `-- zinit-side.zsh/.zinit-countdown
  |-- zinit-side.zsh/.zinit-compute-ice
- |-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/+zi-log
  |-- zinit.zsh/.zinit-any-to-user-plugin
  `-- zinit.zsh/zinit
 
@@ -781,7 +781,7 @@ Has 39 line(s). Calls functions:
  |-- .zinit-pager
  |-- zinit-side.zsh/.zinit-exists-physically-message
  |-- zinit-side.zsh/.zinit-first
- |-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/+zi-log
  `-- zinit.zsh/.zinit-any-to-user-plugin
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
@@ -874,7 +874,7 @@ Has 24 line(s). Calls functions:
 
  .zinit-module
  `-- .zinit-build-module
-     `-- zinit.zsh/+zinit-message
+     `-- zinit.zsh/+zi-log
 
 Called by:
 
@@ -1059,7 +1059,7 @@ Has 42 line(s). Calls functions:
 
  .zinit-self-update
  |-- .zinit-pager
- |-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/+zi-log
  `-- zinit.zsh/.zinit-get-mtime-into
 
 Uses feature(s): _setopt_, _source_, _zcompile_
@@ -1248,7 +1248,7 @@ ____
 Has 47 line(s). Calls functions:
 
  .zinit-show-zstatus
- `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/+zi-log
 
 Uses feature(s): _setopt_
 
@@ -1329,7 +1329,7 @@ Has 46 line(s). Calls functions:
  |   `-- zinit.zsh/.zinit-get-object-path
  |-- zinit-install.zsh/.zinit-compinit
  |-- zinit-install.zsh/.zinit-forget-completion
- `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/+zi-log
 
 Uses feature(s): _setopt_, _source_
 
@@ -1425,16 +1425,16 @@ Has 84 line(s). Calls functions:
  |   |-- zinit-side.zsh/.zinit-exists-physically-message
  |   |-- zinit-side.zsh/.zinit-store-ices
  |   |-- zinit-side.zsh/.zinit-two-paths
- |   |-- zinit.zsh/+zinit-message
+ |   |-- zinit.zsh/+zi-log
  |   |-- zinit.zsh/.zinit-any-to-user-plugin
  |   `-- zinit.zsh/.zinit-set-m-func
  |-- .zinit-update-or-status-snippet
  |   |-- zinit-install.zsh/.zinit-update-snippet
  |   `-- zinit-side.zsh/.zinit-compute-ice
  |-- .zinit-wait-for-update-jobs
- |   `-- zinit.zsh/+zinit-message
+ |   `-- zinit.zsh/+zi-log
  |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- |-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/+zi-log
  `-- zinit.zsh/.zinit-any-to-user-plugin
 
 Uses feature(s): _setopt_
@@ -1472,7 +1472,7 @@ Has 325 line(s). Calls functions:
  |-- zinit-side.zsh/.zinit-exists-physically-message
  |-- zinit-side.zsh/.zinit-store-ices
  |-- zinit-side.zsh/.zinit-two-paths
- |-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/+zi-log
  |-- zinit.zsh/.zinit-any-to-user-plugin
  `-- zinit.zsh/.zinit-set-m-func
 
@@ -1501,7 +1501,7 @@ Has 133 line(s). Calls functions:
  .zinit-update-or-status-all
  |-- .zinit-self-update
  |   |-- .zinit-pager
- |   |-- zinit.zsh/+zinit-message
+ |   |-- zinit.zsh/+zi-log
  |   `-- zinit.zsh/.zinit-get-mtime-into
  |-- .zinit-update-all-parallel
  |   |-- .zinit-update-or-status
@@ -1517,16 +1517,16 @@ Has 133 line(s). Calls functions:
  |   |   |-- zinit-side.zsh/.zinit-exists-physically-message
  |   |   |-- zinit-side.zsh/.zinit-store-ices
  |   |   |-- zinit-side.zsh/.zinit-two-paths
- |   |   |-- zinit.zsh/+zinit-message
+ |   |   |-- zinit.zsh/+zi-log
  |   |   |-- zinit.zsh/.zinit-any-to-user-plugin
  |   |   `-- zinit.zsh/.zinit-set-m-func
  |   |-- .zinit-update-or-status-snippet
  |   |   |-- zinit-install.zsh/.zinit-update-snippet
  |   |   `-- zinit-side.zsh/.zinit-compute-ice
  |   |-- .zinit-wait-for-update-jobs
- |   |   `-- zinit.zsh/+zinit-message
+ |   |   `-- zinit.zsh/+zi-log
  |   |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- |   |-- zinit.zsh/+zinit-message
+ |   |-- zinit.zsh/+zi-log
  |   `-- zinit.zsh/.zinit-any-to-user-plugin
  |-- .zinit-update-or-status
  |   |-- .zinit-pager
@@ -1541,7 +1541,7 @@ Has 133 line(s). Calls functions:
  |   |-- zinit-side.zsh/.zinit-exists-physically-message
  |   |-- zinit-side.zsh/.zinit-store-ices
  |   |-- zinit-side.zsh/.zinit-two-paths
- |   |-- zinit.zsh/+zinit-message
+ |   |-- zinit.zsh/+zi-log
  |   |-- zinit.zsh/.zinit-any-to-user-plugin
  |   `-- zinit.zsh/.zinit-set-m-func
  |-- .zinit-update-or-status-snippet
@@ -1549,7 +1549,7 @@ Has 133 line(s). Calls functions:
  |   `-- zinit-side.zsh/.zinit-compute-ice
  |-- zinit-install.zsh/.zinit-compinit
  |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
- |-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/+zi-log
  |-- zinit.zsh/.zinit-any-to-user-plugin
  `-- zinit.zsh/.zinit-get-mtime-into
 
@@ -1590,7 +1590,7 @@ Called by:
 Has 18 line(s). Calls functions:
 
  .zinit-wait-for-update-jobs
- `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/+zi-log
 
 Uses feature(s): _wait_
 
@@ -1611,7 +1611,7 @@ ____
 Has 2 line(s). Calls functions:
 
  zi::version
- `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/+zi-log
 
 Called by:
 

--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -62,7 +62,7 @@ Uses feature(s): _source_
 Has 43 line(s). Calls functions:
 
  .zi::get-architecture
- `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/+zi-log
 
 Uses feature(s): _setopt_
 
@@ -99,7 +99,7 @@ Has 83 line(s). Calls functions:
  .zinit-compile-plugin
  |-- zinit-side.zsh/.zinit-compute-ice
  |-- zinit-side.zsh/.zinit-first
- `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/+zi-log
 
 Uses feature(s): _eval_, _setopt_, _zcompile_
 
@@ -127,7 +127,7 @@ Has 26 line(s). Calls functions:
  .zinit-compinit
  |-- .zinit-forget-completion
  |-- compinit
- `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/+zi-log
 
 Uses feature(s): _autoload_, _compinit_, _setopt_, _unfunction_
 
@@ -169,7 +169,7 @@ ____
 Has 53 line(s). Calls functions:
 
  .zinit-download-file-stdout
- `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/+zi-log
 
 Uses feature(s): _setopt_, _trap_, _type_
 
@@ -197,21 +197,21 @@ Has 377 line(s). Calls functions:
 
  .zinit-download-snippet
  |-- .zinit-download-file-stdout
- |   `-- zinit.zsh/+zinit-message
+ |   `-- zinit.zsh/+zi-log
  |-- .zinit-get-url-mtime
  |-- .zinit-install-completions
  |   |-- .zinit-compinit
  |   |   |-- .zinit-forget-completion
  |   |   |-- compinit
- |   |   `-- zinit.zsh/+zinit-message
+ |   |   `-- zinit.zsh/+zi-log
  |   |-- .zinit-forget-completion
  |   |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
  |   |-- zinit-side.zsh/.zinit-exists-physically-message
- |   |-- zinit.zsh/+zinit-message
+ |   |-- zinit.zsh/+zi-log
  |   `-- zinit.zsh/.zinit-any-to-user-plugin
  |-- .zinit-mirror-using-svn
  |-- zinit-side.zsh/.zinit-store-ices
- |-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/+zi-log
  `-- zinit.zsh/is-at-least
 
 Uses feature(s): _is-at-least_, _setopt_, _trap_, _zcompile_
@@ -227,8 +227,8 @@ Has 30 line(s). Calls functions:
 
  .zinit-extract
  |-- ziextract
- |   `-- zinit.zsh/+zinit-message
- `-- zinit.zsh/+zinit-message
+ |   `-- zinit.zsh/+zi-log
+ `-- zinit.zsh/+zi-log
 
 Uses feature(s): _setopt_
 
@@ -264,8 +264,8 @@ Has 70 line(s). Calls functions:
 
  .zinit-get-cygwin-package
  |-- .zinit-download-file-stdout
- |   `-- zinit.zsh/+zinit-message
- `-- zinit.zsh/+zinit-message
+ |   `-- zinit.zsh/+zi-log
+ `-- zinit.zsh/+zi-log
 
 Uses feature(s): _setopt_
 
@@ -285,7 +285,7 @@ ____
 Has 52 line(s). Calls functions:
 
  .zinit-get-latest-gh-r-url-part
- `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/+zi-log
 
 Uses feature(s): _setopt_
 
@@ -300,15 +300,15 @@ Has 195 line(s). Calls functions:
 
  .zinit-get-package
  |-- .zinit-download-file-stdout
- |   `-- zinit.zsh/+zinit-message
+ |   `-- zinit.zsh/+zi-log
  |-- .zinit-jq-check
- |   `-- zinit.zsh/+zinit-message
+ |   `-- zinit.zsh/+zi-log
  |-- .zinit-json-to-array
  |   `-- .zinit-jq-check
- |       `-- zinit.zsh/+zinit-message
+ |       `-- zinit.zsh/+zi-log
  |-- ziextract
- |   `-- zinit.zsh/+zinit-message
- |-- zinit.zsh/+zinit-message
+ |   `-- zinit.zsh/+zi-log
+ |-- zinit.zsh/+zi-log
  `-- zinit.zsh/@zinit-substitute
 
 Uses feature(s): _eval_, _setopt_, _trap_
@@ -355,11 +355,11 @@ Has 62 line(s). Calls functions:
  |-- .zinit-compinit
  |   |-- .zinit-forget-completion
  |   |-- compinit
- |   `-- zinit.zsh/+zinit-message
+ |   `-- zinit.zsh/+zi-log
  |-- .zinit-forget-completion
  |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
  |-- zinit-side.zsh/.zinit-exists-physically-message
- |-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/+zi-log
  `-- zinit.zsh/.zinit-any-to-user-plugin
 
 Uses feature(s): _setopt_
@@ -382,7 +382,7 @@ ____
 Has 8 line(s). Calls functions:
 
  .zinit-jq-check
- `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/+zi-log
 
 Called by:
 
@@ -405,7 +405,7 @@ Has 4 line(s). Calls functions:
 
  .zinit-json-get-value
  `-- .zinit-jq-check
-     `-- zinit.zsh/+zinit-message
+     `-- zinit.zsh/+zi-log
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -426,7 +426,7 @@ Has 13 line(s). Calls functions:
 
  .zinit-json-to-array
  `-- .zinit-jq-check
-     `-- zinit.zsh/+zinit-message
+     `-- zinit.zsh/+zi-log
 
 Uses feature(s): _eval_, _setopt_
 
@@ -475,28 +475,28 @@ Has 214 line(s). Calls functions:
 
  .zinit-setup-plugin-dir
  |-- .zinit-download-file-stdout
- |   `-- zinit.zsh/+zinit-message
+ |   `-- zinit.zsh/+zi-log
  |-- .zinit-get-cygwin-package
  |   |-- .zinit-download-file-stdout
- |   |   `-- zinit.zsh/+zinit-message
- |   `-- zinit.zsh/+zinit-message
+ |   |   `-- zinit.zsh/+zi-log
+ |   `-- zinit.zsh/+zi-log
  |-- .zinit-get-latest-gh-r-url-part
- |   `-- zinit.zsh/+zinit-message
+ |   `-- zinit.zsh/+zi-log
  |-- .zinit-install-completions
  |   |-- .zinit-compinit
  |   |   |-- .zinit-forget-completion
  |   |   |-- compinit
- |   |   `-- zinit.zsh/+zinit-message
+ |   |   `-- zinit.zsh/+zi-log
  |   |-- .zinit-forget-completion
  |   |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
  |   |-- zinit-side.zsh/.zinit-exists-physically-message
- |   |-- zinit.zsh/+zinit-message
+ |   |-- zinit.zsh/+zi-log
  |   `-- zinit.zsh/.zinit-any-to-user-plugin
  |-- ziextract
- |   `-- zinit.zsh/+zinit-message
+ |   `-- zinit.zsh/+zi-log
  |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
  |-- zinit-side.zsh/.zinit-store-ices
- |-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/+zi-log
  `-- zinit.zsh/.zinit-get-object-path
 
 Uses feature(s): _setopt_, _trap_
@@ -527,23 +527,23 @@ Has 76 line(s). Calls functions:
  .zinit-update-snippet
  |-- .zinit-download-snippet
  |   |-- .zinit-download-file-stdout
- |   |   `-- zinit.zsh/+zinit-message
+ |   |   `-- zinit.zsh/+zi-log
  |   |-- .zinit-get-url-mtime
  |   |-- .zinit-install-completions
  |   |   |-- .zinit-compinit
  |   |   |   |-- .zinit-forget-completion
  |   |   |   |-- compinit
- |   |   |   `-- zinit.zsh/+zinit-message
+ |   |   |   `-- zinit.zsh/+zi-log
  |   |   |-- .zinit-forget-completion
  |   |   |-- zinit-side.zsh/.zinit-any-colorify-as-uspl2
  |   |   |-- zinit-side.zsh/.zinit-exists-physically-message
- |   |   |-- zinit.zsh/+zinit-message
+ |   |   |-- zinit.zsh/+zi-log
  |   |   `-- zinit.zsh/.zinit-any-to-user-plugin
  |   |-- .zinit-mirror-using-svn
  |   |-- zinit-side.zsh/.zinit-store-ices
- |   |-- zinit.zsh/+zinit-message
+ |   |-- zinit.zsh/+zi-log
  |   `-- zinit.zsh/is-at-least
- |-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/+zi-log
  |-- zinit.zsh/.zinit-get-object-path
  `-- zinit.zsh/.zinit-pack-ice
 
@@ -580,7 +580,7 @@ ____
 Has 283 line(s). Calls functions:
 
  ziextract
- `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/+zi-log
 
 Uses feature(s): _setopt_, _unfunction_, _zparseopts_
 
@@ -606,7 +606,7 @@ Has 1 line(s). Calls functions:
 
  zpextract
  `-- ziextract
-     `-- zinit.zsh/+zinit-message
+     `-- zinit.zsh/+zi-log
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -656,7 +656,7 @@ Has 19 line(s). Calls functions:
  `-- .zinit-compile-plugin
      |-- zinit-side.zsh/.zinit-compute-ice
      |-- zinit-side.zsh/.zinit-first
-     `-- zinit.zsh/+zinit-message
+     `-- zinit.zsh/+zi-log
 
 Uses feature(s): _setopt_
 
@@ -746,8 +746,8 @@ Has 10 line(s). Calls functions:
  ∞zinit-extract-hook
  |-- .zinit-extract
  |   |-- ziextract
- |   |   `-- zinit.zsh/+zinit-message
- |   `-- zinit.zsh/+zinit-message
+ |   |   `-- zinit.zsh/+zi-log
+ |   `-- zinit.zsh/+zi-log
  `-- zinit.zsh/@zinit-substitute
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
@@ -804,7 +804,7 @@ Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 Has 35 line(s). Calls functions:
 
  ∞zinit-mv-hook
- |-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/+zi-log
  `-- zinit.zsh/@zinit-substitute
 
 Uses feature(s): _setopt_
@@ -816,7 +816,7 @@ Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 Has 18 line(s). Calls functions:
 
  ∞zinit-ps-on-update-hook
- `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/+zi-log
 
 Uses feature(s): _eval_
 
@@ -827,7 +827,7 @@ Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 Has 79 line(s). Calls functions:
 
  ∞zinit-reset-hook
- `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/+zi-log
 
 Uses feature(s): _eval_
 

--- a/doc/zsdoc/zinit-side.zsh.adoc
+++ b/doc/zsdoc/zinit-side.zsh.adoc
@@ -99,7 +99,7 @@ Has 110 line(s). Calls functions:
  |   |   `-- zinit.zsh/.zinit-any-to-user-plugin
  |   |-- .zinit-exists-physically
  |   |   `-- zinit.zsh/.zinit-any-to-user-plugin
- |   |-- zinit.zsh/+zinit-message
+ |   |-- zinit.zsh/+zi-log
  |   |-- zinit.zsh/.zinit-any-to-pid
  |   `-- zinit.zsh/.zinit-any-to-user-plugin
  |-- .zinit-two-paths
@@ -136,7 +136,7 @@ ____
 Has 20 line(s). Calls functions:
 
  .zinit-countdown
- `-- zinit.zsh/+zinit-message
+ `-- zinit.zsh/+zi-log
 
 Uses feature(s): _trap_
 
@@ -192,7 +192,7 @@ Has 25 line(s). Calls functions:
  |   `-- zinit.zsh/.zinit-any-to-user-plugin
  |-- .zinit-exists-physically
  |   `-- zinit.zsh/.zinit-any-to-user-plugin
- |-- zinit.zsh/+zinit-message
+ |-- zinit.zsh/+zi-log
  |-- zinit.zsh/.zinit-any-to-pid
  `-- zinit.zsh/.zinit-any-to-user-plugin
 

--- a/doc/zsdoc/zinit.zsh.adoc
+++ b/doc/zsdoc/zinit.zsh.adoc
@@ -88,7 +88,7 @@ PRECMD-HOOK @zinit-scheduler
 Has 244 line(s). Calls functions:
 
  Script-Body
- |-- +zinit-message
+ |-- +zi-log
  |-- .zinit-get-mtime-into
  |-- .zinit-prepare-home
  |   |-- zinit-autoload.zsh/.zinit-clear-completions
@@ -98,15 +98,15 @@ Has 244 line(s). Calls functions:
  |-- colors
  |-- is-at-least
  |-- zinit
- |   |-- +zinit-message
+ |   |-- +zi-log
  |   |-- +zinit-prehelp-usage-message
- |   |   `-- +zinit-message
+ |   |   `-- +zi-log
  |   |-- .zinit-add-fpath
  |   |   `-- .zinit-any-to-user-plugin
  |   |-- .zinit-compdef-clear
- |   |   `-- +zinit-message
+ |   |   `-- +zi-log
  |   |-- .zinit-compdef-replay
- |   |   `-- +zinit-message
+ |   |   `-- +zi-log
  |   |-- .zinit-get-object-path
  |   |   `-- .zinit-any-to-user-plugin
  |   |-- .zinit-ice
@@ -129,45 +129,45 @@ Has 244 line(s). Calls functions:
  |   |   |   |   |-- .zinit-tmp-subst-off
  |   |   |   |   |-- .zinit-tmp-subst-on
  |   |   |   |   `-- :zinit-tmp-subst-autoload
- |   |   |   |       |-- +zinit-message
+ |   |   |   |       |-- +zi-log
  |   |   |   |       |-- .zinit-add-report
  |   |   |   |       |-- .zinit-any-to-user-plugin
  |   |   |   |       `-- is-at-least
  |   |   |   |-- .zinit-load-snippet
+ |   |   |   |   |-- +zi-log
  |   |   |   |   |-- +zinit-deploy-message
- |   |   |   |   |-- +zinit-message
  |   |   |   |   |-- .zinit-add-report
  |   |   |   |   |-- .zinit-find-other-matches
  |   |   |   |   |-- .zinit-get-object-path
  |   |   |   |   |   `-- .zinit-any-to-user-plugin
  |   |   |   |   |-- .zinit-pack-ice
  |   |   |   |   |-- .zinit-set-m-func
- |   |   |   |   |   `-- +zinit-message
+ |   |   |   |   |   `-- +zi-log
  |   |   |   |   |-- .zinit-setup-params
  |   |   |   |   `-- zinit-install.zsh/.zinit-download-snippet
  |   |   |   |-- .zinit-pack-ice
  |   |   |   |-- .zinit-register-plugin
- |   |   |   |   `-- +zinit-message
+ |   |   |   |   `-- +zi-log
  |   |   |   |-- .zinit-set-m-func
- |   |   |   |   `-- +zinit-message
+ |   |   |   |   `-- +zi-log
  |   |   |   |-- .zinit-setup-params
  |   |   |   |-- zinit-install.zsh/.zinit-get-package
  |   |   |   `-- zinit-install.zsh/.zinit-setup-plugin-dir
  |   |   `-- .zinit-load-snippet
+ |   |       |-- +zi-log
  |   |       |-- +zinit-deploy-message
- |   |       |-- +zinit-message
  |   |       |-- .zinit-add-report
  |   |       |-- .zinit-find-other-matches
  |   |       |-- .zinit-get-object-path
  |   |       |   `-- .zinit-any-to-user-plugin
  |   |       |-- .zinit-pack-ice
  |   |       |-- .zinit-set-m-func
- |   |       |   `-- +zinit-message
+ |   |       |   `-- +zi-log
  |   |       |-- .zinit-setup-params
  |   |       `-- zinit-install.zsh/.zinit-download-snippet
  |   |-- .zinit-parse-opts
  |   |-- .zinit-run
- |   |   |-- +zinit-message
+ |   |   |-- +zi-log
  |   |   |-- .zinit-any-to-user-plugin
  |   |   `-- .zinit-get-object-path
  |   |       `-- .zinit-any-to-user-plugin
@@ -214,50 +214,6 @@ _Exports (environment):_ PMSPEC [big]*//* ZPFX [big]*//* ZSH_CACHE_DIR
 
 ____
  
- Wrapper function for +zinit-message until migrated to +zi-log
-
-____
-
-Has 1 line(s). Calls functions:
-
- +zi-log
- `-- +zinit-message
-
-Called by:
-
- zinit-additional.zsh/.zinit-debug-clear
- zinit-additional.zsh/.zinit-debug-report
- zinit-additional.zsh/.zinit-debug-revert
- zinit-additional.zsh/.zinit-debug-start
- zinit-additional.zsh/.zinit-debug-status
- zinit-additional.zsh/.zinit-debug-stop
- zinit-additional.zsh/:zinit-tmp-subst-source
- zinit-autoload.zsh/.zinit-list-plugins
- zinit-autoload.zsh/.zinit-unload
-
-==== +zinit-deploy-message
-
-____
- 
- Deploys a sub-prompt message to be displayed OR a 'zle .reset-prompt'
- call to be invoked
-
-____
-
-Has 13 line(s). Doesn't call other functions.
-
-Uses feature(s): _read_, _zle_
-
-Called by:
-
- .zinit-load-snippet
- .zinit-load
- zinit-autoload.zsh/.zinit-recall
-
-==== +zinit-message
-
-____
- 
  Logging function
 
 ____
@@ -266,7 +222,7 @@ Has 16 line(s). Doesn't call other functions.
 
 Called by:
 
- +zi-log
+ +zinit-message
  +zinit-prehelp-usage-message
  .zinit-compdef-clear
  .zinit-compdef-replay
@@ -277,14 +233,23 @@ Called by:
  :zinit-tmp-subst-autoload
  Script-Body
  zinit
+ zinit-additional.zsh/.zinit-debug-clear
+ zinit-additional.zsh/.zinit-debug-report
+ zinit-additional.zsh/.zinit-debug-revert
+ zinit-additional.zsh/.zinit-debug-start
+ zinit-additional.zsh/.zinit-debug-status
+ zinit-additional.zsh/.zinit-debug-stop
+ zinit-additional.zsh/:zinit-tmp-subst-source
  zinit-autoload.zsh/.zinit-build-module
  zinit-autoload.zsh/.zinit-cd
  zinit-autoload.zsh/.zinit-confirm
  zinit-autoload.zsh/.zinit-delete
  zinit-autoload.zsh/.zinit-glance
+ zinit-autoload.zsh/.zinit-list-plugins
  zinit-autoload.zsh/.zinit-self-update
  zinit-autoload.zsh/.zinit-show-zstatus
  zinit-autoload.zsh/.zinit-uninstall-completions
+ zinit-autoload.zsh/.zinit-unload
  zinit-autoload.zsh/.zinit-update-all-parallel
  zinit-autoload.zsh/.zinit-update-or-status-all
  zinit-autoload.zsh/.zinit-update-or-status
@@ -310,12 +275,46 @@ Called by:
  zinit-side.zsh/.zinit-countdown
  zinit-side.zsh/.zinit-exists-physically-message
 
+==== +zinit-deploy-message
+
+____
+ 
+ Deploys a sub-prompt message to be displayed OR a 'zle .reset-prompt'
+ call to be invoked
+
+____
+
+Has 13 line(s). Doesn't call other functions.
+
+Uses feature(s): _read_, _zle_
+
+Called by:
+
+ .zinit-load-snippet
+ .zinit-load
+ zinit-autoload.zsh/.zinit-recall
+
+==== +zinit-message
+
+____
+ 
+ Wrapper function to maintain backward compatibility
+
+____
+
+Has 1 line(s). Calls functions:
+
+ +zinit-message
+ `-- +zi-log
+
+Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
+
 ==== +zinit-prehelp-usage-message
 
 Has 38 line(s). Calls functions:
 
  +zinit-prehelp-usage-message
- `-- +zinit-message
+ `-- +zi-log
 
 Called by:
 
@@ -443,7 +442,7 @@ ____
 Has 3 line(s). Calls functions:
 
  .zinit-compdef-clear
- `-- +zinit-message
+ `-- +zi-log
 
 Called by:
 
@@ -462,7 +461,7 @@ ____
 Has 17 line(s). Calls functions:
 
  .zinit-compdef-replay
- `-- +zinit-message
+ `-- +zi-log
 
 Uses feature(s): _compdef_
 
@@ -726,27 +725,27 @@ Has 95 line(s). Calls functions:
  |   |-- .zinit-tmp-subst-off
  |   |-- .zinit-tmp-subst-on
  |   `-- :zinit-tmp-subst-autoload
- |       |-- +zinit-message
+ |       |-- +zi-log
  |       |-- .zinit-add-report
  |       |-- .zinit-any-to-user-plugin
  |       `-- is-at-least
  |-- .zinit-load-snippet
+ |   |-- +zi-log
  |   |-- +zinit-deploy-message
- |   |-- +zinit-message
  |   |-- .zinit-add-report
  |   |-- .zinit-find-other-matches
  |   |-- .zinit-get-object-path
  |   |   `-- .zinit-any-to-user-plugin
  |   |-- .zinit-pack-ice
  |   |-- .zinit-set-m-func
- |   |   `-- +zinit-message
+ |   |   `-- +zi-log
  |   |-- .zinit-setup-params
  |   `-- zinit-install.zsh/.zinit-download-snippet
  |-- .zinit-pack-ice
  |-- .zinit-register-plugin
- |   `-- +zinit-message
+ |   `-- +zi-log
  |-- .zinit-set-m-func
- |   `-- +zinit-message
+ |   `-- +zi-log
  |-- .zinit-setup-params
  |-- zinit-install.zsh/.zinit-get-package
  `-- zinit-install.zsh/.zinit-setup-plugin-dir
@@ -791,40 +790,40 @@ Has 12 line(s). Calls functions:
  |   |   |-- .zinit-tmp-subst-off
  |   |   |-- .zinit-tmp-subst-on
  |   |   `-- :zinit-tmp-subst-autoload
- |   |       |-- +zinit-message
+ |   |       |-- +zi-log
  |   |       |-- .zinit-add-report
  |   |       |-- .zinit-any-to-user-plugin
  |   |       `-- is-at-least
  |   |-- .zinit-load-snippet
+ |   |   |-- +zi-log
  |   |   |-- +zinit-deploy-message
- |   |   |-- +zinit-message
  |   |   |-- .zinit-add-report
  |   |   |-- .zinit-find-other-matches
  |   |   |-- .zinit-get-object-path
  |   |   |   `-- .zinit-any-to-user-plugin
  |   |   |-- .zinit-pack-ice
  |   |   |-- .zinit-set-m-func
- |   |   |   `-- +zinit-message
+ |   |   |   `-- +zi-log
  |   |   |-- .zinit-setup-params
  |   |   `-- zinit-install.zsh/.zinit-download-snippet
  |   |-- .zinit-pack-ice
  |   |-- .zinit-register-plugin
- |   |   `-- +zinit-message
+ |   |   `-- +zi-log
  |   |-- .zinit-set-m-func
- |   |   `-- +zinit-message
+ |   |   `-- +zi-log
  |   |-- .zinit-setup-params
  |   |-- zinit-install.zsh/.zinit-get-package
  |   `-- zinit-install.zsh/.zinit-setup-plugin-dir
  `-- .zinit-load-snippet
+     |-- +zi-log
      |-- +zinit-deploy-message
-     |-- +zinit-message
      |-- .zinit-add-report
      |-- .zinit-find-other-matches
      |-- .zinit-get-object-path
      |   `-- .zinit-any-to-user-plugin
      |-- .zinit-pack-ice
      |-- .zinit-set-m-func
-     |   `-- +zinit-message
+     |   `-- +zi-log
      |-- .zinit-setup-params
      `-- zinit-install.zsh/.zinit-download-snippet
 
@@ -858,7 +857,7 @@ Has 128 line(s). Calls functions:
  |-- .zinit-tmp-subst-off
  |-- .zinit-tmp-subst-on
  `-- :zinit-tmp-subst-autoload
-     |-- +zinit-message
+     |-- +zi-log
      |-- .zinit-add-report
      |-- .zinit-any-to-user-plugin
      `-- is-at-least
@@ -882,15 +881,15 @@ ____
 Has 203 line(s). Calls functions:
 
  .zinit-load-snippet
+ |-- +zi-log
  |-- +zinit-deploy-message
- |-- +zinit-message
  |-- .zinit-add-report
  |-- .zinit-find-other-matches
  |-- .zinit-get-object-path
  |   `-- .zinit-any-to-user-plugin
  |-- .zinit-pack-ice
  |-- .zinit-set-m-func
- |   `-- +zinit-message
+ |   `-- +zi-log
  |-- .zinit-setup-params
  `-- zinit-install.zsh/.zinit-download-snippet
 
@@ -973,7 +972,7 @@ ____
 Has 23 line(s). Calls functions:
 
  .zinit-register-plugin
- `-- +zinit-message
+ `-- +zi-log
 
 Called by:
 
@@ -991,7 +990,7 @@ ____
 Has 24 line(s). Calls functions:
 
  .zinit-run
- |-- +zinit-message
+ |-- +zi-log
  |-- .zinit-any-to-user-plugin
  `-- .zinit-get-object-path
      `-- .zinit-any-to-user-plugin
@@ -1038,40 +1037,40 @@ Has 47 line(s). Calls functions:
  |   |   |-- .zinit-tmp-subst-off
  |   |   |-- .zinit-tmp-subst-on
  |   |   `-- :zinit-tmp-subst-autoload
- |   |       |-- +zinit-message
+ |   |       |-- +zi-log
  |   |       |-- .zinit-add-report
  |   |       |-- .zinit-any-to-user-plugin
  |   |       `-- is-at-least
  |   |-- .zinit-load-snippet
+ |   |   |-- +zi-log
  |   |   |-- +zinit-deploy-message
- |   |   |-- +zinit-message
  |   |   |-- .zinit-add-report
  |   |   |-- .zinit-find-other-matches
  |   |   |-- .zinit-get-object-path
  |   |   |   `-- .zinit-any-to-user-plugin
  |   |   |-- .zinit-pack-ice
  |   |   |-- .zinit-set-m-func
- |   |   |   `-- +zinit-message
+ |   |   |   `-- +zi-log
  |   |   |-- .zinit-setup-params
  |   |   `-- zinit-install.zsh/.zinit-download-snippet
  |   |-- .zinit-pack-ice
  |   |-- .zinit-register-plugin
- |   |   `-- +zinit-message
+ |   |   `-- +zi-log
  |   |-- .zinit-set-m-func
- |   |   `-- +zinit-message
+ |   |   `-- +zi-log
  |   |-- .zinit-setup-params
  |   |-- zinit-install.zsh/.zinit-get-package
  |   `-- zinit-install.zsh/.zinit-setup-plugin-dir
  |-- .zinit-load-snippet
+ |   |-- +zi-log
  |   |-- +zinit-deploy-message
- |   |-- +zinit-message
  |   |-- .zinit-add-report
  |   |-- .zinit-find-other-matches
  |   |-- .zinit-get-object-path
  |   |   `-- .zinit-any-to-user-plugin
  |   |-- .zinit-pack-ice
  |   |-- .zinit-set-m-func
- |   |   `-- +zinit-message
+ |   |   `-- +zi-log
  |   |-- .zinit-setup-params
  |   `-- zinit-install.zsh/.zinit-download-snippet
  `-- zinit-autoload.zsh/.zinit-unload
@@ -1094,7 +1093,7 @@ ____
 Has 17 line(s). Calls functions:
 
  .zinit-set-m-func
- `-- +zinit-message
+ `-- +zi-log
 
 Uses feature(s): _setopt_
 
@@ -1242,7 +1241,7 @@ ____
 Has 111 line(s). Calls functions:
 
  :zinit-tmp-subst-autoload
- |-- +zinit-message
+ |-- +zi-log
  |-- .zinit-add-report
  |-- .zinit-any-to-user-plugin
  `-- is-at-least
@@ -1337,7 +1336,7 @@ Has 4 line(s). Calls functions:
 
  @autoload
  `-- :zinit-tmp-subst-autoload
-     |-- +zinit-message
+     |-- +zi-log
      |-- .zinit-add-report
      |-- .zinit-any-to-user-plugin
      `-- is-at-least
@@ -1414,40 +1413,40 @@ Has 75 line(s). *Is a precmd hook*. Calls functions:
  |   |   |   |-- .zinit-tmp-subst-off
  |   |   |   |-- .zinit-tmp-subst-on
  |   |   |   `-- :zinit-tmp-subst-autoload
- |   |   |       |-- +zinit-message
+ |   |   |       |-- +zi-log
  |   |   |       |-- .zinit-add-report
  |   |   |       |-- .zinit-any-to-user-plugin
  |   |   |       `-- is-at-least
  |   |   |-- .zinit-load-snippet
+ |   |   |   |-- +zi-log
  |   |   |   |-- +zinit-deploy-message
- |   |   |   |-- +zinit-message
  |   |   |   |-- .zinit-add-report
  |   |   |   |-- .zinit-find-other-matches
  |   |   |   |-- .zinit-get-object-path
  |   |   |   |   `-- .zinit-any-to-user-plugin
  |   |   |   |-- .zinit-pack-ice
  |   |   |   |-- .zinit-set-m-func
- |   |   |   |   `-- +zinit-message
+ |   |   |   |   `-- +zi-log
  |   |   |   |-- .zinit-setup-params
  |   |   |   `-- zinit-install.zsh/.zinit-download-snippet
  |   |   |-- .zinit-pack-ice
  |   |   |-- .zinit-register-plugin
- |   |   |   `-- +zinit-message
+ |   |   |   `-- +zi-log
  |   |   |-- .zinit-set-m-func
- |   |   |   `-- +zinit-message
+ |   |   |   `-- +zi-log
  |   |   |-- .zinit-setup-params
  |   |   |-- zinit-install.zsh/.zinit-get-package
  |   |   `-- zinit-install.zsh/.zinit-setup-plugin-dir
  |   |-- .zinit-load-snippet
+ |   |   |-- +zi-log
  |   |   |-- +zinit-deploy-message
- |   |   |-- +zinit-message
  |   |   |-- .zinit-add-report
  |   |   |-- .zinit-find-other-matches
  |   |   |-- .zinit-get-object-path
  |   |   |   `-- .zinit-any-to-user-plugin
  |   |   |-- .zinit-pack-ice
  |   |   |-- .zinit-set-m-func
- |   |   |   `-- +zinit-message
+ |   |   |   `-- +zi-log
  |   |   |-- .zinit-setup-params
  |   |   `-- zinit-install.zsh/.zinit-download-snippet
  |   `-- zinit-autoload.zsh/.zinit-unload
@@ -1512,15 +1511,15 @@ Has 15 line(s). Calls functions:
 
  pmodload
  `-- .zinit-load-snippet
+     |-- +zi-log
      |-- +zinit-deploy-message
-     |-- +zinit-message
      |-- .zinit-add-report
      |-- .zinit-find-other-matches
      |-- .zinit-get-object-path
      |   `-- .zinit-any-to-user-plugin
      |-- .zinit-pack-ice
      |-- .zinit-set-m-func
-     |   `-- +zinit-message
+     |   `-- +zi-log
      |-- .zinit-setup-params
      `-- zinit-install.zsh/.zinit-download-snippet
 
@@ -1541,7 +1540,7 @@ Has 1 line(s). Calls functions:
 
  zicdclear
  `-- .zinit-compdef-clear
-     `-- +zinit-message
+     `-- +zi-log
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1558,7 +1557,7 @@ Has 1 line(s). Calls functions:
 
  zicdreplay
  `-- .zinit-compdef-replay
-     `-- +zinit-message
+     `-- +zi-log
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1606,15 +1605,15 @@ ____
 Has 553 line(s). Calls functions:
 
  zinit
- |-- +zinit-message
+ |-- +zi-log
  |-- +zinit-prehelp-usage-message
- |   `-- +zinit-message
+ |   `-- +zi-log
  |-- .zinit-add-fpath
  |   `-- .zinit-any-to-user-plugin
  |-- .zinit-compdef-clear
- |   `-- +zinit-message
+ |   `-- +zi-log
  |-- .zinit-compdef-replay
- |   `-- +zinit-message
+ |   `-- +zi-log
  |-- .zinit-get-object-path
  |   `-- .zinit-any-to-user-plugin
  |-- .zinit-ice
@@ -1637,45 +1636,45 @@ Has 553 line(s). Calls functions:
  |   |   |   |-- .zinit-tmp-subst-off
  |   |   |   |-- .zinit-tmp-subst-on
  |   |   |   `-- :zinit-tmp-subst-autoload
- |   |   |       |-- +zinit-message
+ |   |   |       |-- +zi-log
  |   |   |       |-- .zinit-add-report
  |   |   |       |-- .zinit-any-to-user-plugin
  |   |   |       `-- is-at-least
  |   |   |-- .zinit-load-snippet
+ |   |   |   |-- +zi-log
  |   |   |   |-- +zinit-deploy-message
- |   |   |   |-- +zinit-message
  |   |   |   |-- .zinit-add-report
  |   |   |   |-- .zinit-find-other-matches
  |   |   |   |-- .zinit-get-object-path
  |   |   |   |   `-- .zinit-any-to-user-plugin
  |   |   |   |-- .zinit-pack-ice
  |   |   |   |-- .zinit-set-m-func
- |   |   |   |   `-- +zinit-message
+ |   |   |   |   `-- +zi-log
  |   |   |   |-- .zinit-setup-params
  |   |   |   `-- zinit-install.zsh/.zinit-download-snippet
  |   |   |-- .zinit-pack-ice
  |   |   |-- .zinit-register-plugin
- |   |   |   `-- +zinit-message
+ |   |   |   `-- +zi-log
  |   |   |-- .zinit-set-m-func
- |   |   |   `-- +zinit-message
+ |   |   |   `-- +zi-log
  |   |   |-- .zinit-setup-params
  |   |   |-- zinit-install.zsh/.zinit-get-package
  |   |   `-- zinit-install.zsh/.zinit-setup-plugin-dir
  |   `-- .zinit-load-snippet
+ |       |-- +zi-log
  |       |-- +zinit-deploy-message
- |       |-- +zinit-message
  |       |-- .zinit-add-report
  |       |-- .zinit-find-other-matches
  |       |-- .zinit-get-object-path
  |       |   `-- .zinit-any-to-user-plugin
  |       |-- .zinit-pack-ice
  |       |-- .zinit-set-m-func
- |       |   `-- +zinit-message
+ |       |   `-- +zi-log
  |       |-- .zinit-setup-params
  |       `-- zinit-install.zsh/.zinit-download-snippet
  |-- .zinit-parse-opts
  |-- .zinit-run
- |   |-- +zinit-message
+ |   |-- +zi-log
  |   |-- .zinit-any-to-user-plugin
  |   `-- .zinit-get-object-path
  |       `-- .zinit-any-to-user-plugin
@@ -1727,7 +1726,7 @@ Has 1 line(s). Calls functions:
 
  zpcdclear
  `-- .zinit-compdef-clear
-     `-- +zinit-message
+     `-- +zi-log
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1737,7 +1736,7 @@ Has 1 line(s). Calls functions:
 
  zpcdreplay
  `-- .zinit-compdef-replay
-     `-- +zinit-message
+     `-- +zi-log
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 
@@ -1764,15 +1763,15 @@ Has 1 line(s). Calls functions:
 
  zplugin
  `-- zinit
-     |-- +zinit-message
+     |-- +zi-log
      |-- +zinit-prehelp-usage-message
-     |   `-- +zinit-message
+     |   `-- +zi-log
      |-- .zinit-add-fpath
      |   `-- .zinit-any-to-user-plugin
      |-- .zinit-compdef-clear
-     |   `-- +zinit-message
+     |   `-- +zi-log
      |-- .zinit-compdef-replay
-     |   `-- +zinit-message
+     |   `-- +zi-log
      |-- .zinit-get-object-path
      |   `-- .zinit-any-to-user-plugin
      |-- .zinit-ice
@@ -1795,45 +1794,45 @@ Has 1 line(s). Calls functions:
      |   |   |   |-- .zinit-tmp-subst-off
      |   |   |   |-- .zinit-tmp-subst-on
      |   |   |   `-- :zinit-tmp-subst-autoload
-     |   |   |       |-- +zinit-message
+     |   |   |       |-- +zi-log
      |   |   |       |-- .zinit-add-report
      |   |   |       |-- .zinit-any-to-user-plugin
      |   |   |       `-- is-at-least
      |   |   |-- .zinit-load-snippet
+     |   |   |   |-- +zi-log
      |   |   |   |-- +zinit-deploy-message
-     |   |   |   |-- +zinit-message
      |   |   |   |-- .zinit-add-report
      |   |   |   |-- .zinit-find-other-matches
      |   |   |   |-- .zinit-get-object-path
      |   |   |   |   `-- .zinit-any-to-user-plugin
      |   |   |   |-- .zinit-pack-ice
      |   |   |   |-- .zinit-set-m-func
-     |   |   |   |   `-- +zinit-message
+     |   |   |   |   `-- +zi-log
      |   |   |   |-- .zinit-setup-params
      |   |   |   `-- zinit-install.zsh/.zinit-download-snippet
      |   |   |-- .zinit-pack-ice
      |   |   |-- .zinit-register-plugin
-     |   |   |   `-- +zinit-message
+     |   |   |   `-- +zi-log
      |   |   |-- .zinit-set-m-func
-     |   |   |   `-- +zinit-message
+     |   |   |   `-- +zi-log
      |   |   |-- .zinit-setup-params
      |   |   |-- zinit-install.zsh/.zinit-get-package
      |   |   `-- zinit-install.zsh/.zinit-setup-plugin-dir
      |   `-- .zinit-load-snippet
+     |       |-- +zi-log
      |       |-- +zinit-deploy-message
-     |       |-- +zinit-message
      |       |-- .zinit-add-report
      |       |-- .zinit-find-other-matches
      |       |-- .zinit-get-object-path
      |       |   `-- .zinit-any-to-user-plugin
      |       |-- .zinit-pack-ice
      |       |-- .zinit-set-m-func
-     |       |   `-- +zinit-message
+     |       |   `-- +zi-log
      |       |-- .zinit-setup-params
      |       `-- zinit-install.zsh/.zinit-download-snippet
      |-- .zinit-parse-opts
      |-- .zinit-run
-     |   |-- +zinit-message
+     |   |-- +zi-log
      |   |-- .zinit-any-to-user-plugin
      |   `-- .zinit-get-object-path
      |       `-- .zinit-any-to-user-plugin

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -668,17 +668,17 @@ ZINIT[EXTENDED_GLOB]=""
         fi
 
         if (( action )); then
-            +zinit-message "{info}Uninstalling completion \`{file}$cfile{info}'{…}{rst}"
+            +zi-log "{info}Uninstalling completion \`{file}$cfile{info}'{…}{rst}"
             # Make compinit notice the change
             .zinit-forget-completion "$cfile"
             (( global_action ++ ))
         else
-            +zinit-message "{info}Completion \`{file}$cfile{info}' not installed.{rst}"
+            +zi-log "{info}Completion \`{file}$cfile{info}' not installed.{rst}"
         fi
     done
 
     if (( global_action > 0 )); then
-        +zinit-message "{info}Uninstalled {num}$global_action{info} completions.{rst}"
+        +zi-log "{info}Uninstalled {num}$global_action{info} completions.{rst}"
     fi
 
     .zinit-compinit >/dev/null
@@ -725,27 +725,27 @@ ZINIT[EXTENDED_GLOB]=""
         }
     fi
     ( builtin cd -q "${ZINIT[MODULE_DIR]}"
-      +zinit-message "{pname}== Building module zdharma-continuum/zinit-module, running: make clean, then ./configure and then make =={rst}"
-      +zinit-message "{pname}== The module sources are located at: "${ZINIT[MODULE_DIR]}" =={rst}"
+      +zi-log "{pname}== Building module zdharma-continuum/zinit-module, running: make clean, then ./configure and then make =={rst}"
+      +zi-log "{pname}== The module sources are located at: "${ZINIT[MODULE_DIR]}" =={rst}"
       if [[ -f Makefile ]] {
           if [[ "$1" = "--clean" ]] {
-              noglob +zinit-message {p}-- make distclean --{rst}
+              noglob +zi-log {p}-- make distclean --{rst}
               make distclean
               ((1))
           } else {
-              noglob +zinit-message {p}-- make clean --{rst}
+              noglob +zi-log {p}-- make clean --{rst}
               make clean
           }
       }
-      noglob +zinit-message  {p}-- ./configure --{rst}
+      noglob +zi-log  {p}-- ./configure --{rst}
       CPPFLAGS=-I/usr/local/include CFLAGS="-g -Wall -O3" LDFLAGS=-L/usr/local/lib ./configure --disable-gdbm --without-tcsetpgrp && {
-          noglob +zinit-message {p}-- make --{rst}
+          noglob +zi-log {p}-- make --{rst}
           if { make } {
             [[ -f Src/zdharma_continuum/zinit.so ]] && cp -vf Src/zdharma_continuum/zinit.{so,bundle}
-            noglob +zinit-message "{info}Module has been built correctly.{rst}"
+            noglob +zi-log "{info}Module has been built correctly.{rst}"
             .zinit-module info
           } else {
-              noglob +zinit-message  "{error}Module didn't build.{rst} "
+              noglob +zi-log  "{error}Module didn't build.{rst} "
               .zinit-module info --link
           }
       }
@@ -798,12 +798,12 @@ ZINIT[EXTENDED_GLOB]=""
         if [[ -e $REPLY ]]; then
             builtin pushd $REPLY
         else
-            +zinit-message "No such plugin or snippet"
+            +zi-log "No such plugin or snippet"
             return 1
         fi
         builtin print
     } || {
-        +zinit-message "No such plugin or snippet"
+        +zi-log "No such plugin or snippet"
         return 1
     }
 } # ]]]
@@ -1047,17 +1047,17 @@ ZINIT[EXTENDED_GLOB]=""
     integer retval
     if (( OPTS[opt_-y,--yes] )); then
         builtin eval "${2}"; retval=$?
-        (( OPTS[opt_-q,--quiet] )) || +zinit-message -lrP "{m} Action executed (exit code: {num}${retval}{rst})"
+        (( OPTS[opt_-q,--quiet] )) || +zi-log -lrP "{m} Action executed (exit code: {num}${retval}{rst})"
     else
       local choice prompt
-      builtin print -D -v prompt "$(+zinit-message '{i} Press [{opt}Y{rst}/{opt}y{rst}] to continue: {nl}')"
-      +zinit-message "${1}"
+      builtin print -D -v prompt "$(+zi-log '{i} Press [{opt}Y{rst}/{opt}y{rst}] to continue: {nl}')"
+      +zi-log "${1}"
       if builtin read -qs "choice?${prompt}"; then
         builtin eval "${2}"; retval=$?
-        +zinit-message "{m} Action executed (exit code: {num}${retval}{rst})"
+        +zi-log "{m} Action executed (exit code: {num}${retval}{rst})"
         return 0
       else
-        +zinit-message "{m} No action executed ('{opt}${choice}{rst}' not 'Y' or 'y')"
+        +zi-log "{m} No action executed ('{opt}${choice}{rst}' not 'Y' or 'y')"
         return 1
       fi
     fi
@@ -1225,7 +1225,7 @@ EOF
       return 0
     }
     (( $#o_clean && $#o_all )) && {
-        +zinit-message "{e} Invalid usage: Options --all and --clean are mutually exclusive"
+        +zi-log "{e} Invalid usage: Options --all and --clean are mutually exclusive"
         return 1
     }
     (( $#o_clean )) && {
@@ -1245,8 +1245,8 @@ EOF
       unld_plgns=(${(@)${unld_plgns[@]##$ZINIT[PLUGINS_DIR]/#}//---//})
       # delete unloaded snippets & plugins
       (( $#del_list || $#unld_plgns )) && {
-        +zinit-message "{m} Deleting {num}${#unld_snips}{rst} unloaded snippets:" $unld_snips
-        +zinit-message "{m} Deleting {num}${#unld_plgns}{rst} unloaded plugins:" $unld_plgns
+        +zi-log "{m} Deleting {num}${#unld_snips}{rst} unloaded snippets:" $unld_snips
+        +zi-log "{m} Deleting {num}${#unld_plgns}{rst} unloaded plugins:" $unld_plgns
         if (( $#o_yes )) || ( .zinit-prompt "delete ${#unld_snips} snippets and ${#unld_plgns} plugins?"); then
           for snip in $del_list $unld_plgns ; do
             zinit delete --yes "$snip"
@@ -1255,7 +1255,7 @@ EOF
           return _retval
         fi
       } || {
-        +zinit-message "{m} No unloaded plugins or snippets to delete"
+        +zi-log "{m} No unloaded plugins or snippets to delete"
         return 0
       }
     }
@@ -1268,13 +1268,13 @@ EOF
               builtin unset "ZINIT[$f]"
             done
             local rc=$?
-            +zinit-message "{m} Deleted all completed with return code {num}${rc}{rst}"
+            +zi-log "{m} Deleted all completed with return code {num}${rc}{rst}"
             return $rc
         fi
         return 1
     fi
     (( !$# )) && {
-        +zinit-message "{e} Invalid usage: This command requires at least 1 plugin or snippet argument."
+        +zi-log "{e} Invalid usage: This command requires at least 1 plugin or snippet argument."
         return 0
     }
     local i
@@ -1284,7 +1284,7 @@ EOF
             local the_id="${${i:#(%|/)*}}" filename is_snippet local_dir
             .zinit-compute-ice "$the_id" "pack" ICE2 local_dir filename is_snippet || return 1
             if [[ "$local_dir" != /* ]]; then
-                +zinit-message "{w} No available plugin or snippet with the name '$i'"
+                +zi-log "{w} No available plugin or snippet with the name '$i'"
                 return 1
             fi
             ICE2[teleid]="${ICE2[teleid]:-${ICE2[id-as]}}"
@@ -1303,9 +1303,9 @@ EOF
                 command rm -rf -- ${(q)${${local_dir:#[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/abcYZX321}}(N) # delete files
                 command rm -f -- $ZINIT[HOME_DIR]/**/*(-@N) # delete broken symlins
                 builtin unset "ZINIT[STATES__${ICE2[id-as]}]" || builtin unset "ZINIT[STATES__${ICE2[teleid]}]"
-                +zinit-message "{m} Uninstalled $i"
+                +zi-log "{m} Uninstalled $i"
             else
-                +zinit-message "{w} No available plugin or snippet with the name '$i'"
+                +zi-log "{w} No available plugin or snippet with the name '$i'"
                 return 1
             fi
         done
@@ -1374,7 +1374,7 @@ EOF
     .zinit-exists-physically-message "$user" "$plugin" || return 1
 
     .zinit-first "$1" "$2" || {
-       +zinit-message '{log-err} No source file found, cannot glance'
+       +zi-log '{log-err} No source file found, cannot glance'
         return 1
     }
 
@@ -1385,17 +1385,17 @@ EOF
 
     {
         if (( ${+commands[pygmentize]} )); then
-            +zinit-message "{log-info} Inspecting via {cmd}pygmentize{rst}"
+            +zi-log "{log-info} Inspecting via {cmd}pygmentize{rst}"
             pygmentize -l 'bash' "$fname"
         elif (( ${+commands[highlight]} )); then
-            +zinit-message "{log-info} Inspecting via {cmd}highlight{rst}"
+            +zi-log "{log-info} Inspecting via {cmd}highlight{rst}"
             if (( has_256_colors )); then
                 highlight --force --output-format xterm256 --quiet --syntax sh "$fname"
             else
                 highlight --force --output-format ansi --quiet --syntax sh "$fname"
             fi
         elif (( ${+commands[source-highlight]} )); then
-            +zinit-message "{log-info} Inspecting via {cmd}source-highlight{rst}"
+            +zi-log "{log-info} Inspecting via {cmd}source-highlight{rst}"
             source-highlight -fesc --failsafe -s zsh -o STDOUT -i "$fname"
         else
             cat "$fname"
@@ -1786,7 +1786,7 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
     builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob typesetsilent warncreateglobal
 
-    [[ $1 = -q ]] && +zinit-message "{pre}[self-update]{info} updating zinit repository{msg2}" \
+    [[ $1 = -q ]] && +zi-log "{pre}[self-update]{info} updating zinit repository{msg2}" \
 
     local nl=$'\n' escape=$'\x1b['
     local current_branch=$(git -C $ZINIT[BIN_DIR] rev-parse --abbrev-ref HEAD)
@@ -1794,7 +1794,7 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
     local -a lines
     (
         builtin cd -q "$ZINIT[BIN_DIR]" \
-        && +zinit-message -n "{pre}[self-update]{info} fetching latest changes from {obj}$current_branch{info} branch$nl{rst}" \
+        && +zi-log -n "{pre}[self-update]{info} fetching latest changes from {obj}$current_branch{info} branch$nl{rst}" \
         && command git fetch --quiet \
         && lines=( ${(f)"$(command git log --color --date=short --pretty=format:'%Cgreen%cd %h %Creset%s %Cred%d%Creset || %b' ..origin/HEAD)"} )
         if (( ${#lines} > 0 )); then
@@ -1819,16 +1819,16 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
         }
     )
     if [[ $1 != -q ]] {
-        +zinit-message "{pre}[self-update]{info} compiling zinit via {obj}zcompile{rst}"
+        +zi-log "{pre}[self-update]{info} compiling zinit via {obj}zcompile{rst}"
     }
     command rm -f $ZINIT[BIN_DIR]/*.zwc(DN)
     zcompile -U $ZINIT[BIN_DIR]/zinit.zsh
     zcompile -U $ZINIT[BIN_DIR]/zinit-{'side','install','autoload','additional'}.zsh
     zcompile -U $ZINIT[BIN_DIR]/share/git-process-output.zsh
     # Load for the current session
-    [[ $1 != -q ]] && +zinit-message "{pre}[self-update]{info} reloading zinit for the current session{rst}"
+    [[ $1 != -q ]] && +zi-log "{pre}[self-update]{info} reloading zinit for the current session{rst}"
 
-    # +zinit-message "{pre}[self-update]{info} resetting zinit repository via{rst}: {cmd}${ICE[reset]:-git reset --hard HEAD}{rst}"
+    # +zi-log "{pre}[self-update]{info} resetting zinit repository via{rst}: {cmd}${ICE[reset]:-git reset --hard HEAD}{rst}"
     source $ZINIT[BIN_DIR]/zinit.zsh
     zcompile -U $ZINIT[BIN_DIR]/zinit-{'side','install','autoload'}.zsh
     # Read and remember the new modification timestamps
@@ -2125,13 +2125,13 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
 
     local infoc="${ZINIT[col-info2]}"
 
-    +zinit-message "Zinit's main directory: {file}${ZINIT[HOME_DIR]}{rst}"
-    +zinit-message "Zinit's binary directory: {file}${ZINIT[BIN_DIR]}{rst}"
-    +zinit-message "Plugin directory: {file}${ZINIT[PLUGINS_DIR]}{rst}"
-    +zinit-message "Completions directory: {file}${ZINIT[COMPLETIONS_DIR]}{rst}"
+    +zi-log "Zinit's main directory: {file}${ZINIT[HOME_DIR]}{rst}"
+    +zi-log "Zinit's binary directory: {file}${ZINIT[BIN_DIR]}{rst}"
+    +zi-log "Plugin directory: {file}${ZINIT[PLUGINS_DIR]}{rst}"
+    +zi-log "Completions directory: {file}${ZINIT[COMPLETIONS_DIR]}{rst}"
 
     # Without _zlocal/zinit
-    +zinit-message "Loaded plugins: {num}$(( ${#ZINIT_REGISTERED_PLUGINS[@]} - 1 )){rst}"
+    +zi-log "Loaded plugins: {num}$(( ${#ZINIT_REGISTERED_PLUGINS[@]} - 1 )){rst}"
 
     # Count light-loaded plugins
     integer light=0
@@ -2140,32 +2140,32 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
         [[ "$s" = 1 ]] && (( light ++ ))
     done
     # Without _zlocal/zinit
-    +zinit-message "Light loaded: {num}$(( light - 1 )){rst}"
+    +zi-log "Light loaded: {num}$(( light - 1 )){rst}"
 
     # Downloaded plugins, without _zlocal/zinit, custom
     typeset -a plugins
     plugins=( "${ZINIT[PLUGINS_DIR]}"/*(DN) )
-    +zinit-message "Downloaded plugins: {num}$(( ${#plugins} - 1 )){rst}"
+    +zi-log "Downloaded plugins: {num}$(( ${#plugins} - 1 )){rst}"
 
     # Number of enabled completions, with _zlocal/zinit
     typeset -a completions
     completions=( "${ZINIT[COMPLETIONS_DIR]}"/_[^_.]*~*.zwc(DN) )
-    +zinit-message "Enabled completions: {num}${#completions[@]}{rst}"
+    +zi-log "Enabled completions: {num}${#completions[@]}{rst}"
 
     # Number of disabled completions, with _zlocal/zinit
     completions=( "${ZINIT[COMPLETIONS_DIR]}"/[^_.]*~*.zwc(DN) )
-    +zinit-message "Disabled completions: {num}${#completions[@]}{rst}"
+    +zi-log "Disabled completions: {num}${#completions[@]}{rst}"
 
     # Number of completions existing in all plugins
     completions=( "${ZINIT[PLUGINS_DIR]}"/*/**/_[^_.]*~*(*.zwc|*.html|*.txt|*.png|*.jpg|*.jpeg|*.js|*.md|*.yml|*.ri|_zsh_highlight*|/zsdoc/*|*.ps1)(DN) )
-    +zinit-message "Completions available overall: {num}${#completions[@]}{rst}"
+    +zi-log "Completions available overall: {num}${#completions[@]}{rst}"
 
     # Enumerate snippets loaded
-    # }, ${infoc}{rst}", j:, :, {msg}"$'\e[0m, +zinit-message h
-    +zinit-message -n "Snippets loaded: "
+    # }, ${infoc}{rst}", j:, :, {msg}"$'\e[0m, +zi-log h
+    +zi-log -n "Snippets loaded: "
     local sni
     for sni in ${(onv)ZINIT_SNIPPETS[@]}; do
-        +zinit-message -n "{url}${sni% <[^>]#>}{rst} ${(M)sni%<[^>]##>}, "
+        +zi-log -n "{url}${sni% <[^>]#>}{rst} ${(M)sni%<[^>]##>}, "
     done
     [[ -z $sni ]] && builtin print -n " "
     builtin print '\b\b  '
@@ -2185,7 +2185,7 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
         fi
     done
 
-    +zinit-message "Compiled plugins: {num}$count{rst}"
+    +zi-log "Compiled plugins: {num}$count{rst}"
 } # ]]]
 
 # FUNCTION: .zinit-stress [[[
@@ -2824,7 +2824,7 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
             local PUFILE=$PUDIR/${counter}_$PUFILEMAIN.out
 
             .zinit-any-colorify-as-uspl2 "$uspl"
-            +zinit-message "Updating $REPLY{…}" >! $PUFILE
+            +zi-log "Updating $REPLY{…}" >! $PUFILE
 
             .zinit-any-to-user-plugin "$uspl"
             local user=${reply[-2]} plugin=${reply[-1]}
@@ -2879,7 +2879,7 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
         .zinit-exists-physically "$user" "$plugin" || return $retval
         .zinit-any-colorify-as-uspl2 "$2" "$3"
         (( !OPTS[opt_-q,--quiet] )) && \
-            +zinit-message "{msg2}Updating also \`$REPLY{rst}{msg2}'" \
+            +zi-log "{msg2}Updating also \`$REPLY{rst}{msg2}'" \
                 "plugin (already updated a snippet of the same name){…}{rst}"
     } else {
         .zinit-exists-physically-message "$user" "$plugin" || return 1
@@ -2976,7 +2976,7 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
                 }
             }
             if (( ZINIT[annex-multi-flag:pull-active] <= 1 && !OPTS[opt_-q,--quiet] )) {
-                +zinit-message "{info}[{pre}${ice[from]}{info}]{rst} latest version ({version}${version}{rst}) already installed"
+                +zi-log "{info}[{pre}${ice[from]}{info}]{rst} latest version ({version}${version}{rst}) already installed"
             }
         }
 
@@ -3117,10 +3117,10 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
         fi
         if [[ -n ${(v)ice[(I)(mv|cp|atpull|ps-on-update|cargo)]} || $+ice[sbin]$+ice[make]$+ice[extract]$+ice[configure] -ne 0 ]] {
             if (( !OPTS[opt_-q,--quiet] && ZINIT[annex-multi-flag:pull-active] == 1 )) {
-                +zinit-message -n "{pre}[update]{msg3} Continuing with the update because "
+                +zi-log -n "{pre}[update]{msg3} Continuing with the update because "
                 (( ${+ice[run-atpull]} )) && \
-                    +zinit-message "{ice}run-atpull{apo}''{msg3} ice given.{rst}" || \
-                    +zinit-message "{opt}-u{msg3}/{opt}--urge{msg3} given.{rst}"
+                    +zi-log "{ice}run-atpull{apo}''{msg3} ice given.{rst}" || \
+                    +zi-log "{opt}-u{msg3}/{opt}--urge{msg3} given.{rst}"
             }
         }
 
@@ -3224,7 +3224,7 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
     .zinit-self-update -q
 
     [[ $2 = restart ]] && \
-        +zinit-message "{msg2}Restarting the update with the new codebase loaded.{rst}"$'\n'
+        +zi-log "{msg2}Restarting the update with the new codebase loaded.{rst}"$'\n'
 
     local file
     integer sum el update_rc
@@ -3236,7 +3236,7 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
     if [[ $2 != restart ]] && (( ZINIT[mtime] + ZINIT[mtime-side] +
         ZINIT[mtime-install] + ZINIT[mtime-autoload] != sum
     )) {
-        +zinit-message "{msg2}Detected Zinit update in another session -" \
+        +zi-log "{msg2}Detected Zinit update in another session -" \
             "{pre}reloading Zinit{msg2}{…}{rst}"
         source $ZINIT[BIN_DIR]/zinit.zsh
         source $ZINIT[BIN_DIR]/zinit-side.zsh
@@ -3245,7 +3245,7 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
         for file ( "" -side -install -autoload ) {
             .zinit-get-mtime-into "${ZINIT[BIN_DIR]}/zinit$file.zsh" "ZINIT[mtime$file]"
         }
-        +zinit-message "%B{pname}Done.{rst}"$'\n'
+        +zi-log "%B{pname}Done.{rst}"$'\n'
         .zinit-update-or-status-all "$1" restart
         return $?
     }
@@ -3254,13 +3254,13 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
 
     if (( OPTS[opt_-p,--parallel] )) && [[ $1 = update ]] {
         (( !OPTS[opt_-q,--quiet] )) && \
-            +zinit-message '{info2}Parallel Update Starts Now{…}{rst}'
+            +zi-log '{info2}Parallel Update Starts Now{…}{rst}'
         .zinit-update-all-parallel
         retval=$?
         .zinit-compinit 1 1 &>/dev/null
         rehash
         if (( !OPTS[opt_-q,--quiet] )) {
-            +zinit-message "{msg2}The update took {obj}${SECONDS}{msg2} seconds{rst}"
+            +zi-log "{msg2}The update took {obj}${SECONDS}{msg2} seconds{rst}"
         }
         return $retval
     }
@@ -3276,7 +3276,7 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
         snipps=( ${ZINIT[SNIPPETS_DIR]}/**/(._zinit|._zplugin)(ND) )
 
         [[ $st != status && ${OPTS[opt_-q,--quiet]} != 1 && -n $snipps ]] && \
-            +zinit-message "{info}Note:{rst} updating also unloaded snippets"
+            +zi-log "{info}Note:{rst} updating also unloaded snippets"
 
         for snip ( ${ZINIT[SNIPPETS_DIR]}/**/(._zinit|._zplugin)/mode(D) ) {
             [[ ! -f ${snip:h}/url ]] && continue
@@ -3297,10 +3297,10 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
 
     if [[ $st = status ]]; then
         (( !OPTS[opt_-q,--quiet] )) && \
-            +zinit-message "{info}Note:{rst} status done also for unloaded plugins"
+            +zi-log "{info}Note:{rst} status done also for unloaded plugins"
     else
         (( !OPTS[opt_-q,--quiet] )) && \
-            +zinit-message "{info}Note:{rst} updating also unloaded plugins"
+            +zi-log "{info}Note:{rst} updating also unloaded plugins"
     fi
 
     ZINIT[first-plugin-mark]=init
@@ -3345,7 +3345,7 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
             .zinit-update-or-status update "$user" "$plugin"
             update_rc=$?
             [[ $update_rc -ne 0 ]] && {
-                +zinit-message "🚧{warn}Warning: {pid}${user}/${plugin} {warn}update returned {obj}$update_rc"
+                +zi-log "🚧{warn}Warning: {pid}${user}/${plugin} {warn}update returned {obj}$update_rc"
                 retval=$?
             }
         fi
@@ -3353,7 +3353,7 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
 
     .zinit-compinit 1 1 &>/dev/null
     if (( !OPTS[opt_-q,--quiet] )) {
-        +zinit-message "{msg2}The update took {obj}${SECONDS}{msg2} seconds{rst}"
+        +zi-log "{msg2}The update took {obj}${SECONDS}{msg2} seconds{rst}"
     }
 
     return "$retval"
@@ -3416,7 +3416,7 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
         counter=0
         PUAssocArray=()
     } elif (( counter == 1 && !OPTS[opt_-q,--quiet] )) {
-        +zinit-message "{obj}Spawning the next{num}" \
+        +zi-log "{obj}Spawning the next{num}" \
             "${OPTS[value]}{obj} concurrent update jobs" \
             "({msg2}${tpe}{obj}){…}{rst}"
     }
@@ -3427,7 +3427,7 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
 #
 # User-action entry point.
 zi::version() {
-	+zinit-message "zinit{cmd} $(git --git-dir=$(realpath ${ZINIT[BIN_DIR]}/.git) describe --tags) {rst}(${OSTYPE}_${CPUTYPE})"
+	+zi-log "zinit{cmd} $(git --git-dir=$(realpath ${ZINIT[BIN_DIR]}/.git) describe --tags) {rst}(${OSTYPE}_${CPUTYPE})"
 	return $?
 } # ]]]
 

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -13,7 +13,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 .zinit-jq-check() {
     command -v jq >/dev/null && return 0
 
-    +zinit-message "{error}❌ ERROR: jq binary not found" \
+    +zi-log "{error}❌ ERROR: jq binary not found" \
         "{nl}{u-warn}Please install jq:{rst}" \
         "https://github.com/jqlang/jq" \
         "{nl}{u-warn}To do so with zinit, please refer to:{rst}" \
@@ -102,7 +102,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     [[ -n "$localpkg" ]] && pkgname="{pid}$pkgname{rst} {note}[$tmpfile]{rst}"
 
     if [[ -z $pkgjson ]] {
-        +zinit-message "{error}❌ Error: the package {hi}${pkgname}" \
+        +zi-log "{error}❌ Error: the package {hi}${pkgname}" \
                        "{error}couldn't be found.{rst}"
         return 1
     }
@@ -119,7 +119,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     # Check if user requested an unknown profile
     if ! (( ${profiles[(I)${profile}]} )) {
         # Assumption: the default profile is the first in the table (-> different color).
-        +zinit-message "{u-warn}Error{b-warn}:{error} the profile {apo}\`{hi}$profile{apo}\`" \
+        +zi-log "{u-warn}Error{b-warn}:{error} the profile {apo}\`{hi}$profile{apo}\`" \
             "{error}couldn't be found, aborting. Available profiles are:" \
             "{lhi}${(pj:$epro_sep:)profiles[@]}{error}.{rst}"
         return 1
@@ -129,7 +129,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     local -A metadata
     .zinit-json-to-array "$pkgjson" "$json_meta" metadata
     if [[ "$?" -ne 0 || -z "$metadata" ]] {
-        +zinit-message '{error}❌ ERROR: Failed to retrieve metadata from package.json'
+        +zi-log '{error}❌ ERROR: Failed to retrieve metadata from package.json'
         return 1
     }
 
@@ -159,13 +159,13 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
         eval "ICE[id-as]=\"${ICE[id-as]//(#m)[\"\\]/${map[$MATCH]}}\""
     }
 
-    +zinit-message "{info3}Package{ehi}:{rst} ${pkgname}. Selected" \
+    +zi-log "{info3}Package{ehi}:{rst} ${pkgname}. Selected" \
         "profile{ehi}:{rst} {hi}$profile{rst}. Available" \
         "profiles:${${${(M)profile:#default}:+$lhi_hl}:-$profile_hl}" \
         "${(pj:$pro_sep:)profiles[@]}{rst}."
 
     if [[ $profile != *bgn* && -n ${(M)profiles[@]:#*bgn*} ]] {
-        +zinit-message "{note}Note:{rst} The {apo}\`{profile}bgn{glob}*{apo}\`{rst}" \
+        +zi-log "{note}Note:{rst} The {apo}\`{profile}bgn{glob}*{apo}\`{rst}" \
             "profiles (if any are available) are the recommended ones (the reason" \
             "is that they expose the binaries provided by the package without" \
             "altering (i.e.: {slight}cluttering{rst}{…}) the {var}\$PATH{rst}" \
@@ -181,37 +181,37 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
             ]]; then
                 local -A namemap
                 namemap=( bgn bin-gem-node dl patch-dl monitor readurl )
-                +zinit-message -n "{u-warn}ERROR{b-warn}: {error}the "
+                +zi-log -n "{u-warn}ERROR{b-warn}: {error}the "
                 if [[ -z ${(MS)ICE[requires]##(\;|(#s))$required(\;|(#e))} ]]; then
-                    +zinit-message -n "{error}requested profile {apo}\`{hi}$profile{apo}\`{error} "
+                    +zi-log -n "{error}requested profile {apo}\`{hi}$profile{apo}\`{error} "
                 else
-                    +zinit-message -n "{error}package {pid}$pkg{error} "
+                    +zi-log -n "{error}package {pid}$pkg{error} "
                 fi
-                +zinit-message '{error}requires the {apo}`{annex}'${namemap[$required]}'{apo}`' \
+                +zi-log '{error}requires the {apo}`{annex}'${namemap[$required]}'{apo}`' \
                     "{error}annex, which is currently not installed." \
                     "{nl}{nl}If you'd like to install it, you can visit its homepage:" \
                     "{nl}– {url}https://github.com/zdharma-continuum/zinit-annex-${(L)namemap[$required]}{rst}" \
                     "{nl}for instructions."
                 (( ${#profiles[@]:#$profile} > 0 )) && \
-                    +zinit-message "{nl}Other available profiles are:" \
+                    +zi-log "{nl}Other available profiles are:" \
 "{profile}${(pj:$pro_sep:)${profiles[@]:#$profile}}{rst}."
 
                 return 1
             fi
         else
             if ! command -v $required &>/dev/null; then
-                +zinit-message -n "{u-warn}ERROR{b-warn}: {error}the "
+                +zi-log -n "{u-warn}ERROR{b-warn}: {error}the "
                 if [[ -n ${(MS)ICE[requires]##(\;|(#s))$required(\;|(#e))} ]]; then
-                    +zinit-message -n "{error}requested profile {apo}\`{hi}$profile{apo}\`{error} "
+                    +zi-log -n "{error}requested profile {apo}\`{hi}$profile{apo}\`{error} "
                 else
-                    +zinit-message -n "{error}package {pid}$pkg{error} "
+                    +zi-log -n "{error}package {pid}$pkg{error} "
                 fi
-                +zinit-message '{error}requires a {apo}`{cmd}'$required'{apo}`{error}' \
+                +zi-log '{error}requires a {apo}`{cmd}'$required'{apo}`{error}' \
                     "command to be available in {var}\$PATH{error}.{rst}" \
                     "{nl}{error}The package cannot be installed unless the" \
                     "command will be available."
                 (( ${#profiles[@]:#$profile} > 0 )) && \
-                    +zinit-message "{nl}Other available profiles are:" \
+                    +zi-log "{nl}Other available profiles are:" \
                         "{profile}${(pj:$pro_sep:)${profiles[@]:#$profile}}{rst}."
                 return 1
             fi
@@ -219,18 +219,18 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     }
 
     if [[ -n ${ICE[dl]} && -z ${(k)ZINIT_EXTS[(r)<-> z-annex-data: zinit-annex-patch-dl *]} ]] {
-        +zinit-message "{nl}{u-warn}WARNING{b-warn}:{rst} the profile uses" \
+        +zi-log "{nl}{u-warn}WARNING{b-warn}:{rst} the profile uses" \
             "{ice}dl''{rst} ice however there's currently no {annex}zinit-annex-patch-dl{rst}" \
             "annex loaded, which provides it."
-        +zinit-message "The ice will be inactive, i.e.: no additional" \
+        +zi-log "The ice will be inactive, i.e.: no additional" \
             "files will become downloaded (the ice downloads the given URLs)." \
             "The package should still work, as it doesn't indicate to" \
             "{u}{slight}require{rst} the annex."
-        +zinit-message "{nl}You can download the" \
+        +zi-log "{nl}You can download the" \
             "annex from its homepage at {url}https://github.com/zdharma-continuum/zinit-annex-patch-dl{rst}."
     }
 
-    [[ -n ${message} ]] && +zinit-message "{info}${message}{rst}"
+    [[ -n ${message} ]] && +zi-log "{info}${message}{rst}"
 
     if (( ${+ICE[is-snippet]} )) {
         reply=( "" "$url" )
@@ -248,18 +248,18 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
             local fname="${${URL%%\?*}:t}"
 
             command mkdir -p $dir || {
-                +zinit-message "{u-warn}Error{b-warn}:{error} Couldn't create directory:" \
+                +zi-log "{u-warn}Error{b-warn}:{error} Couldn't create directory:" \
                     "{dir}$dir{error}, aborting.{rst}"
                 return 1
             }
             builtin cd -q $dir || return 1
 
-            +zinit-message "Downloading tarball for {pid}$plugin{rst}{…}"
+            +zi-log "Downloading tarball for {pid}$plugin{rst}{…}"
 
             if { ! .zinit-download-file-stdout "$URL" 0 1 >! "$fname" } {
                 if { ! .zinit-download-file-stdout "$URL" 1 1 >! "$fname" } {
                     command rm -f "$fname"
-                    +zinit-message "Download of the file {apo}\`{file}$fname{apo}\`{rst}" \
+                    +zi-log "Download of the file {apo}\`{file}$fname{apo}\`{rst}" \
                         "failed. No available download tool? One of:" \
                         "{cmd}${(pj:$tool_sep:)${=:-curl wget lftp lynx}}{rst}."
 
@@ -301,7 +301,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
         local_path tpe=$4 update=$5 version=$6
 
     if .zinit-get-object-path plugin "$id_as" && [[ -z $update ]] {
-        +zinit-message "{u-warn}ERROR{b-warn}:{error} A plugin named {pid}$id_as{error}" \
+        +zi-log "{u-warn}ERROR{b-warn}:{error} A plugin named {pid}$id_as{error}" \
                 "already exists, aborting."
         return 1
     }
@@ -343,7 +343,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
             .zinit-any-colorify-as-uspl2 "$user" "$plugin"
             local pid_hl='{pid}' id_msg_part=" (at label{ehi}:{rst} {id-as}$id_as{rst}{…})"
             (( $+ICE[pack] )) && local infix_m="({b}{ice}pack{apo}''{rst}) "
-            +zinit-message "{nl}Downloading $infix_m{pid}$user${user:+/}$plugin{…}${${${id_as:#$user/$plugin}}:+$id_msg_part}"
+            +zi-log "{nl}Downloading $infix_m{pid}$user${user:+/}$plugin{…}${${${id_as:#$user/$plugin}}:+$id_msg_part}"
         }
 
         local site
@@ -378,11 +378,11 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                         { local old_version="$(<$local_path/._zinit/is_release${count:#1})"; } 2>/dev/null
                         old_version=${old_version/(#b)(\/[^\/]##)(#c4,4)\/([^\/]##)*/${match[2]}}
                     }
-                    +zinit-message "(Requesting \`${REPLY:t}'${version:+, version $version}{…}${old_version:+ Current version: $old_version.})"
+                    +zi-log "(Requesting \`${REPLY:t}'${version:+, version $version}{…}${old_version:+ Current version: $old_version.})"
                     if { ! .zinit-download-file-stdout "$url" 0 1 >! "${REPLY:t}" } {
                         if { ! .zinit-download-file-stdout "$url" 1 1 >! "${REPLY:t}" } {
                             command rm -f "${REPLY:t}"
-                            +zinit-message "Download of release for \`$remote_url_path' " \
+                            +zi-log "Download of release for \`$remote_url_path' " \
                                 "failed.{nl}Tried url: $url."
                             return 1
                         }
@@ -589,9 +589,9 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     for comps msg in ${(kv)comp_types}; do
         local comps_num=${#${(e)comps}}
         if (( comps_num > 0 )); then
-            +zinit-message "{m} ${msg} {num}$comps_num{rst} completion${=${comps_num:#1}:+s}"
+            +zi-log "{m} ${msg} {num}$comps_num{rst} completion${=${comps_num:#1}:+s}"
             if (( quiet == 0 )); then
-                +zinit-message "{m} Added $comps_num completion${=${comps_num:#1}:+s} to {var}$comps{rst} array"
+                +zi-log "{m} Added $comps_num completion${=${comps_num:#1}:+s} to {var}$comps{rst} array"
             fi
         fi
     done
@@ -637,7 +637,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
         .zinit-forget-completion "$cfile"
     done
 
-    +zinit-message "Initializing completion ({func}compinit{rst}){…}"
+    +zi-log "Initializing completion ({func}compinit{rst}){…}"
     command rm -f ${ZINIT[ZCOMPDUMP_PATH]:-${ZDOTDIR:-$HOME}/.zcompdump}
 
     # Workaround for a nasty trick in _vim
@@ -682,7 +682,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
         elif (( ${+commands[lynx]} )); then
             command lynx -source "$url" || return 1
         else
-            +zinit-message "{u-warn}ERROR{b-warn}:{rst}No download tool detected" \
+            +zi-log "{u-warn}ERROR{b-warn}:{rst}No download tool detected" \
                 "(one of: {cmd}curl{rst}, {cmd}wget{rst}, {cmd}lftp{rst}," \
                 "{cmd}lynx{rst})."
             return 2
@@ -848,12 +848,12 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                 if [[ -f $plugin_dir/$filename ]] {
                     reply=( "$plugin_dir" $plugin_dir/$filename )
                 } elif { ! .zinit-first % "$plugin_dir" } {
-                    +zinit-message "{m} No files for compilation found"
+                    +zi-log "{m} No files for compilation found"
                     return 1
                 }
             } else {
                 .zinit-first "$1" "$2" || {
-                    +zinit-message "{m} No files for compilation found"
+                    +zi-log "{m} No files for compilation found"
                     return 1
                 }
             }
@@ -862,15 +862,15 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
         first=${reply[-1]}
         local fname=${first#$pdir_path/}
 
-        +zinit-message -n "{m} Compiling {file}$fname{rst}"
+        +zi-log -n "{m} Compiling {file}$fname{rst}"
         if [[ -z ${ICE[(i)(\!|)(sh|bash|ksh|csh)]} ]] {
             () {
                 builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
                 if { ! zcompile -U "$first" } {
-                    +zinit-message "{msg2}Warning:{rst} Compilation failed. Don't worry, the plugin will work also without compilation."
-                    +zinit-message "{msg2}Warning:{rst} Consider submitting an error report to Zinit or to the plugin's author."
+                    +zi-log "{msg2}Warning:{rst} Compilation failed. Don't worry, the plugin will work also without compilation."
+                    +zi-log "{msg2}Warning:{rst} Consider submitting an error report to Zinit or to the plugin's author."
                 } else {
-                    +zinit-message " [{happy}OK{rst}]"
+                    +zi-log " [{happy}OK{rst}]"
                 }
                 # Try to catch possible additional file
                 zcompile -U "${${first%.plugin.zsh}%.zsh-theme}.zsh" 2>/dev/null
@@ -887,7 +887,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
             eval "list+=( \$plugin_dir/$~pat(N) )"
         }
         if [[ ${#list} -eq 0 ]] {
-            +zinit-message "{w} ice {ice}compile{apo}''{rst} didn't match any files."
+            +zi-log "{w} ice {ice}compile{apo}''{rst} didn't match any files."
         } else {
             integer retval
             for first in $list; do
@@ -897,9 +897,9 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                 }
             done
             builtin print -rl -- ${list[@]#$plugin_dir/} >! ${TMPDIR:-/tmp}/zinit.compiled.$$.lst
-            +zinit-message -n "{m} {num}${#list}{rst} compiled file${=${list:#1}:+s} added to {var}\$ADD_COMPILED{rst} array"
+            +zi-log -n "{m} {num}${#list}{rst} compiled file${=${list:#1}:+s} added to {var}\$ADD_COMPILED{rst} array"
             if (( retval )) {
-                +zinit-message " (exit code: {ehi}$retval{rst})"
+                +zi-log " (exit code: {ehi}$retval{rst})"
             }
         }
     fi
@@ -960,14 +960,14 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 
     if [[ ! -d $local_dir/$dirname ]]; then
         local id_msg_part="{…} (at label{ehi}:{rst} {id-as}$id_as{rst})"
-        [[ $update != -u ]] && +zinit-message "{nl}{info}Setting up snippet:" \
+        [[ $update != -u ]] && +zi-log "{nl}{info}Setting up snippet:" \
                                     "{url}$sname{rst}${ICE[id-as]:+$id_msg_part}"
         command mkdir -p "$local_dir"
     fi
 
     if [[ $update = -u && ${OPTS[opt_-q,--quiet]} != 1 ]]; then
         local id_msg_part="{…} (identified as{ehi}:{rst} {id-as}$id_as{rst})"
-        +zinit-message "{nl}{info2}Updating snippet: {url}$sname{rst}${ICE[id-as]:+$id_msg_part}"
+        +zi-log "{nl}{info2}Updating snippet: {url}$sname{rst}${ICE[id-as]:+$id_msg_part}"
     fi
 
     # A flag for the annexes. 0 – no new commits, 1 - run-atpull mode,
@@ -985,7 +985,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
             (
                 () { setopt localoptions noautopushd; builtin cd -q "$local_dir"; } || return 4
 
-                (( !OPTS[opt_-q,--quiet] )) && +zinit-message "Downloading {apo}\`{url}$sname{apo}\`{rst}${${ICE[svn]+" (with Subversion)"}:-" (with curl, wget, lftp)"}{…}"
+                (( !OPTS[opt_-q,--quiet] )) && +zi-log "Downloading {apo}\`{url}$sname{apo}\`{rst}${${ICE[svn]+" (with Subversion)"}:-" (with curl, wget, lftp)"}{…}"
 
                 if (( ${+ICE[svn]} )) {
                     if [[ $update = -u ]] {
@@ -1024,8 +1024,8 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                             # the messages on an actual update
                             if (( OPTS[opt_-q,--quiet] )); then
                                 local id_msg_part="{…} (identified as{ehi}: {id-as}$id_as{rst})"
-                                +zinit-message "{nl}{info2}Updating snippet {url}${sname}{rst}${ICE[id-as]:+$id_msg_part}"
-                                +zinit-message "Downloading {apo}\`{rst}$sname{apo}\`{rst} (with Subversion){…}"
+                                +zi-log "{nl}{info2}Updating snippet {url}${sname}{rst}${ICE[id-as]:+$id_msg_part}"
+                                +zi-log "Downloading {apo}\`{rst}$sname{apo}\`{rst} (with Subversion){…}"
                             fi
                             .zinit-mirror-using-svn "$url" "-u" "$dirname" || return 4
                         }
@@ -1051,7 +1051,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                             () {
                                 builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
                                 zcompile -U "${list[1]}" &>/dev/null || \
-                                    +zinit-message "{u-warn}Warning{b-warn}:{rst} couldn't compile {apo}\`{file}${list[1]}{apo}\`{rst}."
+                                    +zi-log "{u-warn}Warning{b-warn}:{rst} couldn't compile {apo}\`{file}${list[1]}{apo}\`{rst}."
                             }
                         }
                     fi
@@ -1079,7 +1079,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                     local -a matched
                     matched=( $local_dir/$dirname/$filename(DNms-$secs) )
                     if (( ${#matched} )) {
-                        +zinit-message "{info}Already up to date.{rst}"
+                        +zi-log "{info}Already up to date.{rst}"
                         # Empty-update return-short path – it also decides the
                         # pull-active flag after the return from this sub-shell
                         (( ${+ICE[run-atpull]} || OPTS[opt_-u,--urge] )) && skip_dl=1 || return 0
@@ -1117,7 +1117,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                         if { ! .zinit-download-file-stdout "$url" 0 1 >! "$dirname/$filename" } {
                             if { ! .zinit-download-file-stdout "$url" 1 1 >! "$dirname/$filename" } {
                                 command rm -f "$dirname/$filename"
-                                +zinit-message "{u-warn}ERROR{b-warn}:{rst} Download failed."
+                                +zi-log "{u-warn}ERROR{b-warn}:{rst} Download failed."
                                 return 4
                             }
                         }
@@ -1175,26 +1175,26 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 
             command mkdir -p "$local_dir/$dirname"
             if [[ ! -e $url ]] {
-                (( !OPTS[opt_-q,--quiet] )) && +zinit-message "{ehi}ERROR:{error} The source file {file}$url{error} doesn't exist.{rst}"
+                (( !OPTS[opt_-q,--quiet] )) && +zi-log "{ehi}ERROR:{error} The source file {file}$url{error} doesn't exist.{rst}"
                 retval=4
             }
             if [[ -e $url && ! -f $url && $url != /dev/null ]] {
-                (( !OPTS[opt_-q,--quiet] )) && +zinit-message "{ehi}ERROR:{error} The source {file}$url{error} isn't a regular file.{rst}"
+                (( !OPTS[opt_-q,--quiet] )) && +zi-log "{ehi}ERROR:{error} The source {file}$url{error} isn't a regular file.{rst}"
                 retval=4
             }
             if [[ -e $url && ! -r $url && $url != /dev/null ]] {
-                (( !OPTS[opt_-q,--quiet] )) && +zinit-message "{ehi}ERROR:{error} The source {file}$url{error} isn't" \
+                (( !OPTS[opt_-q,--quiet] )) && +zi-log "{ehi}ERROR:{error} The source {file}$url{error} isn't" \
                     "accessible (wrong permissions).{rst}"
                 retval=4
             }
             if ! (( ${+ICE[link] )) {
                 if (( !OPTS[opt_-q,--quiet] )) && [[ $url != /dev/null ]] {
-                    +zinit-message "{msg}Copying {file}$filename{msg}{…}{rst}"
+                    +zi-log "{msg}Copying {file}$filename{msg}{…}{rst}"
                     command cp -vf "$url" "$local_dir/$dirname/$filename" || \
-                        { +zinit-message "{ehi}ERROR:{error} The file copying has been unsuccessful.{rst}"; retval=4; }
+                        { +zi-log "{ehi}ERROR:{error} The file copying has been unsuccessful.{rst}"; retval=4; }
                 } else {
                     command cp -f "$url" "$local_dir/$dirname/$filename" &>/dev/null || \
-                        { +zinit-message "{ehi}ERROR:{error} The copying of {file}$filename{error} has been unsuccessful"\
+                        { +zi-log "{ehi}ERROR:{error} The copying of {file}$filename{error} has been unsuccessful"\
     "${${(M)OPTS[opt_-q,--quiet]:#1}:+, skip the -q/--quiet option for more information}.{rst}"; retval=4; }
                 }
             } else {
@@ -1206,12 +1206,12 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                     fi
                 }
                 if (( !OPTS[opt_-q,--quiet] )) && [[ $url != /dev/null ]] {
-                    +zinit-message "{msg}Linking {file}$filename{msg}{…}{rst}"
+                    +zi-log "{msg}Linking {file}$filename{msg}{…}{rst}"
                     command ln -svf "$url" "$local_dir/$dirname/$filename" || \
-                        { +zinit-message "{ehi}ERROR:{error} The file linking has been unsuccessful.{rst}"; retval=4; }
+                        { +zi-log "{ehi}ERROR:{error} The file linking has been unsuccessful.{rst}"; retval=4; }
                 } else {
                     command ln -sf "$url" "$local_dir/$dirname/$filename" &>/dev/null || \
-                        { +zinit-message "{ehi}ERROR:{error} The link of {file}$filename{error} has been unsuccessful"\
+                        { +zi-log "{ehi}ERROR:{error} The link of {file}$filename{error} has been unsuccessful"\
     "${${(M)OPTS[opt_-q,--quiet]:#1}:+, skip the -q/--quiet option for more information}.{rst}"; retval=4; }
                 }
             }
@@ -1224,7 +1224,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
             local pfx=$local_dir/$dirname/._zinit
             .zinit-store-ices "$pfx" ICE url_rsvd "" "$save_url" "${+ICE[svn]}"
         } elif [[ -n $id_as ]] {
-            +zinit-message "{u-warn}Warning{b-warn}:{rst} the snippet {url}$id_as{rst} isn't" \
+            +zi-log "{u-warn}Warning{b-warn}:{rst} the snippet {url}$id_as{rst} isn't" \
                 "fully downloaded – you should remove it with {apo}\`{cmd}zinit delete $id_as{apo}\`{rst}."
         }
 
@@ -1397,7 +1397,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     if (( ${#tmp} > 1 && ${#tmp} % 2 == 0 )) {
         ICE=( "${(kv)ICE[@]}" "${tmp[@]}" )
     } elif [[ -n ${ZINIT_SICE[$id_as]} ]] {
-        +zinit-message "{error}WARNING:{msg2} Inconsistency #3" \
+        +zi-log "{error}WARNING:{msg2} Inconsistency #3" \
             "occurred, please report the string: \`{obj}${ZINIT_SICE[$id_as]}{msg2}' to the" \
             "GitHub issues page: {obj}https://github.com/zdharma-continuum/zinit/issues/{msg2}.{rst}"
     }
@@ -1425,7 +1425,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     }
 
     if { ! .zinit-get-object-path snippet "$id_as" } {
-        +zinit-message "{msg2}Error: the snippet \`{obj}$id_as{msg2}'" \
+        +zi-log "{msg2}Error: the snippet \`{obj}$id_as{msg2}'" \
                 "doesn't exist, aborting the update.{rst}"
             return 1
     }
@@ -1500,7 +1500,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
       _sys='pc-windows-gnu'
       ;;
     (*)
-      +zinit-message "{info}[{pre}gh-r{info}]{error} Unsupported OS: {obj}${_os}{rst}"
+      +zi-log "{info}[{pre}gh-r{info}]{error} Unsupported OS: {obj}${_os}{rst}"
       ;;
   esac
   case "$_cpu" in
@@ -1517,7 +1517,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
       _os=${_os}eabihf
       ;;
     (*)
-      +zinit-message "{info}[{pre}ziextract{info}]{error} Unsupported CPU: {obj}$_cpu{rst}"
+      +zi-log "{info}[{pre}ziextract{info}]{error} Unsupported CPU: {obj}$_cpu{rst}"
       ;;
   esac
   echo "${_sys};${_cpu};${_os}"
@@ -1532,7 +1532,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
   local plugin="$2" urlpart="$3" user="$1"
   local -a bpicks filtered init_list list parts
   parts=(${(@s:;:)$(.zi::get-architecture)})
-  # +zinit-message "{info}[{pre}gh-r{info}]{rst} filters -> {glob}${(@)parts}{rst}"
+  # +zi-log "{info}[{pre}gh-r{info}]{rst} filters -> {glob}${(@)parts}{rst}"
   if [[ -z $urlpart ]]; then
     local tag_version=${ICE[ver]}
     if [[ -z $tag_version ]]; then
@@ -1555,7 +1555,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     if [[ -n $bpick ]]; then
       list=( ${(M)list[@]:#(#i)*/$~bpick} )
       if (( !$#list )); then
-        +zinit-message "{info}[{pre}gh-r{info}] {error}Error{rst}: {ice}bpick{rst} ice found no release assets{rst}. To fix, modify the {ice}bpick{rst} glob pattern {glob}${bpick}{rst}"
+        +zi-log "{info}[{pre}gh-r{info}] {error}Error{rst}: {ice}bpick{rst} ice found no release assets{rst}. To fix, modify the {ice}bpick{rst} glob pattern {glob}${bpick}{rst}"
       fi
     fi
 
@@ -1565,7 +1565,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     for part in "${parts[@]}"; do
       if (( $#list > 1 )); then
         filtered=( ${(M)list[@]:#(#i)*${~part}*} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} )
-        # +zinit-message "{info}[{pre}gh-r{info}]{rst} filter -> {glob}${part}{rst}{nl}  - ${(@pj:\n  - :)list[1,2]}{nl}"
+        # +zi-log "{info}[{pre}gh-r{info}]{rst} filter -> {glob}${part}{rst}{nl}  - ${(@pj:\n  - :)list[1,2]}{nl}"
       else
         break
       fi
@@ -1574,7 +1574,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     if (( $#list > 1 )) { filtered=( ${list[@]:#(#i)*.(sha[[:digit:]]#|asc)} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} ); }
 
     if (( !$#list )); then
-      +zinit-message "{nl}{info}[{pre}gh-r{info}] {error}Error{rst}: No GitHub release assets found for {glob}${tag_version}{rst}"
+      +zi-log "{nl}{info}[{pre}gh-r{info}] {error}Error{rst}: No GitHub release assets found for {glob}${tag_version}{rst}"
       return 1
     fi
     reply+=( "${list[1]}" )
@@ -1596,7 +1596,7 @@ ziextract() {
     local -a opt_move opt_move2 opt_norm opt_auto opt_nobkp
     zparseopts -D -E -move=opt_move -move2=opt_move2 -norm=opt_norm \
             -auto=opt_auto -nobkp=opt_nobkp || \
-        { +zinit-message "{info}[{pre}ziextract{info}]{error} Incorrect options given to" \
+        { +zi-log "{info}[{pre}ziextract{info}]{error} Incorrect options given to" \
                   "\`{pre}ziextract{msg2}' (available are: {meta}--auto{msg2}," \
                   "{meta}--move{msg2}, {meta}--move2{msg2}, {meta}--norm{msg2}," \
                   "{meta}--nobkp{msg2}).{rst}"; return 1; }
@@ -1630,7 +1630,7 @@ ziextract() {
                 type=${(L)desc/(#b)(#i)(* |(#s))(zip|rar|xz|7-zip|gzip|bzip2|tar|exe|PE32) */$match[2]}
                 if [[ $type = (zip|rar|xz|7-zip|gzip|bzip2|tar|exe|pe32) ]] {
                     (( !OPTS[opt_-q,--quiet] )) && \
-                        +zinit-message "{info}[{pre}ziextract{info}]{msg2} detected a {meta}$type{rst} archive in the file {file}$fname{rst}."
+                        +zi-log "{info}[{pre}ziextract{info}]{msg2} detected a {meta}$type{rst} archive in the file {file}$fname{rst}."
                     ziextract "$fname" "$type" $opt_move $opt_move2 $opt_norm --norm ${${${#archives}:#1}:+--nobkp}
                     integer iret_val=$?
                     ret_val+=iret_val
@@ -1656,7 +1656,7 @@ ziextract() {
                                 # this might delete too soon… However, it's unusual case.
                                 [[ $fname != $infname && $norm -eq 0 ]] && command rm -f "$infname"
                                 (( !OPTS[opt_-q,--quiet] )) && \
-                                    +zinit-message "{info}[{pre}ziextract{info}]{msg2} detected a {obj}${type2}{rst} archive in the file {file}${fname}{rst}."
+                                    +zi-log "{info}[{pre}ziextract{info}]{msg2} detected a {obj}${type2}{rst} archive in the file {file}${fname}{rst}."
                                 ziextract "$fname" "$type2" $opt_move $opt_move2 $opt_norm ${${${#archives}:#1}:+--nobkp}
                                 ret_val+=$?
                                 stage2_processed+=( $fname )
@@ -1674,11 +1674,11 @@ ziextract() {
     }
 
     if [[ -z $file ]] {
-        +zinit-message "{info}[{pre}ziextract{info}]{error} argument needed (the file to extract) or the {meta}--auto{msg} option."
+        +zi-log "{info}[{pre}ziextract{info}]{error} argument needed (the file to extract) or the {meta}--auto{msg} option."
         return 1
     }
     if [[ ! -e $file ]] {
-        +zinit-message "{info}[{pre}ziextract{info}]{error} ERROR:{msg} the file \`{meta}${file}{msg}' doesn't exist.{rst}"
+        +zi-log "{info}[{pre}ziextract{info}]{error} ERROR:{msg} the file \`{meta}${file}{msg}' doesn't exist.{rst}"
         return 1
     }
     if (( !nobkp )) {
@@ -1690,7 +1690,7 @@ ziextract() {
     .zinit-extract-wrapper() {
         local file="$1" fun="$2" retval
         (( !OPTS[opt_-q,--quiet] )) && \
-            +zinit-message "{info}[{pre}ziextract{info}]{rst} Unpacking the files from: \`{obj}$file{msg}'{…}{rst}"
+            +zi-log "{info}[{pre}ziextract{info}]{rst} Unpacking the files from: \`{obj}$file{msg}'{…}{rst}"
         $fun; retval=$?
         if (( retval == 0 )) {
             local -a files
@@ -1701,7 +1701,7 @@ ziextract() {
     }
 
     →zinit-check() { (( ${+commands[$1]} )) || \
-        +zinit-message "{info}[{pre}ziextract{info}]{error} Error:{msg} No command {data}$1{msg}, it is required to unpack {file}$2{rst}."
+        +zi-log "{info}[{pre}ziextract{info}]{error} Error:{msg} No command {data}$1{msg}, it is required to unpack {file}$2{rst}."
     }
 
     case "${${ext:+.$ext}:-$file}" in
@@ -1787,7 +1787,7 @@ ziextract() {
                 command hdiutil detach $attached_vol
 
                 if (( retval )) {
-                    +zinit-message "{info}[{pre}ziextract{info}]{error} Error:{msg} problem occurred when attempted to copy the files" \
+                    +zi-log "{info}[{pre}ziextract{info}]{error} Error:{msg} problem occurred when attempted to copy the files" \
                             "from the mounted image: \`{obj}${file}{msg}'.{rst}"
                 }
                 return $retval
@@ -1809,14 +1809,14 @@ ziextract() {
 
     if [[ $(typeset -f + →zinit-extract) == "→zinit-extract" ]] {
         .zinit-extract-wrapper "$file" →zinit-extract || {
-            +zinit-message -n "{info}[{pre}ziextract{info}]{error} Error:{msg} extraction of the archive \`{file}${file}{msg}' had problems"
+            +zi-log -n "{info}[{pre}ziextract{info}]{error} Error:{msg} extraction of the archive \`{file}${file}{msg}' had problems"
             local -a bfiles
             bfiles=( ._backup/*(DN) )
             if (( ${#bfiles} && !nobkp )) {
-                +zinit-message -n ", restoring the previous version of the plugin/snippet"
+                +zi-log -n ", restoring the previous version of the plugin/snippet"
                 command mv ._backup/*(DN) . 2>/dev/null
             }
-            +zinit-message ".{rst}"
+            +zi-log ".{rst}"
             unfunction -- →zinit-extract →zinit-check 2>/dev/null
             return 1
         }
@@ -1839,11 +1839,11 @@ ziextract() {
         command chmod a+x "${execs[@]}"
         if (( !OPTS[opt_-q,--quiet] )) {
             if (( ${#execs} == 1 )); then
-                    +zinit-message "{info}[{pre}ziextract{info}]{rst} Successfully extracted and assigned +x chmod to the file: {obj}${execs[1]}{rst}."
+                    +zi-log "{info}[{pre}ziextract{info}]{rst} Successfully extracted and assigned +x chmod to the file: {obj}${execs[1]}{rst}."
             else
                 local sep="$ZINIT[col-rst],$ZINIT[col-obj] "
                 if (( ${#execs} > 7 )) {
-                    +zinit-message "{info}[{pre}ziextract{info}]{rst} Successfully" \
+                    +zi-log "{info}[{pre}ziextract{info}]{rst} Successfully" \
                         "extracted and marked executable the appropriate files" \
                         "({obj}${(pj:$sep:)${(@)execs[1,5]:t}},…{rst}) contained" \
                         "in \`{file}$file{rst}'. All the extracted" \
@@ -1851,7 +1851,7 @@ ziextract() {
                         "available in the {msg2}INSTALLED_EXECS{rst}" \
                         "array."
                 } else {
-                    +zinit-message "{info}[{pre}ziextract{info}]{rst} Successfully" \
+                    +zi-log "{info}[{pre}ziextract{info}]{rst} Successfully" \
                         "extracted and marked {obj}${#execs}{rst} executable the appropriate files" \
                         "({obj}${(pj:$sep:)${execs[@]:t}}{rst}) contained" \
                         "in \`{file}$file{rst}'."
@@ -1859,7 +1859,7 @@ ziextract() {
             fi
         }
     } elif (( warning )) {
-        +zinit-message "{info}[{pre}ziextract{info}]{error} Error:{msg} didn't recognize archive type of {obj}${file}{msg} ${ext:+/ {obj2}${ext}{msg} } (no extraction has been done).{rst}"
+        +zi-log "{info}[{pre}ziextract{info}]{error} Error:{msg} didn't recognize archive type of {obj}${file}{msg} ${ext:+/ {obj2}${ext}{msg} } (no extraction has been done).{rst}"
     }
 
     if (( move | move2 )) {
@@ -1890,14 +1890,14 @@ ziextract() {
     local tpe=$1 extract=$2 local_dir=$3
     (
         builtin cd -q "$local_dir" || \
-            { +zinit-message "{error}ERROR:{msg2} The path of the $tpe" \
+            { +zi-log "{error}ERROR:{msg2} The path of the $tpe" \
                       "(\`{file}$local_dir{msg2}') isn't accessible.{rst}"
                 return 1
             }
         local -a files
         files=( ${(@)${(@s: :)${extract##(\!-|-\!|\!|-)}}//(#b)(((#s)|([^\\])[\\]([\\][\\])#)|((#s)|([^\\])([\\][\\])#)) /${match[2]:+$match[3]$match[4] }${match[5]:+$match[6]${(l:${#match[7]}/2::\\:):-} }} )
         if [[ ${#files} -eq 0 && -n ${extract##(\!-|-\!|\!|-)} ]] {
-                +zinit-message "{error}ERROR:{msg2} The files" \
+                +zi-log "{error}ERROR:{msg2} The files" \
                         "(\`{file}${extract##(\!-|-\!|\!|-)}{msg2}')" \
                         "not found, cannot extract.{rst}"
                 return 1
@@ -1946,7 +1946,7 @@ zpextract() {
     # Download mirrors.lst
     #
 
-    +zinit-message "{info}Downloading{ehi}: {obj}mirrors.lst{info}{…}{rst}"
+    +zi-log "{info}Downloading{ehi}: {obj}mirrors.lst{info}{…}{rst}"
     local mlst="$(mktemp)"
     while (( retry -- )) {
         if ! .zinit-download-file-stdout https://cygwin.com/mirrors.lst 0 > $mlst; then
@@ -1961,7 +1961,7 @@ zpextract() {
     }
 
     if [[ -z $mirror ]] {
-        +zinit-message "{error}Couldn't download{error}: {obj}mirrors.lst {error}."
+        +zi-log "{error}Couldn't download{error}: {obj}mirrors.lst {error}."
         return 1
     }
 
@@ -1971,8 +1971,8 @@ zpextract() {
     # Download setup.ini.bz2
     #
 
-    +zinit-message "{info2}Selected mirror is{error}: {url}${mirror}{rst}"
-    +zinit-message "{info}Downloading{ehi}: {file}setup.ini.bz2{info}{…}{rst}"
+    +zi-log "{info2}Selected mirror is{error}: {url}${mirror}{rst}"
+    +zi-log "{info}Downloading{ehi}: {file}setup.ini.bz2{info}{…}{rst}"
     local setup="$(mktemp -u)"
     retry=3
     while (( retry -- )) {
@@ -1983,12 +1983,12 @@ zpextract() {
         command bunzip2 "$setup.bz2" 2>/dev/null
         [[ -s $setup ]] && break
         mirror=${${mlist[ RANDOM % (${#mlist} + 1) ]}%%;*}
-        +zinit-message "{pre}Retrying{error}: {meta}#{obj}$(( 3 - $retry ))/3, {pre}with mirror{error}: {url}${mirror}{rst}"
+        +zi-log "{pre}Retrying{error}: {meta}#{obj}$(( 3 - $retry ))/3, {pre}with mirror{error}: {url}${mirror}{rst}"
     }
     local setup_contents="$(command grep -A 26 "@ $pkg\$" "$setup")"
     local urlpart=${${(S)setup_contents/(#b)*@ $pkg${nl}*install: (*)$nl*/$match[1]}%% *}
     if [[ -z $urlpart ]] {
-        +zinit-message "{error}Couldn't find package{error}: {data2}\`{data}${pkg}{data2}'{error}.{rst}"
+        +zi-log "{error}Couldn't find package{error}: {data2}\`{data}${pkg}{data2}'{error}.{rst}"
         return 2
     }
     local url=$mirror/$urlpart outfile=${TMPDIR:-${TMPDIR:-/tmp}}/${urlpart:t}
@@ -1997,18 +1997,18 @@ zpextract() {
     # Download the package
     #
 
-    +zinit-message "{info}Downloading{ehi}: {file}${url:t}{info}{…}{rst}"
+    +zi-log "{info}Downloading{ehi}: {file}${url:t}{info}{…}{rst}"
     retry=2
     while (( retry -- )) {
         integer retval=0
         if ! .zinit-download-file-stdout $url 0 1 > $outfile; then
             if ! .zinit-download-file-stdout $url 1 1 > $outfile; then
-                +zinit-message "{error}Couldn't download{error}: {url}${url}{error}."
+                +zi-log "{error}Couldn't download{error}: {url}${url}{error}."
                 retval=1
                 mirror=${${mlist[ RANDOM % (${#mlist} + 1) ]}%%;*}
                 url=$mirror/$urlpart outfile=${TMPDIR:-${TMPDIR:-/tmp}}/${urlpart:t}
                 if (( retry )) {
-                    +zinit-message "{info2}Retrying, with mirror{error}: {url}${mirror}{info2}{…}{rst}"
+                    +zi-log "{info2}Retrying, with mirror{error}: {url}${mirror}{info2}{…}{rst}"
                     continue
                 }
             fi
@@ -2150,7 +2150,7 @@ ${${${(M)flags:#*\#*}:+$msg}:-$msg_}
         if [[ $type == snippet ]] {
             if (( $+ICE[svn] )) {
                 if [[ $skip_pull -eq 0 && -d $filename/.svn ]] {
-                    (( !OPTS[opt_-q,--quiet] )) && +zinit-message "{pre}reset ($msg_bit): {msg2}Resetting the repository ($msg_bit) with command: {rst}svn revert --recursive {…}/{file}$filename/.{rst} {…}"
+                    (( !OPTS[opt_-q,--quiet] )) && +zi-log "{pre}reset ($msg_bit): {msg2}Resetting the repository ($msg_bit) with command: {rst}svn revert --recursive {…}/{file}$filename/.{rst} {…}"
                     command svn revert --recursive $filename/.
                 }
             } else {
@@ -2158,9 +2158,9 @@ ${${${(M)flags:#*\#*}:+$msg}:-$msg_}
                     if (( !OPTS[opt_-q,--quiet] )) {
                         if [[ -f $local_dir/$dirname/$filename ]] {
                             if [[ -n $option || -z $ICE[reset] ]] {
-                                +zinit-message "{pre}reset ($msg_bit):{msg2} Removing the snippet-file: {file}$filename{msg2} {…}{rst}"
+                                +zi-log "{pre}reset ($msg_bit):{msg2} Removing the snippet-file: {file}$filename{msg2} {…}{rst}"
                             } else {
-                                +zinit-message "{pre}reset ($msg_bit):{msg2} Removing the snippet-file: {file}$filename{msg2}," \
+                                +zi-log "{pre}reset ($msg_bit):{msg2} Removing the snippet-file: {file}$filename{msg2}," \
                                     "with the supplied code: {data2}$ICE[reset]{msg2} {…}{rst}"
                             }
                             if (( option )) {
@@ -2169,36 +2169,36 @@ ${${${(M)flags:#*\#*}:+$msg}:-$msg_}
                                 eval "${ICE[reset]:-rm -f \"$local_dir/$dirname/$filename\"}"
                             }
                         } else {
-                            +zinit-message "{pre}reset ($msg_bit):{msg2} The file {file}$filename{msg2} is already deleted {…}{rst}"
+                            +zi-log "{pre}reset ($msg_bit):{msg2} The file {file}$filename{msg2} is already deleted {…}{rst}"
                             if [[ -n $ICE[reset] && ! -n $option ]] {
-                                +zinit-message "{pre}reset ($msg_bit):{msg2} (skipped running the provided reset-code:" \
+                                +zi-log "{pre}reset ($msg_bit):{msg2} (skipped running the provided reset-code:" \
                                     "{data2}$ICE[reset]{msg2}){rst}"
                             }
                         }
                     }
                 } else {
                         [[ -f $local_dir/$dirname/$filename ]] && \
-                            +zinit-message "{pre}reset ($msg_bit): {msg2}Skipping the removal of {file}$filename{msg2}" \
+                            +zi-log "{pre}reset ($msg_bit): {msg2}Skipping the removal of {file}$filename{msg2}" \
                                  "as there is no new copy scheduled for download.{rst}" || \
-                            +zinit-message "{pre}reset ($msg_bit): {msg2}The file {file}$filename{msg2} is already deleted" \
+                            +zi-log "{pre}reset ($msg_bit): {msg2}The file {file}$filename{msg2} is already deleted" \
                                 "and {ehi}no new download is being scheduled.{rst}"
                 }
             }
         } elif [[ $type == plugin ]] {
             if (( is_release && !skip_pull )) {
                 if (( option )) {
-                    (( !OPTS[opt_-q,--quiet] )) && +zinit-message "{pre}reset ($msg_bit): {msg2}running: {rst}rm -rf ${${ZINIT[PLUGINS_DIR]:#[/[:space:]]##}:-${TMPDIR:-/tmp}/xyzabc312}/${${(M)${local_dir##${ZINIT[PLUGINS_DIR]}[/[:space:]]#}:#[^/]*}:-${TMPDIR:-/tmp}/xyzabc312-zinit-protection-triggered}/*"
+                    (( !OPTS[opt_-q,--quiet] )) && +zi-log "{pre}reset ($msg_bit): {msg2}running: {rst}rm -rf ${${ZINIT[PLUGINS_DIR]:#[/[:space:]]##}:-${TMPDIR:-/tmp}/xyzabc312}/${${(M)${local_dir##${ZINIT[PLUGINS_DIR]}[/[:space:]]#}:#[^/]*}:-${TMPDIR:-/tmp}/xyzabc312-zinit-protection-triggered}/*"
                     builtin eval command rm -rf ${${ZINIT[PLUGINS_DIR]:#[/[:space:]]##}:-${TMPDIR:-/tmp}/xyzabc312}/"${${(M)${local_dir##${ZINIT[PLUGINS_DIR]}[/[:space:]]#}:#[^/]*}:-${TMPDIR:-/tmp}/xyzabc312-zinit-protection-triggered}"/*(ND)
                 } else {
-                    (( !OPTS[opt_-q,--quiet] )) && +zinit-message "{pre}reset ($msg_bit): {msg2}running: {rst}${ICE[reset]:-rm -rf ${${ZINIT[PLUGINS_DIR]:#[/[:space:]]##}:-${TMPDIR:-/tmp}/xyzabc312}/${${(M)${local_dir##${ZINIT[PLUGINS_DIR]}[/[:space:]]#}:#[^/]*}:-${TMPDIR:-/tmp}/xyzabc312-zinit-protection-triggered}/*}"
+                    (( !OPTS[opt_-q,--quiet] )) && +zi-log "{pre}reset ($msg_bit): {msg2}running: {rst}${ICE[reset]:-rm -rf ${${ZINIT[PLUGINS_DIR]:#[/[:space:]]##}:-${TMPDIR:-/tmp}/xyzabc312}/${${(M)${local_dir##${ZINIT[PLUGINS_DIR]}[/[:space:]]#}:#[^/]*}:-${TMPDIR:-/tmp}/xyzabc312-zinit-protection-triggered}/*}"
                     builtin eval ${ICE[reset]:-command rm -rf ${${ZINIT[PLUGINS_DIR]:#[/[:space:]]##}:-${TMPDIR:-/tmp}/xyzabc312}/"${${(M)${local_dir##${ZINIT[PLUGINS_DIR]}[/[:space:]]#}:#[^/]*}:-${TMPDIR:-/tmp}/xyzabc312-zinit-protection-triggered}"/*(ND)}
                 }
             } elif (( !skip_pull )) {
                 if (( option )) {
-                    +zinit-message "{pre}reset ($msg_bit): {msg2}Resetting the repository with command:{rst} git reset --hard HEAD {…}"
+                    +zi-log "{pre}reset ($msg_bit): {msg2}Resetting the repository with command:{rst} git reset --hard HEAD {…}"
                     command git reset --hard HEAD
                 } else {
-                    +zinit-message "{pre}reset ($msg_bit): {msg2}Resetting the repository with command:{rst} ${ICE[reset]:-git reset --hard HEAD} {…}"
+                    +zi-log "{pre}reset ($msg_bit): {msg2}Resetting the repository with command:{rst} ${ICE[reset]:-git reset --hard HEAD} {…}"
                     builtin eval "${ICE[reset]:-git reset --hard HEAD}"
                 }
             }
@@ -2436,7 +2436,7 @@ for its found {file}meson.build{pre} input file}:-because {flag}m{pre} \
         afr=( ${~from}(DN) )
 
         if (( ! ${#afr} )) {
-            +zinit-message "{warn}Warning: mv ice didn't match any file. [{error}$ICE[mv]{warn}]" \
+            +zi-log "{warn}Warning: mv ice didn't match any file. [{error}$ICE[mv]{warn}]" \
                            "{nl}{warn}Available files:{nl}{obj}$(ls -1)"
             return 1
         }
@@ -2570,7 +2570,7 @@ for its found {file}meson.build{pre} input file}:-because {flag}m{pre} \
         local tpe="$1" dir="${4#%}" hook="$5" subtype="$6"
 
     if (( !OPTS[opt_-q,--quiet] )) {
-        +zinit-message "Running $tpe's provided update code: {info}${ICE[ps-on-update][1,50]}${ICE[ps-on-update][51]:+…}{rst}"
+        +zi-log "Running $tpe's provided update code: {info}${ICE[ps-on-update][1,50]}${ICE[ps-on-update][51]:+…}{rst}"
         (
             builtin cd -q "$dir" || return 1
             eval "$ICE[ps-on-update]"

--- a/zinit-side.zsh
+++ b/zinit-side.zsh
@@ -199,7 +199,7 @@
   (( !${+ICE[countdown]} )) && return 0
 
   builtin emulate -L zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
-  trap "+zinit-message \"{ehi}ABORTING, the ice {ice}$ice{ehi} not ran{rst}\"; return 1" INT
+  trap "+zi-log \"{ehi}ABORTING, the ice {ice}$ice{ehi} not ran{rst}\"; return 1" INT
 
   local count=5 ice tpe="$1"
 
@@ -207,14 +207,14 @@
   [[ $tpe = "atpull" && $ice = "%atclone" ]] && ice="${ICE[atclone]}"
   ice="{b}{ice}$tpe{ehi}:{rst}${ice//(#b)(\{[a-z0-9…–_-]##\})/\\$match[1]}"
 
-  +zinit-message -n "{hi}Running $ice{rst}{hi} ice in...{rst} "
+  +zi-log -n "{hi}Running $ice{rst}{hi} ice in...{rst} "
 
   while (( -- count + 1 )) {
-    +zinit-message -n -- "{b}{error}"$(( count + 1 ))"{rst}{…}"
+    +zi-log -n -- "{b}{error}"$(( count + 1 ))"{rst}{…}"
     sleep 1
   }
 
-  +zinit-message -r -- "{b}{error}0 <running now>{rst}{…}"
+  +zi-log -r -- "{b}{error}0 <running now>{rst}{…}"
   return 0
 } # ]]]
 # FUNCTION: .zinit-exists-physically [[[
@@ -256,10 +256,10 @@
     fi
     .zinit-any-colorify-as-uspl2 "$1" "$2"
 
-    +zinit-message "{error}No such (plugin or snippet){rst}: $REPLY."
+    +zi-log "{error}No such (plugin or snippet){rst}: $REPLY."
 
     [[ $nospec -eq 0 && $spec1 != $spec2 ]] \
-      && +zinit-message "(expands to: {file}${spec2#%}{rst})."
+      && +zi-log "(expands to: {file}${spec2#%}{rst})."
 
     return 1
   fi

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -317,7 +317,7 @@ builtin setopt noaliases
 
     if (( ${+opts[(r)-X]} )); then
         .zinit-add-report "${ZINIT[CUR_USPL2]}" "Warning: Failed autoload ${(j: :)opts[@]} $*"
-        +zinit-message -u2 "{error}builtin autoload required for {obj}${(j: :)opts[@]}{error} option(s)"
+        +zi-log -u2 "{error}builtin autoload required for {obj}${(j: :)opts[@]}{error} option(s)"
         return 1
     fi
     if (( ${+opts[(r)-w]} )); then
@@ -351,7 +351,7 @@ builtin setopt noaliases
             elif [[ $func == /* ]]; then
                 if [[ $ZINIT[MUTE_WARNINGS] != (1|true|on|yes) && \
                         -z $ZINIT[WARN_SHOWN_FOR_$ZINIT[CUR_USPL2]] ]]; then
-                    +zinit-message "{u-warn}Warning{b-warn}: {rst}the plugin {pid}$ZINIT[CUR_USPL2]" \
+                    +zi-log "{u-warn}Warning{b-warn}: {rst}the plugin {pid}$ZINIT[CUR_USPL2]" \
                         "{rst}is using autoload functions specified by their absolute path," \
                         "which is not supported by this Zsh version ({↔} {version}$ZSH_VERSION{rst}," \
                         "required is Zsh >= {version}5.4{rst})." \
@@ -375,7 +375,7 @@ builtin setopt noaliases
                         [[ -f $pth/$func ]] && { sel=$pth; break; }
                     }
                     if [[ -z $sel ]] {
-                        +zinit-message '{u-warn}zinit{b-warn}:{error} Couldn''t find autoload function{ehi}:' \
+                        +zi-log '{u-warn}zinit{b-warn}:{error} Couldn''t find autoload function{ehi}:' \
                             "{apo}\`{file}${func}{apo}\`{error} anywhere in {var}\$fpath{error}."
                             retval=1
                     } else {
@@ -1101,7 +1101,7 @@ builtin setopt noaliases
         ZINIT_REGISTERED_PLUGINS+=( "$uspl2" )
     else
         # Allow overwrite-load, however warn about it.
-        [[ -z ${ZINIT[TEST]}${${+ICE[wait]}:#0}${ICE[load]}${ICE[subscribe]} && ${ZINIT[MUTE_WARNINGS]} != (1|true|on|yes) ]] && +zinit-message "{u-warn}Warning{b-warn}:{rst} plugin {apo}\`{pid}${uspl2}{apo}\`{rst} already registered, will overwrite-load."
+        [[ -z ${ZINIT[TEST]}${${+ICE[wait]}:#0}${ICE[load]}${ICE[subscribe]} && ${ZINIT[MUTE_WARNINGS]} != (1|true|on|yes) ]] && +zi-log "{u-warn}Warning{b-warn}:{rst} plugin {apo}\`{pid}${uspl2}{apo}\`{rst} already registered, will overwrite-load."
         ret=1
     fi
 
@@ -1339,7 +1339,7 @@ builtin setopt noaliases
     if [[ $1 == set ]]; then
         ZINIT[___m_bkp]="${functions[m]}"
         setopt noaliases
-        functions[m]="${functions[+zinit-message]}"
+        functions[m]="${functions[+zi-log]}"
         setopt aliases
     elif [[ $1 == unset ]]; then
         if [[ -n ${ZINIT[___m_bkp]} ]]; then
@@ -1350,7 +1350,7 @@ builtin setopt noaliases
             noglob unset functions[m]
         fi
     else
-        +zinit-message "{error}ERROR #1"
+        +zi-log "{error}ERROR #1"
         return 1
     fi
 } # ]]]
@@ -1362,7 +1362,7 @@ builtin setopt noaliases
 .zinit-load-snippet() {
     typeset -F 3 SECONDS=0
     local -a opts
-    zparseopts -E -D -a opts f -command || { +zinit-message "{u-warn}Error{b-warn}:{rst} Incorrect options (accepted ones: {opt}-f{rst}, {opt}--command{rst})."; return 1; }
+    zparseopts -E -D -a opts f -command || { +zi-log "{u-warn}Error{b-warn}:{rst} Incorrect options (accepted ones: {opt}-f{rst}, {opt}--command{rst})."; return 1; }
     local url="$1" limit="$3"
     [[ -n ${ICE[teleid]} ]] && url="${ICE[teleid]}"
     # Hide arguments from sourced scripts. Without this calls our "$@" are visible as "$@"
@@ -1495,7 +1495,7 @@ builtin setopt noaliases
             ZERO="${list[1-correct]}"
             (( ${+ICE[silent]} )) && { { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( retval += $? )); ((1)); } || { ((1)); { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; }; (( retval += $? )); }
             (( 0 == retval )) && [[ $url = PZT::* || $url = https://github.com/sorin-ionescu/prezto/* ]] && zstyle ":prezto:module:${${id_as%/init.zsh}:t}" loaded 'yes'
-        } else { [[ ${+ICE[silent]} -eq 1 || ${+ICE[pick]} -eq 1 && -z ${ICE[pick]} || ${ICE[pick]} = /dev/null ]] || { +zinit-message "Snippet not loaded ({url}${id_as}{rst})"; retval=1; } }
+        } else { [[ ${+ICE[silent]} -eq 1 || ${+ICE[pick]} -eq 1 && -z ${ICE[pick]} || ${ICE[pick]} = /dev/null ]] || { +zi-log "Snippet not loaded ({url}${id_as}{rst})"; retval=1; } }
 
         [[ -n ${ICE[src]} ]] && { ZERO="${${(M)ICE[src]##/*}:-$local_dir/$dirname/${ICE[src]}}"; (( ${+ICE[silent]} )) && { { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( retval += $? )); ((1)); } || { ((1)); { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; }; (( retval += $? )); }; }
         [[ -n ${ICE[multisrc]} ]] && { local ___oldcd="$PWD"; () { setopt localoptions noautopushd; builtin cd -q "$local_dir/$dirname"; }; eval "reply=(${ICE[multisrc]})"; () { setopt localoptions noautopushd; builtin cd -q "$___oldcd"; }; local fname; for fname in "${reply[@]}"; do ZERO="${${(M)fname:#/*}:-$local_dir/$dirname/$fname}"; (( ${+ICE[silent]} )) && { { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; } 2>/dev/null 1>&2; (( retval += $? )); ((1)); } || { ((1)); { [[ -n $precm ]] && { builtin ${precm[@]} 'source "$ZERO"'; ((1)); } || { ((1)); builtin source "$ZERO"; }; }; (( retval += $? )); }; done; }
@@ -1868,7 +1868,7 @@ builtin setopt noaliases
 
     # Check if compinit was loaded.
     if [[ ${+functions[compdef]} = 0 ]]; then
-        +zinit-message "{u-warn}Error{b-warn}:{rst} The {func}compinit{rst}" \
+        +zi-log "{u-warn}Error{b-warn}:{rst} The {func}compinit{rst}" \
             "function hasn't been loaded, cannot do {it}{cmd}compdef replay{rst}."
         return 1
     fi
@@ -1880,7 +1880,7 @@ builtin setopt noaliases
         # When ZINIT_COMPDEF_REPLAY empty (also when only white spaces).
         [[ ${#pos[@]} = 1 && -z ${pos[-1]} ]] && continue
         pos=( "${(Q)pos[@]}" )
-        [[ $quiet = -q ]] || +zinit-message "Running compdef: {cmd}${pos[*]}{rst}"
+        [[ $quiet = -q ]] || +zi-log "Running compdef: {cmd}${pos[*]}{rst}"
         compdef "${pos[@]}"
     done
 
@@ -1892,7 +1892,7 @@ builtin setopt noaliases
 .zinit-compdef-clear() {
     local quiet="$1" count="${#ZINIT_COMPDEF_REPLAY}"
     ZINIT_COMPDEF_REPLAY=( )
-    [[ $quiet = -q ]] || +zinit-message "Compdef-replay cleared (it had {num}${count}{rst} entries)."
+    [[ $quiet = -q ]] || +zi-log "Compdef-replay cleared (it had {num}${count}{rst} entries)."
 } # ]]]
 
 # FUNCTION: .zinit-add-report [[[
@@ -1927,7 +1927,7 @@ builtin setopt noaliases
 .zinit-run() {
     if [[ $1 = (-l|--last) ]]; then
         { set -- "${ZINIT[last-run-plugin]:-$(<${ZINIT[BIN_DIR]}/last-run-object.txt)}" "${@[2-correct,-1]}"; } &>/dev/null
-        [[ -z $1 ]] && { +zinit-message "{u-warn}Error{b-warn}:{rst} No recent plugin-ID saved on the disk yet, please specify" \
+        [[ -z $1 ]] && { +zi-log "{u-warn}Error{b-warn}:{rst} No recent plugin-ID saved on the disk yet, please specify" \
                             "it as the first argument, i.e.{ehi}: {cmd}zi run {pid}usr/plg{slight} {…}the code to run{…} "; return 1; }
     else
         integer ___nolast=1
@@ -1947,7 +1947,7 @@ builtin setopt noaliases
         eval "${@[2-correct,-1]}"
         () { setopt localoptions noautopushd; builtin cd -q "$___oldpwd"; }
     else
-        +zinit-message "{u-warn}Error{b-warn}:{rst} no such plugin or snippet."
+        +zi-log "{u-warn}Error{b-warn}:{rst} no such plugin or snippet."
     fi
 } # ]]]
 
@@ -2156,9 +2156,9 @@ builtin setopt noaliases
 #    REPLY+="x(${3}…)"
 } # ]]]
 
-# FUNCTION: +zinit-message [[[
+# FUNCTION: +zi-log [[[
 # Logging function
-+zinit-message() {
++zi-log() {
     builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
     local opt msg
     [[ $1 = -* ]] && { local opt=$1; shift; }
@@ -2189,10 +2189,10 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
         print -n $'\015'
     fi
 } # ]]]
-# FUNCTION: +zi-log [[[
-# Wrapper function for +zinit-message until migrated to +zi-log
-+zi-log(){
-    +zinit-message $@
+# FUNCTION: +zinit-message [[[
+# Wrapper function to maintain backward compatibility
++zinit-message(){
+    +zi-log $@
 } # ]]]
 
 # FUNCTION: +zinit-prehelp-usage-message [[[
@@ -2204,7 +2204,7 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
     # -h/--help given?
     if (( OPTS[opt_-h,--help] )) {
         # Yes – a help message:
-        +zinit-message "{lhi}HELP FOR {apo}\`{cmd}$cmd{apo}\`{lhi} subcommand {mdsh}" \
+        +zi-log "{lhi}HELP FOR {apo}\`{cmd}$cmd{apo}\`{lhi} subcommand {mdsh}" \
                 "the available {b-lhi}options{ehi}:{rst}"
         local opt
         for opt ( ${(kos:|:)allowed} ) {
@@ -2214,13 +2214,13 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
                 msg=${${(MS)msg##$cmd:\[[^]]##}:-${(MS)msg##\*:\[[^]]##}}
                 msg=${msg#($cmd|\*):\[}
             }
-            local pre_msg=`+zinit-message -n {opt}${(r:14:)${txt#opt_}}`
-            +zinit-message ${(r:35:: :)pre_msg}{rst}{ehi}→{rst}"  $msg"
+            local pre_msg=`+zi-log -n {opt}${(r:14:)${txt#opt_}}`
+            +zi-log ${(r:35:: :)pre_msg}{rst}{ehi}→{rst}"  $msg"
         }
     } elif [[ -n $allowed ]] {
         shift 2
         # No – an error message:
-        +zinit-message "{b}{u-warn}ERROR{b-warn}:{rst}{msg2} Incorrect options given{ehi}:" \
+        +zi-log "{b}{u-warn}ERROR{b-warn}:{rst}{msg2} Incorrect options given{ehi}:" \
                 "${(Mpj:$sep:)@:#-*}{rst}{msg2}. Allowed for the subcommand{ehi}:{rst}" \
                 "{apo}\`{cmd}$cmd{apo}\`{msg2} are{ehi}:{rst}" \
                 "{nl}{mmdsh} {opt}${allowed//\|/$sep2}{msg2}." \
@@ -2229,7 +2229,7 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
         local -a cmds
         cmds=( load snippet update delete )
         local bcol="{$cmd}" sep="${ZINIT[col-rst]}${ZINIT[col-$cmd]}\`, \`${ZINIT[col-cmd]}"
-        +zinit-message "$bcol(it should be one of, e.g.{ehi}:" \
+        +zi-log "$bcol(it should be one of, e.g.{ehi}:" \
                 "{nb}$bcol\`{cmd}${(pj:$sep:)cmds}$bcol\`," \
                 "{cmd}{…}$bcol, e.g.{ehi}: {nb}$bcol\`{lhi}zinit {b}{cmd}load" \
                 "{pid}username/reponame$bcol\`) or a {b}{hi}for{nb}$bcol-based" \
@@ -2634,7 +2634,7 @@ cdclear) ]]; then
             1="${1:+@}${1#@}${2:+/$2}"
             (( $# > 1 )) && { shift -p $(( $# - 1 )); }
             [[ -z $1 ]] && {
-               +zinit-message "Argument needed, try: {cmd}help."
+               +zi-log "Argument needed, try: {cmd}help."
                return 1
             }
         } else {
@@ -2643,7 +2643,7 @@ cdclear) ]]; then
             local ___last_ice=${@[___retval2]}
             shift ___retval2
             if [[ $# -gt 0 && $1 != for ]] {
-                +zinit-message -n "{b}{u-warn}ERROR{b-warn}:{rst} Unknown subcommand{ehi}:" \
+                +zi-log -n "{b}{u-warn}ERROR{b-warn}:{rst} Unknown subcommand{ehi}:" \
                         "{apo}\`{cmd}$1{apo}\`{rst} "
                 +zinit-prehelp-usage-message rst
                 return 1
@@ -2670,7 +2670,7 @@ cdclear) ]]; then
                     ICE=( "${___ices[@]}" "${(kv)ZINIT_ICES[@]}" )
                     ZINIT_ICE=( "${(kv)ICE[@]}" ) ZINIT_ICES=()
                     integer ___msgs=${+ICE[debug]}
-                    (( ___msgs )) && +zinit-message "{pre}zinit-main:{faint} Processing {pname}$1{faint}{…}{rst}"
+                    (( ___msgs )) && +zi-log "{pre}zinit-main:{faint} Processing {pname}$1{faint}{…}{rst}"
 
                     # Delete up to the final space to get the previously-processed ID.
                     ZINIT[annex-exposed-processed-IDs]+="${___id:+ $___id}"
@@ -2738,7 +2738,7 @@ cdclear) ]]; then
                                 (( 0 == ${#___new_ices} % 2 )) && \
                                     ___ices=( "${___new_ices[@]}" ) || \
                                         { [[ ${ZINIT[MUTE_WARNINGS]} != (1|true|on|yes) ]] && \
-                                            +zinit-message "{u-warn}Warning{b-warn}:{msg} Bad new-ices returned" \
+                                            +zi-log "{u-warn}Warning{b-warn}:{msg} Bad new-ices returned" \
                                                 "from the annex{ehi}:{rst} {annex}${___arr[3]}{msg}," \
                                                 "please file an issue report at:{url}" \
                                     "https://github.com/zdharma-continuum/${___arr[3]}/issues/new{msg}.{rst}"
@@ -2852,14 +2852,14 @@ cdclear) ]]; then
         if (( ___error )) {
             () {
                 builtin emulate -LR zsh -o extendedglob ${=${options[xtrace]:#off}:+-o xtrace}
-                +zinit-message -n "{u-warn}Error{b-warn}:{rst} No plugin or snippet ID given"
+                +zi-log -n "{u-warn}Error{b-warn}:{rst} No plugin or snippet ID given"
                 if [[ -n $___last_ice ]] {
-                    +zinit-message -n " (the last recognized ice was: {ice}"\
+                    +zi-log -n " (the last recognized ice was: {ice}"\
 "${___last_ice/(#m)(${~ZINIT[ice-list]})/"{data}$MATCH"}{apo}''{rst}).{error}
 You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice is in fact a plugin.{rst}
 {note}Note:{rst} The {apo}\`{ice}ice{apo}\`{rst} subcommand is now again required if not using the for-syntax"
                 }
-                +zinit-message "."
+                +zi-log "."
             }
             return 2
        } elif (( ! $# )) {
@@ -2895,11 +2895,11 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
 
             if (( $# == 0 )) {
                 ZINIT[ENV-WHITELIST]=
-                (( OPTS[opt_-v,--verbose] )) && +zinit-message "{msg2}Cleared the parameter whitelist.{rst}"
+                (( OPTS[opt_-v,--verbose] )) && +zi-log "{msg2}Cleared the parameter whitelist.{rst}"
             } else {
                 ZINIT[ENV-WHITELIST]+="${(j: :)${(q-kv)@}} "
                 local ___sep="$ZINIT[col-msg2], $ZINIT[col-data2]"
-                (( OPTS[opt_-v,--verbose] )) && +zinit-message "{msg2}Extended the parameter whitelist with: {data2}${(pj:$___sep:)@}{msg2}.{rst}"
+                (( OPTS[opt_-v,--verbose] )) && +zi-log "{msg2}Extended the parameter whitelist with: {data2}${(pj:$___sep:)@}{msg2}.{rst}"
             }
             ;;
        (*)
@@ -2909,7 +2909,7 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                reply=( "${(Q)${(z@)reply[1]}[@]}" )
                (( ${+functions[${reply[5]}]} )) && \
                    { "${reply[5]}" "$@"; return $?; } || \
-                   { +zinit-message "({error}Couldn't find the subcommand-handler \`{obj}${reply[5]}{error}' of the z-annex \`{file}${reply[3]}{error}')"; return 1; }
+                   { +zi-log "({error}Couldn't find the subcommand-handler \`{obj}${reply[5]}{error}' of the z-annex \`{file}${reply[3]}{error}')"; return 1; }
            }
            (( ${+functions[.zinit-confirm]} )) || builtin source "${ZINIT[BIN_DIR]}/zinit-autoload.zsh" || return 1
            case "$1" in
@@ -2998,7 +2998,7 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                         if .zinit-cdisable "$___f"; then
                             (( ${+functions[.zinit-forget-completion]} )) || builtin source "${ZINIT[BIN_DIR]}/zinit-install.zsh" || return 1
                             .zinit-forget-completion "$___f"
-                            +zinit-message "Initializing completion system ({func}compinit{rst}){…}"
+                            +zi-log "Initializing completion system ({func}compinit{rst}){…}"
                             builtin autoload -Uz compinit
                             compinit -d ${ZINIT[ZCOMPDUMP_PATH]:-${ZDOTDIR:-$HOME}/.zcompdump} "${(Q@)${(z@)ZINIT[COMPINIT_OPTS]}}"
                         else
@@ -3016,7 +3016,7 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                         if .zinit-cenable "$___f"; then
                             (( ${+functions[.zinit-forget-completion]} )) || builtin source "${ZINIT[BIN_DIR]}/zinit-install.zsh" || return 1
                             .zinit-forget-completion "$___f"
-                            +zinit-message "Initializing completion system ({func}compinit{rst}){…}"
+                            +zi-log "Initializing completion system ({func}compinit{rst}){…}"
                             builtin autoload -Uz compinit
                             compinit -d ${ZINIT[ZCOMPDUMP_PATH]:-${ZDOTDIR:-$HOME}/.zcompdump} "${(Q@)${(z@)ZINIT[COMPINIT_OPTS]}}"
                         else
@@ -3029,7 +3029,7 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                     # Installs completions for plugin. Enables them all. It is a reinstallation, thus every obstacle gets overwritten or removed.
                     [[ $2 = -[qQ] ]] && { 5=$2; shift; }
                     .zinit-install-completions "${2%%(///|//|/)}" "${3%%(///|//|/)}" 1 "${(M)4:#-[qQ]}"; ___retval=$?
-                    [[ -z ${(M)4:#-[qQ]} ]] && +zinit-message "Initializing completion ({func}compinit{rst}){…}"
+                    [[ -z ${(M)4:#-[qQ]} ]] && +zi-log "Initializing completion ({func}compinit{rst}){…}"
                     builtin autoload -Uz compinit
                     compinit -d ${ZINIT[ZCOMPDUMP_PATH]:-${ZDOTDIR:-$HOME}/.zcompdump} "${(Q@)${(z@)ZINIT[COMPINIT_OPTS]}}"
                     ;;
@@ -3040,7 +3040,7 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                         (( ${+functions[.zinit-forget-completion]} )) || builtin source "${ZINIT[BIN_DIR]}/zinit-install.zsh" || return 1
                         # Uninstalls completions for plugin.
                         .zinit-uninstall-completions "${2%%(///|//|/)}" "${3%%(///|//|/)}"; ___retval=$?
-                        +zinit-message "Initializing completion ({func}compinit{rst}){…}"
+                        +zi-log "Initializing completion ({func}compinit{rst}){…}"
                         builtin autoload -Uz compinit
                         compinit -d ${ZINIT[ZCOMPDUMP_PATH]:-${ZDOTDIR:-$HOME}/.zcompdump} "${(Q@)${(z@)ZINIT[COMPINIT_OPTS]}}"
                     fi
@@ -3109,10 +3109,10 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                     ;;
                  (*)
                     if [[ -z $1 ]] {
-                       +zinit-message -n "{b}{u-warn}ERROR{b-warn}:{rst} Missing a {cmd}subcommand "
+                       +zi-log -n "{b}{u-warn}ERROR{b-warn}:{rst} Missing a {cmd}subcommand "
                        +zinit-prehelp-usage-message rst
                     } else {
-                       +zinit-message -n "{b}{u-warn}ERROR{b-warn}:{rst} Unknown subcommand{ehi}:{rst}" \
+                       +zi-log -n "{b}{u-warn}ERROR{b-warn}:{rst} Unknown subcommand{ehi}:{rst}" \
                                "{apo}\`{error}$1{apo}\`{rst} "
                        +zinit-prehelp-usage-message rst
                     }
@@ -3236,13 +3236,13 @@ if [[ -e ${${ZINIT[BIN_DIR]}}/zmodules/Src/zdharma/zplugin.so ]] {
         [[ -e ${${ZINIT[BIN_DIR]}}/module/RECOMPILE_REQUEST ]] && local recompile_request_ts="$(<${${ZINIT[BIN_DIR]}}/module/RECOMPILE_REQUEST)"
 
         if [[ ${recompile_request_ts:-1} -gt ${compiled_at_ts:-0} ]] {
-            +zinit-message "{u-warn}WARNING{b-warn}:{rst}{msg} A {lhi}recompilation{rst}" \
+            +zi-log "{u-warn}WARNING{b-warn}:{rst}{msg} A {lhi}recompilation{rst}" \
                 "of the Zinit module has been requested… {hi}Building{rst}…"
             (( ${+functions[.zinit-confirm]} )) || builtin source "${ZINIT[BIN_DIR]}/zinit-autoload.zsh" || return 1
             command make -C "${ZINIT[BIN_DIR]}/zmodules" distclean &>/dev/null
             .zinit-module build &>/dev/null
             if command make -C "${ZINIT[BIN_DIR]}/zmodules" &>/dev/null; then
-                +zinit-message "{ok}Build successful!{rst}"
+                +zi-log "{ok}Build successful!{rst}"
             else
                 builtin print -r -- "${ZINIT[col-error]}Compilation failed.${ZINIT[col-rst]}" \
                      "${ZINIT[col-pre]}You can enter the following command:${ZINIT[col-rst]}" \


### PR DESCRIPTION
## Description

- Rename all instances of `+zinit-message` to `+zi-log`
- Maintain compatibility with community plugins/annexes by forwarding `+zinit-message` calls to `+zi-log`

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [X] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [X] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
