### PR TITLE
fix: handle zinit --help

### DIFF
--- a/tests/commands.zunit
+++ b/tests/commands.zunit
@@ -43,6 +43,16 @@
   assert $output contains 'Loaded: '
   assert $state equals 0
 }
+@test 'help' {
+  for cmd in 'help' '-h' '--help'; do
+    run zinit $cmd
+    assert $output contains '—— help                          – usage information'
+    assert $state equals 0
+  done
+  run zinit -help
+  assert $output contains 'Unknown subcommand'
+  assert $state equals 1  
+}
 @test 'self-update' {
   run zinit self-update
   assert $output contains 'Already up-to-date.'

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -111,7 +111,6 @@ sh|silent|\
 trackbinds|\
 verbose"
 ZINIT[cmds]="\
--help|-h|\
 add-fpath|\
 bindkeys|\
 cclear|cd|cdclear|cdisable|cdlist|cdreplay|cenable|changes|compile|compiled|compinit|completions|create|creinstall|csearch|cuninstall|\
@@ -119,7 +118,7 @@ delete|debug|\
 edit|env-whitelist|\
 fpath|\
 glance|\
-help|\
+help|--help|-h|\
 ice|\
 light|load|\
 man|module|\


### PR DESCRIPTION
## Description

Fix error when running:

```zsh
zinit --help
```

## Related Issue(s)

Closes #593 

## Usage examples

```zsh
zinit --help
```

## How Has This Been Tested?

Added zunit tests for `help`, `-h`, `--help`

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [X] All new and existing tests passed.
- [X] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
