### PR TITLE
fix: set home dir to test env in gh-r tests

### DIFF
--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -2,6 +2,7 @@
 
 
 @setup {
+  HOME="$ZPFX" # Stops programs creating directories in user home
   export ZBIN="${ZPFX}/bin"
   export os_type="${OSTYPE//[0-9\.]*/}"
   zinit default-ice --quiet from'gh-r' nocompile lbin''

--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -78,7 +78,7 @@
   [[ $OSTYPE =~ 'darwin*' ]] && skip "on $os_type"
   run zinit for @imsnif/bandwhich; assert $state equals 0
   local bandwhich="$ZBIN/bandwhich"; assert "$bandwhich" is_executable
-  run $bandwhich --version; assert $state equals 0
+  run $bandwhich --help; assert $state equals 0
 }
 @test 'bat' { # A cat(1) clone with wings
   run zinit for @sharkdp/bat; assert $state equals 0


### PR DESCRIPTION
## Description

Handles programs that create a config dir on first invocation and cluttered users $HOME dir.

<img width="746" alt="Screenshot 2023-09-23 at 12 24 47 AM" src="https://github.com/zdharma-continuum/zinit/assets/10052309/94e92920-8836-497e-a679-3ff4e7b124b4">

## Motivation and Context <!--- What problem does it solve? -->

Annoyed

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [X] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.