### PR TITLE
fix: debug logging logic and format

### DIFF
--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -94,7 +94,7 @@ ____
 
 ____
 
-Has 87 line(s). Calls functions:
+Has 89 line(s). Calls functions:
 
  .zinit-compile-plugin
  |-- zinit-side.zsh/.zinit-compute-ice

--- a/doc/zsdoc/zinit.zsh.adoc
+++ b/doc/zsdoc/zinit.zsh.adoc
@@ -85,7 +85,7 @@ PRECMD-HOOK @zinit-scheduler
 
 ==== Script Body
 
-Has 244 line(s). Calls functions:
+Has 245 line(s). Calls functions:
 
  Script-Body
  |-- +zi-log

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -832,7 +832,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 
     # when from"gh-r" ice set, skip compile unless compile ice is set 
     if [[ ${ICE[from]} = gh-r ]] && (( ${+ICE[compile]} == 0 )); then
-        +zi-log '{d} from"gh-r" detected, skipping compile'
+        +zi-log '{dbg} from"gh-r" detected, skipping compile'
         return 0
     fi
 
@@ -905,6 +905,8 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
             +zi-log -n "{m} {num}${#list}{rst} compiled file${=${list:#1}:+s} added to {var}\$ADD_COMPILED{rst} array"
             if (( retval )) {
                 +zi-log " (exit code: {ehi}$retval{rst})"
+            } else {
+                +zi-log ' '
             }
         }
     fi

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -219,6 +219,7 @@ if [[ -z $SOURCED && ( ${+terminfo} -eq 1 && -n ${terminfo[colors]} ) || ( ${+te
 
     col-i $'\e[1m\e[38;5;82m'"==>"$'\e[0m' col-e $'\e[1m\e[38;5;204m'"Error: "$'\e[0m'
     col-m $'\e[1m\e[38;5;135m'"==>"$'\e[0m' col-w $'\e[1;38;5;214m'"Warning: "$'\e[0m'
+    col-dbg $'\e[2m\e[38;47;108m'"[debug]"$'\e[0m'
 
     col--…   "${${${(M)LANG:#*UTF-8*}:+⋯⋯}:-···}"    col-lr "${${${(M)LANG:#*UTF-8*}:+↔}:-"«-»"}"
     col-ndsh "${${${(M)LANG:#*UTF-8*}:+–}:-}"        col-…  "${${${(M)LANG:#*UTF-8*}:+…}:-...}"
@@ -1977,7 +1978,7 @@ builtin setopt noaliases
     builtin emulate -L zsh -o extendedglob
     REPLY=
     if (( ZINIT[DEBUG] )); then
-        REPLY=$1
+        REPLY="$ZINIT[col-dbg]$1"
     fi
 } # ]]]
 


### PR DESCRIPTION
Using '{dbg}' in +zi-log (i.e., `+zi-log '{dbg} foo bar'`) will only print when "$ZINIT[DEBUG]" is set

## Motivation and Context <!--- What problem does it solve? -->

<img width="1728" alt="Screenshot 2023-11-20 at 07 22 41" src="https://github.com/zdharma-continuum/zinit/assets/10052309/44ae8354-fb22-42d1-a03d-0ad1e18593cc">

## Usage examples

```zsh
+zi-log "{dbg} foo bar"
```

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [X] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
