### PR TITLE
fix: use MACHTYPE instead of arch binary

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1557,7 +1557,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     local junk="(md5|sig|asc|txt|vsix|sum|sha256*|pkg|.(apk|deb|json|rpm|sh(#e)))"
     filtered=( ${list[@]:#(#i)*${~junk}*} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} )
 
-    local -a array=( $(print -rm "*($(arch)|${VENDOR}|)*~^*(${parts[1]}|${(L)$(uname)})*" $list[@]) )
+    local -a array=( $(print -rm "*(${MACHTYPE}|${VENDOR}|)*~^*(${parts[1]}|${(L)$(uname)})*" $list[@]) )
     (( ${#array} > 0 )) && list=( ${array[@]} )
     +zi-log -- "{dbg} filtered ${#filtered} to ${#array} release assets"
 


### PR DESCRIPTION
## Description

`arch` command is not available for systems that do not have GNU coreutils installed. it isn't installed on Synology or NixOS for example.

## Related Issue(s)

Closes #585

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [X] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
