### PR TITLE
refactor: `clist` subcommand renamed to `completions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,7 +641,7 @@ zi light vim/vim
 zi ice as"program" pick"$ZPFX/bin/git-*" make"PREFIX=$ZPFX"
 zi light tj/git-extras
 
-# Handle completions without loading any plugin; see "clist" command.
+# Handle completions without loading any plugin; see "completions" command.
 # This one is to be ran just once, in interactive session.
 zi creinstall %HOME/my_completions
 ```
@@ -814,19 +814,19 @@ Following commands are passed to `zinit ...` to obtain described effects.
 
 ### Completions<a name="completions-1"></a>
 
-| Command                                            | Description                                                                                                                                         |
-| -------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `cclear`                                           | Clear stray and improper completions.                                                                                                               |
-| `cdclear [-q]`                                     | Clear compdef replay list. `-q` – quiet.                                                                                                            |
-| `cdisable {cname}`                                 | Disable completion `cname`.                                                                                                                         |
-| `cdlist`                                           | Show compdef replay list.                                                                                                                           |
-| `cdreplay [-q]`                                    | Replay compdefs (to be done after compinit). `-q` – quiet.                                                                                          |
-| `cenable {cname}`                                  | Enable completion `cname`.                                                                                                                          |
-| `clist \[*columns*\]`, `completions \[*columns*\]` | List completions in use, with <code>columns</code> completions per line. `zpl clist 5` will for example print 5 completions per line. Default is 3. |
-| `compinit`                                         | Refresh installed completions.                                                                                                                      |
-| `creinstall [-q] [-Q] {plg-spec}`                  | Install completions for plugin, can also receive absolute local path. `-q` – quiet. `-Q` - quiet all.                                               |
-| `csearch`                                          | Search for available completions from any plugin.                                                                                                   |
-| `cuninstall {plg-spec}`                            | Uninstall completions for plugin.                                                                                                                   |
+| Command                           | Description                                                                                                                                         |
+| --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cclear`                          | Clear stray and improper completions.                                                                                                               |
+| `cdclear [-q]`                    | Clear compdef replay list. `-q` – quiet.                                                                                                            |
+| `cdisable {cname}`                | Disable completion `cname`.                                                                                                                         |
+| `cdlist`                          | Show compdef replay list.                                                                                                                           |
+| `cdreplay [-q]`                   | Replay compdefs (to be done after compinit). `-q` – quiet.                                                                                          |
+| `cenable {cname}`                 | Enable completion `cname`.                                                                                                                          |
+| `completions \[*columns*\]`       | List completions in use, with <code>columns</code> completions per line. `zpl clist 5` will for example print 5 completions per line. Default is 3. |
+| `compinit`                        | Refresh installed completions.                                                                                                                      |
+| `creinstall [-q] [-Q] {plg-spec}` | Install completions for plugin, can also receive absolute local path. `-q` – quiet. `-Q` - quiet all.                                               |
+| `csearch`                         | Search for available completions from any plugin.                                                                                                   |
+| `cuninstall {plg-spec}`           | Uninstall completions for plugin.                                                                                                                   |
 
 ### Tracking of the Active Session<a name="tracking-of-the-active-session"></a>
 

--- a/_zinit
+++ b/_zinit
@@ -21,7 +21,6 @@ __zinit_commands(){
     'cdreplay:Replay compdef list'
     'cenable:Enable completions'
     'changes:View plugins git log'
-    'clist:List status of all installed completions'
     'compile:Compile plugin (or all plugins if --all passed)'
     'compiled:List of compiled plugins'
     'compinit:Refresh installed completions'
@@ -163,10 +162,6 @@ _zinit_cenable(){
 # FUNCTION: _zinit_changes [[[
 _zinit_changes(){
   _message 'View git log of a plugin' && ret=0
-} # ]]]
-# FUNCTION: _zinit_clist [[[
-_zinit_clist(){
-  _message 'Hit enter to get list of completions' && ret=0
 } # ]]]
 # FUNCTION: _zinit_compiled [[[
 _zinit_compiled(){

--- a/doc/CHANGELOG.md
+++ b/doc/CHANGELOG.md
@@ -639,7 +639,7 @@ For more details check out [PR #61](https://github.com/zdharma-continuum/zinit/p
 
 - 06-11-2017
 
-  - The subcommand `clist` now prints `3` completions per line (not `1`). This makes large amount of completions to look
+  - The subcommand `completions` now prints `3` completions per line (not `1`). This makes large amount of completions to look
     better. Argument can be given, e.g. `6`, to increase the grouping.
   - New Ice-mod `silent` that mutes `stderr` & `stdout` of a plugin or snippet.
 

--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -338,10 +338,9 @@ Called by:
 
 ____
  
- Installs all completions of given plugin. After that they are
- visible to 'compinit'. Visible completions can be selectively
- disabled and enabled. User can access completion data with
- 'clist' or 'completions' subcommand.
+ Installs all completions of given plugin. After that they are visible to
+ 'compinit'. Visible completions can be selectively disabled and enabled. User
+ can access completion data with 'completions' subcommand.
  
  $1 - plugin spec (4 formats: user---plugin, user/plugin, user, plugin)
  $2 - plugin if $1 (i.e., user) given

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -1423,7 +1423,7 @@ EOF
 —— cdreplay [-q]                 – replay compdefs (to be done after compinit), -q – quiet
 —— cenable ${ZINIT[col-info]}cname${ZINIT[col-rst]}                 – enable completion \`cname'
 —— changes ${ZINIT[col-pname]}plg-spec${ZINIT[col-rst]}              – view plugin's git log
-—— clist|completions             – list completions in use
+—— completions                   – list installed completions
 —— compile ${ZINIT[col-pname]}plg-spec${ZINIT[col-rst]}              – compile plugin (or all plugins if ——all passed)
 —— compiled                      – list plugins that are compiled
 —— compinit                      – refresh installed completions

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -522,10 +522,9 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     return 0
 } # ]]]
 # FUNCTION: .zinit-install-completions [[[
-# Installs all completions of given plugin. After that they are
-# visible to 'compinit'. Visible completions can be selectively
-# disabled and enabled. User can access completion data with
-# 'clist' or 'completions' subcommand.
+# Installs all completions of given plugin. After that they are visible to
+# 'compinit'. Visible completions can be selectively disabled and enabled. User
+# can access completion data with 'completions' subcommand.
 #
 # $1 - plugin spec (4 formats: user---plugin, user/plugin, user, plugin)
 # $2 - plugin if $1 (i.e., user) given

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -114,7 +114,7 @@ ZINIT[cmds]="\
 -help|-h|\
 add-fpath|\
 bindkeys|\
-cclear|cd|cdclear|cdisable|cdlist|cdreplay|cenable|changes|clist|compile|compiled|compinit|completions|create|creinstall|csearch|cuninstall|\
+cclear|cd|cdclear|cdisable|cdlist|cdreplay|cenable|changes|compile|compiled|compinit|completions|create|creinstall|csearch|cuninstall|\
 delete|debug|\
 edit|env-whitelist|\
 fpath|\


### PR DESCRIPTION
The `clist` subcommand has been renamed to `completions` to reduce duplicated commands.

## Related Issue(s)

Closes #569

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [X] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [X] I have updated the documentation accordingly.