### PR TITLE
fix: from'gh-r' skips compile by default

### DIFF
--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -94,7 +94,7 @@ ____
 
 ____
 
-Has 83 line(s). Calls functions:
+Has 87 line(s). Calls functions:
 
  .zinit-compile-plugin
  |-- zinit-side.zsh/.zinit-compute-ice

--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -5,7 +5,7 @@
   HOME="$ZPFX" # Stops programs creating directories in user home
   export ZBIN="${ZPFX}/bin"
   export os_type="${OSTYPE//[0-9\.]*/}"
-  zinit default-ice --quiet from'gh-r' nocompile lbin''
+  zinit default-ice --quiet from'gh-r' lbin
 }
 
 # @test 'atmos' {  Universal Tool for DevOps and Cloud Automation (works with terraform, helm, helmfile, etc)
@@ -723,7 +723,7 @@
   run "$s" --version; assert $state equals 0
 }
 @test 'sd' { # Intuitive find & replace CLI a.k.a modern sed
-  run zinit lbin'!sd* -> sd' for @chmln/sd; assert $state equals 0
+  run zinit for @chmln/sd; assert $state equals 0
   local sd="$ZBIN/sd"; assert "$sd" is_executable
   run "$sd" --version; assert $state equals 0
 }

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -830,6 +830,12 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     .zinit-compute-ice "$id_as" "pack" \
         ICE plugin_dir filename is_snippet || return 1
 
+    # when from"gh-r" ice set, skip compile unless compile ice is set 
+    if [[ ${ICE[from]} = gh-r ]] && (( ${+ICE[compile]} == 0 )); then
+        +zi-log '{d} from"gh-r" detected, skipping compile'
+        return 0
+    fi
+
     if [[ ${ICE[pick]} != /dev/null && ${ICE[as]} != null && \
         ${+ICE[null]} -eq 0 && ${ICE[as]} != command && ${+ICE[binary]} -eq 0 && \
         ( ${+ICE[nocompile]} = 0 || ${ICE[nocompile]} = \! )


### PR DESCRIPTION
## Description

Skip compile if from'gh-r' ice is set unless compile is also set.

## Motivation and Context <!--- What problem does it solve? -->

**Old behavior left** & **New behavior right**

<img width="1728" alt="Screenshot 2023-11-20 at 04 56 03" src="https://github.com/zdharma-continuum/zinit/assets/10052309/82499646-65a6-4a25-a323-1f366700dc0b">

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [X] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
