### PR TITLE
fix: respect delete flags after positional arguments

### DIFF
--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -1213,7 +1213,7 @@ EOF
       '  -y, --yes      Don´t prompt for user confirmation'
     )
     zmodload zsh/zutil
-    zparseopts -D -F -K -- \
+    zparseopts -D -E -F -K -- \
       {a,-all}=o_all \
       {c,-clean}=o_clean \
       {d,-dry-run}=o_debug \


### PR DESCRIPTION
## Description

`zinit delete` option flags can go before or after positional arguments.

## Motivation and Context <!--- What problem does it solve? -->

<img width="2054" alt="Screenshot 2023-10-28 at 8 44 36 PM" src="https://github.com/zdharma-continuum/zinit/assets/10052309/c9ddbab2-bf78-41bd-b3ae-592ab3eb048f">

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [X] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
