### PR TITLE
feat: configure, make, cmake, and build ices

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,4 +1,4 @@
-name: Unit tests
+name: Unit Tests
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macos-latest", "ubuntu-latest"]
+        os: ["macos-latest","ubuntu-latest"]
       fail-fast: false
 
     steps:
@@ -39,15 +39,30 @@ jobs:
         id: setup-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
-      # - name: "install musl"
-      #   if: runner.os == 'Linux'
-      #   run: sudo apt-get install build-essential curl file gcc gcc-multilib glibc-source libc6 libc6-dev unzip xz-utils zsh
+      - name: "install musl"
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update --yes
+          sudo apt-get install --yes \
+            autoconf automake autotools-dev \
+            build-essential byacc\
+            cmake curl \
+            file \
+            gcc gettext glibc-source grep \
+            libc6 libc6-dev libevent-dev libncurses5-dev libncursesw5-dev libtool libuvc0 lua5.1 \
+            m4 \
+            ninja-build \
+            pkg-config \
+            unzip \
+            xz-utils \
+            zsh
 
       - name: "install dependencies"
         id: install-deps
         run: |
           export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
-          brew install --force --overwrite gnu-sed coreutils unzip xz zsh
+          brew install --force --overwrite autoconf automake binutils byacc cmake coreutils curl gettext gnu-sed libevent libtool libuv lua lua@5.1 make ninja ncurses pkg-config texinfo unzip xz zsh
+          brew link --force --overwrite ncurses
 
       - name: "install zunit"
         id: install-zunit
@@ -56,23 +71,20 @@ jobs:
           git clone --depth 1 https://github.com/zdharma-continuum/zunit; cd ./zunit
           zsh -c -l './build.zsh' && sudo chmod u+x ./zunit && cp ./zunit "$HOME/.local/bin/"
 
-      # - name: disable secssessment system policy security
-      #   run: sudo spctl --master-disable
+      - name: "commands"
+        run: zunit run tests/commands.zunit
+
+      - name: "plugins"
+        run: zunit run tests/plugins.zunit
+
+      - name: "gh-r"
+        run: zunit run tests/gh-r.zunit
 
       - name: "annexes"
         run: zunit run tests/annexes.zunit
 
-      - name: "commands"
-        run: zunit run tests/commands.zunit
-
-      - name: "gh-r"
-        run: zunit run --fail-fast --verbose tests/gh-r.zunit
-
       - name: "ices"
         run: zunit run tests/ices.zunit
-
-      - name: "plugins"
-        run: zunit run tests/plugins.zunit
 
       - name: "snippets"
         run: zunit run tests/snippets.zunit

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: ["macos-latest","ubuntu-latest"]
+        os: ["macos-latest", "ubuntu-latest"]
       fail-fast: false
 
     steps:
@@ -67,21 +67,32 @@ jobs:
           mkdir -p "$HOME/.local/bin" && echo "$HOME/.local/bin" >> $GITHUB_PATH
           git clone --depth 1 https://github.com/zdharma-continuum/zunit; cd ./zunit
           zsh -l -c './build.zsh' && sudo chmod u+x ./zunit && cp ./zunit "$HOME/.local/bin/"
+      
+      - name: Run tests
+        shell: zsh {0}
+        run: |
+           command -p ls -1 ./tests/*zunit \
+             | parallel \
+             --use-cpus-instead-of-cores \
+             -N0 \
+             --jobs=2 \
+             --keep-order \
+             $HOME/.local/bin/zunit run
 
-      - name: "annexes"
-        run: zunit run tests/annexes.zunit
+      # - name: "annexes"
+      #   run: zunit run tests/annexes.zunit
       
-      - name: "commands"
-        run: zunit run tests/commands.zunit
+      # - name: "commands"
+      #   run: zunit run tests/commands.zunit
         
-      - name: "gh-r"
-        run: zunit run --fail-fast --verbose tests/gh-r.zunit
+      # - name: "gh-r"
+      #   run: zunit run --fail-fast --verbose tests/gh-r.zunit
       
-      - name: "ices"
-        run: zunit run tests/ices.zunit
+      # - name: "ices"
+      #   run: zunit run tests/ices.zunit
       
-      - name: "plugins"
-        run: zunit run tests/plugins.zunit
+      # - name: "plugins"
+      #   run: zunit run tests/plugins.zunit
       
-      - name: "snippets"
-        run: zunit run tests/snippets.zunit
+      # - name: "snippets"
+      #   run: zunit run tests/snippets.zunit

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -5,6 +5,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
   TERM: xterm-256color
 
 on:
@@ -43,25 +44,21 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get update --yes
-          sudo apt-get install --yes \
+          sudo apt-get install --no-install-recommends --yes \
             autoconf automake autotools-dev \
             build-essential byacc\
-            cmake curl \
             file \
             gcc gettext glibc-source grep \
             libc6 libc6-dev libevent-dev libncurses5-dev libncursesw5-dev libtool libuvc0 lua5.1 \
             m4 \
             ninja-build \
             pkg-config \
-            unzip \
-            xz-utils \
-            zsh
+            xz-utils
 
       - name: "install dependencies"
         id: install-deps
         run: |
-          export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
-          brew install --force --overwrite autoconf automake binutils byacc cmake coreutils curl gettext gnu-sed libevent libtool libuv lua lua@5.1 make ninja ncurses pkg-config texinfo unzip xz zsh
+          brew install --force --overwrite autoconf automake binutils byacc cmake coreutils curl gettext gnu-sed libevent libtool libuv lua lua@5.1 make ncurses ninja parallel pkg-config texinfo unzip xz zsh
           brew link --force --overwrite ncurses
 
       - name: "install zunit"
@@ -69,22 +66,14 @@ jobs:
         run: |
           mkdir -p "$HOME/.local/bin" && echo "$HOME/.local/bin" >> $GITHUB_PATH
           git clone --depth 1 https://github.com/zdharma-continuum/zunit; cd ./zunit
-          zsh -c -l './build.zsh' && sudo chmod u+x ./zunit && cp ./zunit "$HOME/.local/bin/"
+          zsh -l -c './build.zsh' && sudo chmod u+x ./zunit && cp ./zunit "$HOME/.local/bin/"
 
-      - name: "commands"
-        run: zunit run tests/commands.zunit
-
-      - name: "plugins"
-        run: zunit run tests/plugins.zunit
-
-      - name: "gh-r"
-        run: zunit run tests/gh-r.zunit
-
-      - name: "annexes"
-        run: zunit run tests/annexes.zunit
-
-      - name: "ices"
-        run: zunit run tests/ices.zunit
-
-      - name: "snippets"
-        run: zunit run tests/snippets.zunit
+      - name: Run tests
+        shell: zsh {0}
+        run: |
+          command -p ls -1 ./tests/*zunit \
+            | parallel \
+            --jobs=4 \
+            --keep-order \
+            --line-buffer \
+            $HOME/.local/bin/zunit run

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -68,12 +68,20 @@ jobs:
           git clone --depth 1 https://github.com/zdharma-continuum/zunit; cd ./zunit
           zsh -l -c './build.zsh' && sudo chmod u+x ./zunit && cp ./zunit "$HOME/.local/bin/"
 
-      - name: Run tests
-        shell: zsh {0}
-        run: |
-          command -p ls -1 ./tests/*zunit \
-            | parallel \
-            --jobs=4 \
-            --keep-order \
-            --line-buffer \
-            $HOME/.local/bin/zunit run
+      - name: "annexes"
+        run: zunit run tests/annexes.zunit
+      
+      - name: "commands"
+        run: zunit run tests/commands.zunit
+        
+      - name: "gh-r"
+        run: zunit run --fail-fast --verbose tests/gh-r.zunit
+      
+      - name: "ices"
+        run: zunit run tests/ices.zunit
+      
+      - name: "plugins"
+        run: zunit run tests/plugins.zunit
+      
+      - name: "snippets"
+        run: zunit run tests/snippets.zunit

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -73,10 +73,9 @@ jobs:
         run: |
            command -p ls -1 ./tests/*zunit \
              | parallel \
-             --use-cpus-instead-of-cores \
-             -N0 \
-             --jobs=2 \
+             --jobs=0 \
              --keep-order \
+             --line-buffer \
              $HOME/.local/bin/zunit run
 
       # - name: "annexes"

--- a/tests/_support/annex_test_assertions
+++ b/tests/_support/annex_test_assertions
@@ -8,3 +8,8 @@ is_annex() {
   assert ${PWD}/${${annex}//zinit-annex/z-a}.plugin.zsh is_file
   assert ${PWD}/${${annex}//zinit-annex/z-a}.plugin.zsh is_readable
 }
+
+load_bin_gem_node(){
+  run zinit load @zdharma-continuum/zinit-annex-bin-gem-node
+  zinit default-ice --quiet from'gh-r'
+}

--- a/tests/_support/bootstrap
+++ b/tests/_support/bootstrap
@@ -1,5 +1,5 @@
-#!/usr/bin/env zsh
-setopt NO_GLOBAL_RCS NO_GLOBAL_EXPORT NO_RCS
+emulate zsh
+setopt no_global_rcs no_rcs no_aliases extended_glob
 
 # Log functions [[[
 function error(){ print -P "%F{red}[ERROR]%f: ${1}" && return 1; }
@@ -19,24 +19,29 @@ if [[ ! -d ${TMP_ZUNIT} ]]; then
     exit 1
 fi
 
-typeset -gAH ZINIT;
-ZINIT[HOME_DIR]=${TMP_ZUNIT};
-ZINIT[BIN_DIR]=$ZINIT[HOME_DIR]/zinit.git;
-ZINIT[COMPLETIONS_DIR]=$ZINIT[HOME_DIR]/completions;
-ZINIT[PLUGINS_DIR]=$ZINIT[HOME_DIR]/plugins;
-ZINIT[SNIPPETS_DIR]=$ZINIT[HOME_DIR]/snippets;
-ZINIT[ZCOMPDUMP_PATH]=$ZINIT[HOME_DIR]/zcompdump;
-ZPFX=$ZINIT[HOME_DIR]/polaris;
+typeset -gx zi_test_dir="${TMP_ZUNIT}"
+typeset -gxAUH ZINIT
+# DEBUG           'true'
+ZINIT+=(
+  BIN_DIR         ${zi_test_dir}/zinit.git
+  COMPLETIONS_DIR ${zi_test_dir}/completions SNIPPETS_DIR ${zi_test_dir}/snippets
+  HOME_DIR        ${zi_test_dir}             PLUGINS_DIR  ${zi_test_dir}/plugins
+  ZCOMPDUMP_PATH  ${zi_test_dir}/zcompdump   ZPFX         ${zi_test_dir}/polaris
+  POLARIS         ${zi_test_dir}/polaris
+)
+typeset -gxH ZPFX=
+ZPFX="$zi_test_dir"/polaris
 
 command git diff > ${ZINIT[HOME_DIR]}/unstaged.diff
-info 'creating test env'
+# info 'creating test env'
 git clone \
+    --quiet \
     --depth=1 \
     --dissociate \
     --no-hardlinks \
     --reference "${GIT_REPO}" \
     file://${GIT_REPO:A} \
-    "${ZINIT[BIN_DIR]}"
+    "${ZINIT[BIN_DIR]}" >/dev/null
 if (( $? != 0 )); then
     error "Unable to copy ${GIT_REPO} to ${TMP_ZUNIT}" >&2
     exit 1
@@ -46,23 +51,28 @@ if [[ -s $ZINIT[HOME_DIR]/unstaged.diff ]]; then
     (
         git -C $ZINIT[BIN_DIR] apply $ZINIT[HOME_DIR]/unstaged.diff && \
             chmod g-rwX "${ZINIT[HOME_DIR]}" && \
-            zcompile "${ZINIT[BIN_DIR]}/zinit.zsh"
-    )
+            zcompile "${ZINIT[BIN_DIR]}/zinit.zsh" >/dev/null
+    ) >/dev/null
 fi
 (( $? != 0 )) && { error "Unable to copy ${GIT_REPO} to ${TMP_ZUNIT}" >&2; exit 1 }
 
-source $ZINIT[BIN_DIR]/zinit.zsh
-(( $? != 0 )) && { error "Unable to copy ${GIT_REPO} to ${TMP_ZUNIT}" >&2; exit 1 }
-# ]]]
-# Install Annexes [[[
-info 'installing test dependencies'
-for annex (binary-symlink default-ice); do
-  if [[ ! -d ${GIT_REPO}/tests/_support/$annex ]]; then;
-    git clone https://github.com/zdharma-continuum/zinit-annex-$annex ${GIT_REPO:A}/tests/_support/$annex
-  fi
-  zinit light ${GIT_REPO:A}/tests/_support/$annex
-  info "loaded $annex dependencies"
-done
-# ]]]
+hash -f
+builtin hash -d zinit=$zi_test_dir
+builtin hash -d zpfx=$zi_test_dir/polaris
+builtin hash -d plugins=$zi_test_dir/plugins
+source $zi_test_dir/zinit.git/zinit.zsh
+(( $? != 0 )) && { error "Unable to source zinit" >&2; exit 1 }
+hash -f
+builtin hash -d zinit=$zi_test_dir
+builtin hash -d zpfx=$zi_test_dir/polaris
+builtin hash -d plugins=$zi_test_dir/plugins
+{
+  zinit for \
+    @zdharma-continuum/zinit-annex-bin-gem-node \
+    @zdharma-continuum/zinit-annex-binary-symlink \
+    @zdharma-continuum/zinit-annex-default-ice \
+    @zdharma-continuum/zinit-annex-linkman
+}>/dev/null
 
-# vim:ft=zsh:sw=2:sts=2:et:foldmarker=[[[,]]]:foldmethod=marker
++zi-log "{m} loaded $annex dependencies"
+zinit zstatus

--- a/tests/commands.zunit
+++ b/tests/commands.zunit
@@ -51,12 +51,20 @@
   done
   run zinit -help
   assert $output contains 'Unknown subcommand'
-  assert $state equals 1  
+  assert $state equals 1
 }
 @test 'self-update' {
   run zinit self-update
   assert $output contains 'Already up-to-date.'
   assert $state equals 0
 }
-
-# vim:ft=zsh:sw=2:sts=2:et:foldmarker={,}:foldmethod=marker
+@test 'set-debug' {
+  ZINIT+=(DEBUG 'true')
+  run +zi-log -n '{dbg} message'
+  assert $output contains '[debug]'; assert $state equals 0
+}
+@test 'unset-dbg' {
+  run +zi-log -n '{dbg} message'; assert $output contains ''
+  run +zi-log -n '{m} message'
+  assert $output contains 'message'; assert $state equals 0
+}

--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -1,11 +1,11 @@
 #!/usr/bin/env zunit
 
-
 @setup {
-  HOME="$ZPFX" # Stops programs creating directories in user home
-  export ZBIN="${ZPFX}/bin"
-  export os_type="${OSTYPE//[0-9\.]*/}"
-  zinit default-ice --quiet from'gh-r' lbin
+    load "${PWD}/tests/_support/annex_test_assertions"
+    HOME="$zi_test_dir" # Stops programs creating directories in user home
+    typeset -gx ZBIN="$zi_test_dir/polaris/bin" os_type="${OSTYPE//[0-9\.]*/}"
+    [[ ! -d $ZBIN ]] && mkdir -p "$ZBIN"
+    zinit default-ice --quiet from'gh-r' lbin'!' null
 }
 
 # @test 'atmos' {  Universal Tool for DevOps and Cloud Automation (works with terraform, helm, helmfile, etc)
@@ -36,7 +36,7 @@
 @test 'act' { # Run your GitHub Actions locally
   run zinit for @nektos/act; assert $state equals 0
   local act="$ZBIN/act"; assert "$act" is_executable
-  $act --version; assert $state equals 0
+  run "$act" --version; assert $state equals 0
 }
 @test 'akamai' { # Manage and configure Akamai from the Command Line.
   run zinit id-as'akamai' lbin'akamai*->akamai' for @akamai/cli; assert $state equals 0
@@ -78,7 +78,7 @@
   [[ $OSTYPE =~ 'darwin*' ]] && skip "on $os_type"
   run zinit for @imsnif/bandwhich; assert $state equals 0
   local bandwhich="$ZBIN/bandwhich"; assert "$bandwhich" is_executable
-  run $bandwhich --help; assert $state equals 0
+  run "$bandwhich" --version; assert $state equals 0
 }
 @test 'bat' { # A cat(1) clone with wings
   run zinit for @sharkdp/bat; assert $state equals 0
@@ -473,12 +473,12 @@
   local just="$ZBIN/just"; assert "$just" is_executable
   run $just --version; assert $state equals 0
 }
-@test 'keepassxc' { # a cross-platform community-driven port of the Windows application Keepass Password Safe
-  [[ $OSTYPE =~ 'linux*' ]] && skip "skipped on $os_type"
-  run zinit for lbin'!*-cli -> keepassxc-cli' @keepassxreboot/keepassxc; assert $state equals 0
-  local keepassxc="$ZBIN/keepassxc-cli"; assert "$keepassxc" is_executable
-  run $keepassxc --version; assert $state equals 0
-}
+# @test 'keepassxc' { # a cross-platform community-driven port of the Windows application Keepass Password Safe
+#   [[ $OSTYPE =~ 'linux*' ]] && skip "skipped on $os_type"
+#   run zinit for lbin'!*-cli -> keepassxc-cli' @keepassxreboot/keepassxc; assert $state equals 0
+#   local keepassxc="$ZBIN/keepassxc-cli"; assert "$keepassxc" is_executable
+#   run $keepassxc --version; assert $state equals 0
+# }
 @test 'ko' { # Build and deploy Go applications on Kubernetes
   run zinit for @ko-build/ko; assert $state equals 0
   local ko="$ZBIN/ko"; assert "$ko" is_executable
@@ -498,6 +498,16 @@
   run zinit for id-as'kubedb' lbin'*->kubedb' @kubedb/cli; assert $state equals 0
   local cli="$ZBIN/kubedb"; assert "$cli" is_executable
   run "$cli" version; assert $state equals 0
+}
+@test 'kubectl-plugins' { # Faster way to switch between clusters and namespaces in kubectl
+  [[ $OSTYPE =~ 'darwin*' ]] && skip "skipped on $os_type"
+  load_bin_gem_node
+  run zinit for bpick'kubectx;kubens' sbin'kubectx;kubens' @ahmetb/kubectx
+  local bin prog
+  for bin in 'kubectx' 'kubens'; do
+    prog="$ZBIN/${bin}"; assert "$prog" is_executable;
+    run "$prog" --help; assert $state equals 0
+  done
 }
 @test 'lazygit' { # simple terminal UI for git commands
   run zinit for @jesseduffield/lazygit; assert $state equals 0
@@ -550,12 +560,36 @@
 @test 'mcfly' { # Fly through your shell history. Great Scott
   run zinit ver'v0.8.3' for @cantino/mcfly; assert $state equals 0
   local mcfly="$ZBIN/mcfly"; assert "$mcfly" is_executable
-  run $mcfly --version; assert $state equals 0
+  run "$mcfly" --version; assert $state equals 0
 }
-@test 'mdbook' { # Create book from markdown files. Like Gitbook but implemented in Rust
-  run zinit for @rust-lang/mdBook; assert $state equals 0
-  local mdbook="$ZBIN/mdbook"; assert "$mdbook" is_executable
-  run $mdbook --version; assert $state equals 0
+@test 'mdbook-lbin' { # Create book from markdown files. Like Gitbook but implemented in Rust
+  local mdbook="$ZBIN/mdbook";
+  run zinit for @rust-lang/mdBook; assert $state equals 0 assert "$mdbook" is_executable
+
+  run "$mdbook" --version; assert $state equals 0
+
+  run command file "$(command realpath ${mdbook})"; assert $output contains 'executable'
+
+  run zinit delete --yes rust-lang/mdBook; assert $state equals 0
+
+  run "$mdbook" --version;
+  assert $state equals 127; assert $output contains 'no such file or directory'
+}
+@test 'mdbook-sbin' { # Create book from markdown files. Like Gitbook but implemented in Rust
+  load_bin_gem_node
+  local mdbook="$ZBIN/mdbook";
+
+  run zinit from'gh-r' sbin"mdbook" for @rust-lang/mdBook; assert $state equals 0 assert "$mdbook" is_executable
+
+  run "$mdbook" --version; assert $state equals 0
+
+  run command file "$(command realpath ${mdbook})";
+  assert $output contains 'zsh script'; assert $output contains 'ASCII text'
+
+  run zinit delete --yes rust-lang/mdBook; assert $state equals 0
+
+  run "$mdbook" --version;
+  assert $state equals 127; assert $output contains 'no such file or directory'
 }
 @test 'mdcat' { # cat for markdown
   run zinit for @swsnr/mdcat; assert $state equals 0

--- a/tests/ices.zunit
+++ b/tests/ices.zunit
@@ -34,7 +34,7 @@
   assert "$ZPLUGINS/test---atclone/readme.md" not_exists
 }
 @test 'make' {
-  run zinit as"null" id-as"test/make" atclone"printf 'all:\n\ttouch whatever\n' > Makefile" make"" for zdharma-continuum/null
+  run zinit as"null" id-as"test/make" atclone"printf 'all:\n\ttouch whatever\n' > Makefile" make"all" for zdharma-continuum/null
   assert $state equals 0
   assert "$ZPLUGINS/test---make/whatever" is_file
 }

--- a/tests/plugins.zunit
+++ b/tests/plugins.zunit
@@ -1,55 +1,125 @@
 #!/usr/bin/env zunit
 
-
 @setup {
-  zinit default-ice as'null' light-mode nocompile nocompletions
-  ZBIN=$ZPFX/bin
-  export LC_CTYPE=C
-  export LANG=C
+  HOME="$zi_test_dir"
+  typeset -gx ZBIN="$zi_test_dir/polaris/bin"
 }
 
-# @test 'nnn' {
-#   run zinit light-mode for jarun/nnn
-#   zinit cd jarun/nnn
-#   run PREFIX=$ZPFX make install; assert $state equals 0
-#   local nnn="$ZPFX/bin/nnn";     assert $nnn   is_executable
-#   $nnn -V;                       assert $state equals 0
+# @test 'cmatrix' {
+#   run zinit build for @abishekvashok/cmatrix;
+#   local cmatrix="$ZBIN/cmatrix"; assert "$cmatrix" is_executable
+#   run "$cmatrix" -V; assert $state equals 0
+#   # ensure cmake artifacts are deleted
+#   zinit delete --yes abishekvashok/cmatrix; assert $state equals 0
+#   run "$cmatrix"; assert $state equals 127
 # }
-@test 'pipes' {
-  run zinit for @pipeseroni/pipes.sh
-  # zinit cd pipeseroni/pipes.sh
-  run zinit run pipeseroni/pipes.sh make PREFIX=$ZPFX install; assert $state equals 0
-  local pipes="$ZBIN/pipes.sh"; assert $pipes is_executable
-  $pipes -v; assert $state equals 0
+@test 'figlet' {
+  run zinit make for @cmatsuoka/figlet; assert $state equals 0
+  local figlet="$ZBIN/figlet"; assert "$figlet" is_executable
+  run "$figlet" -I 1; assert $state equals 0
 }
-@test 'tree' {
-  run zinit light-mode for Old-Man-Programmer/tree
-  zinit cd Old-Man-Programmer/tree
-  run make PREFIX=$ZPFX install; assert $state equals 0
-  local tree="$ZBIN/tree";   assert $tree  is_executable
-  $tree -v;                      assert $state equals 0
+@test 'htop' {
+  run zinit build for @htop-dev/htop; assert $state equals 0
+  local htop="$ZBIN/htop"; assert "$htop" is_executable
+  run "$htop" --version; assert $state equals 0
+}
+@test 'bash' {
+  run zinit build for @bminor/bash; assert $state equals 0
+  local bash="$ZBIN/bash"; assert $bash is_executable
+  run "$bash" --version; assert $state equals 0
+}
+@test 'ctags' {
+  run zinit build for @universal-ctags/ctags; assert $state equals 0
+  local ctags="$ZBIN/ctags"; assert "$ctags" is_executable
+  run "$ctags" --version; assert $state equals 0
+}
+@test 'lua-format' {
+  run zinit cmake for @Koihik/LuaFormatter; assert $state equals 0
+  local lua_format="$ZBIN/lua-format"; assert "$lua_format" is_executable
+  run "$lua_format" --version; assert $state equals 0
+  run zinit delete --yes Koihik/LuaFormatter; assert $state equals 0
+  run "$lua_format" --version; assert $state equals 127
+}
+@test 'jq' {
+  run zinit build for @jqlang/jq; assert $state equals 0
+  local jq="$ZBIN/jq"; assert "$jq" is_executable
+  run "$jq" --version; assert $state equals 0
+}
+@test 'ncurses' {
+  run zinit configure'--enable-widec --enable-termcap' make for @mirror/ncurses; assert $state equals 0
+  local ncurses="$ZBIN/clear"; assert "$ncurses" is_executable
+  run "$ncurses" -V; assert $state equals 0
+  run zinit delete --yes mirror/ncurses; assert $state equals 0
+  run "$ncurses" -V; assert $state equals 127
+}
+@test 'neofetch' {
+  run zinit make for @dylanaraps/neofetch; assert $state equals 0
+  local neofetch="$ZBIN/neofetch"; assert "$neofetch" is_executable
+  run "$neofetch" --version; assert $state equals 1; assert $output contains 'Neofetch'
+}
+@test 'neovim-make' {
+  run zinit make for @neovim/neovim; assert $state equals 0
+  local neovim="$ZBIN/nvim"; assert $neovim is_executable
+  run "$neovim" --version; assert $state equals 0
+
+  nvim_ver="$($neovim --version | head -n1 | awk '{print $2}')";
+  nvim_commit="$(git --work-tree=$ZINIT[PLUGINS_DIR]/neovim---neovim rev-parse --short HEAD)";
+  print -lPr " " "nvim ver: %F{blue}$nvim_ver%f" "nvim commit sha: %F{blue}$nvim_commit%f" "check: [[ %F{blue}$nvim_ver%f = %F{blue}*$nvim_commit(#e)%f ]]"
+  [[ $nvim_ver = *$nvim_commit(#e) ]] && print -P "%F{green}ok%f"
+  run zinit delete --yes neovim/neovim; assert $state equals 0
+  run "$neovim" --version; assert $state equals 127
+}
+# @test 'neovim-cmake' {
+#   run zinit cmake for @neovim/neovim; assert $state equals 0
+#   local neovim="$ZBIN/nvim"; assert $neovim is_executable
+#   run "$neovim" --version; assert $state equals 0
+#
+#   nvim_ver="$($neovim --version | head -n1 | awk '{print $2}')";
+#   nvim_commit="$(git --work-tree=$ZINIT[PLUGINS_DIR]/neovim---neovim rev-parse --short HEAD)";
+#   print -lPr " " "nvim ver: %F{blue}$nvim_ver%f" "nvim commit sha: %F{blue}$nvim_commit%f" "check: [[ %F{blue}$nvim_ver%f = %F{blue}*$nvim_commit(#e)%f ]]"
+#   [[ $nvim_ver = *$nvim_commit(#e) ]] && print -P "%F{green}ok%f"
+#
+#   run zinit delete --yes neovim/neovim; assert $state equals 0
+# }
+@test 'tmux' {
+  if [[ $OSTYPE =~ 'darwin*' ]]; then
+    run zinit configure'--disable-utf8proc' make for @tmux/tmux; assert $state equals 0
+  else
+    run zinit build for @tmux/tmux; assert $state equals 0
+  fi
+  local tmux="$ZBIN/tmux"; assert $tmux is_executable
+  run "$tmux" -V; assert $state equals 0
+  run zinit delete --yes tmux/tmux; assert $state equals 0
+  run "$tmux" -V; assert $state equals 127
 }
 @test 'vim' {
-  run zinit light-mode for vim/vim
-  zinit cd vim/vim
-  run ./configure --prefix=$ZPFX && make PREFIX=$ZPFX install
-  assert $state equals 0
+  run zinit build for @vim/vim; assert $state equals 0
   local vim="$ZBIN/vim"; assert $vim is_executable
-  $vim --version; assert $state equals 0
+  run "$vim" --version; assert $state equals 0
+  # run zinit delete --yes vim/vim; assert $state equals 0
 }
-@test 'zsh-completions' {
-  run zinit light-mode for zsh-users/zsh-completions
-  zinit cd zsh-users/zsh-completions
-  run zinit creinstall -q .; assert $state equals 0
-  local broken_completions=($(echo "$ZINIT[COMPLETIONS_DIR]"/*(-@))); assert "${#broken_completions[@]}" equals 0
+@test 'zsh' {
+  # run zinit configure'--with-tcsetpgrp' make'install.bin' for @zsh-users/zsh; assert $state equals 0
+  run zinit configure'--with-tcsetpgrp' atclone"./Util/preconfig"  make'install.bin' for @zsh-users/zsh; assert $state equals 0
+  local zsh="$ZBIN/zsh"; assert $zsh is_executable
+  run "$zsh" --version; assert $state equals 0
+  run zinit delete --yes zsh-users/zsh; assert $state equals 0
+  run "$zsh" --version; assert $state equals 127
 }
-# @test 'zsh_bin' {
-#   run zinit as'null' sbin'bin/zsh' for @romkatv/zsh-bin
-#   assert $state equals 0
-#   local zsh_static="$ZPFX/bin/zsh"
-#   assert "$zsh_static" is_executable
-#   $zsh_static --help
-#   assert $state equals 0
+
+# ===========
+# Flaky tests
+# ===========
+# @test 'stow' {
+#   run zinit configure'--without-pmdir' make for @aspiers/stow; assert $state equals 0
+#   local stow="$ZBIN/stow"; assert "$stow" is_executable
+#   run "$stow" --version; assert $state equals 0
+# }
+# @test 'zsh-completions' {
+#   run zinit light-mode for zsh-users/zsh-completions
+#   zinit cd zsh-users/zsh-completions
+#   run zinit creinstall -q .; assert $state equals 0
+#   local broken_completions=($(echo "$ZINIT[COMPLETIONS_DIR]"/*(-@N))); assert "$#broken_completions[@]" equals 0
 # }
 
-# vim:ft=zsh:sw=2:sts=2:et:foldmarker=@test,}:foldmethod=marker
+# vim:ft=zsh:sw=2:sts=2:et:foldmarker={,}:foldmethod=indent

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -1279,8 +1279,8 @@ EOF
     }
     local i
     if (( $#o_yes )) || ( .zinit-prompt "Delete ${(j:, :)@}"); then
-        local -A ICE ICE2
         for i in $@; do
+            local -A ICE=() ICE2=()
             local the_id="${${i:#(%|/)*}}" filename is_snippet local_dir
             .zinit-compute-ice "$the_id" "pack" ICE2 local_dir filename is_snippet || return 1
             if [[ "$local_dir" != /* ]]; then
@@ -1697,24 +1697,38 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
     done
 } # ]]]
 # FUNCTION: .zinit-run-delete-hooks [[[
-.zinit-run-delete-hooks() {
-    if [[ -n ${ICE[atdelete]} ]]; then
-        .zinit-countdown "atdelete" && ( (( ${+ICE[nocd]} == 0 )) && \
-                { builtin cd -q "$5" && eval "${ICE[atdelete]}"; ((1)); } || \
-                eval "${ICE[atdelete]}" )
+.zinit-run-delete-hooks () {
+    local make_path=$5/Makefile mfest_path=$5/build/install_manifest.txt quiet='2>/dev/null 1>&2' 
+    if [[ -f $make_path ]] && grep '^uninstall' $make_path &> /dev/null; then
+        +zi-log -n "{m} Make uninstall... "
+        eval 'command make -C ${make_path:h} {prefix,{,CMAKE_INSTALL_}PREFIX}=$ZINIT[ZPFX] --ignore-errors uninstall' 2>/dev/null 1>&2
+        if (( $? == 0 )); then
+            +zi-log " [{happy}OK{rst}]"
+        else
+            +zi-log " [{error}Failed{rst}]"
+        fi
+    elif [[ -f $mfest_path ]]; then
+        +zi-log -n "{m} Cmake uninstall... "
+        if { command cmake --build ${mfest_path:h} --target uninstall || xargs rm -rf < "$mfest_path" } &>/dev/null ; then
+            +zi-log " [{happy}OK{rst}]"
+        else
+            +zi-log " [{error}Failed{rst}]"
+        fi
     fi
-
+    eval 'find $ZINIT[ZPFX] -depth -type d -empty -delete' &> /dev/null
+    if [[ -n ${ICE[atdelete]} ]]; then
+        (
+            (( ${+ICE[nocd]} == 0 )) && {
+                builtin cd -q "$5" && eval "${ICE[atdelete]}"
+                ((1))
+            } || eval "${ICE[atdelete]}"
+        )
+    fi
     local -a arr
     local key
-
-    # Run annexes' atdelete hooks
-    reply=(
-        ${(on)ZINIT_EXTS2[(I)zinit hook:atdelete-pre <->]}
-        ${(on)ZINIT_EXTS[(I)z-annex hook:atdelete-<-> <->]}
-        ${(on)ZINIT_EXTS2[(I)zinit hook:atdelete-post <->]}
-    )
+    reply=(${(on)ZINIT_EXTS2[(I)zinit hook:atdelete-pre <->]} ${(on)ZINIT_EXTS[(I)z-annex hook:atdelete-<-> <->]} ${(on)ZINIT_EXTS2[(I)zinit hook:atdelete-post <->]}) 
     for key in "${reply[@]}"; do
-        arr=( "${(Q)${(z@)ZINIT_EXTS[$key]:-$ZINIT_EXTS2[$key]}[@]}" )
+        arr=("${(Q)${(z@)ZINIT_EXTS[$key]:-$ZINIT_EXTS2[$key]}[@]}") 
         "${arr[5]}" "$1" "$2" $3 "$4" "$5" "${${key##(zinit|z-annex) hook:}%% <->}" delete:TODO
     done
 } # ]]]

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -75,8 +75,8 @@ fi
 ZINIT[ice-list]="\
 \!bash|\!csh|\!ksh|\!sh|\
 aliases|as|atclone|atdelete|atinit|atload|atpull|autoload|\
-bash|binary|bindmap|blockf|bpick|\
-cloneonly|cloneopts|compile|completions|configure|countdown|cp|csh|\
+bash|binary|bindmap|blockf|bpick|build|\
+cloneonly|cloneopts|cmake|compile|completions|configure|countdown|cp|csh|\
 debug|depth|\
 extract|\
 from|git|\
@@ -97,7 +97,7 @@ ZINIT[nval-ice-list]="\
 \!bash|\!csh|\!ksh|\!sh|\
 aliases|\
 bash|binary|blockf|\
-cloneonly|cloneopts|countdown|csh|\
+cloneonly|cloneopts|cmake|configure|countdown|csh|\
 debug|\
 git|\
 is-snippet|\
@@ -133,13 +133,15 @@ zstatus"
 # Can be customized.
 : ${ZINIT[COMPLETIONS_DIR]:=${ZINIT[HOME_DIR]}/completions}
 : ${ZINIT[MODULE_DIR]:=${ZINIT[HOME_DIR]}/module}
-: ${ZINIT[PACKAGES_REPO]:=zdharma-continuum/zinit-packages}
 : ${ZINIT[PACKAGES_BRANCH]:=HEAD}
+: ${ZINIT[PACKAGES_REPO]:=zdharma-continuum/zinit-packages}
 : ${ZINIT[PLUGINS_DIR]:=${ZINIT[HOME_DIR]}/plugins}
+: ${ZINIT[POLARIS_DIR]:=${ZINIT[HOME_DIR]}/polaris}
 : ${ZINIT[SERVICES_DIR]:=${ZINIT[HOME_DIR]}/services}
 : ${ZINIT[SNIPPETS_DIR]:=${ZINIT[HOME_DIR]}/snippets}
+: ${ZINIT[ZPFX]:=${ZINIT[HOME_DIR]}/polaris}
 typeset -g ZPFX
-: ${ZPFX:=${ZINIT[HOME_DIR]}/polaris}
+: ${ZPFX:=${ZINIT[ZPFX]}}
 : ${ZINIT[ALIASES_OPT]::=${${options[aliases]:#off}:+1}}
 : ${ZINIT[MAN_DIR]:=${ZPFX}/man}
 
@@ -149,6 +151,11 @@ export ZPFX=${~ZPFX} ZSH_CACHE_DIR="${ZSH_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.ca
     PMSPEC=0uUpiPsf
 [[ -z ${path[(re)$ZPFX/bin]} ]] && [[ -d "$ZPFX/bin" ]] && path=( "$ZPFX/bin" "${path[@]}" )
 [[ -z ${path[(re)$ZPFX/sbin]} ]] && [[ -d "$ZPFX/sbin" ]] && path=( "$ZPFX/sbin" "${path[@]}" )
+
+hash -f
+hash -d zinit=${ZINIT[HOME_DIR]}
+hash -d plugins=${ZINIT[PLUGINS_DIR]}
+hash -d zpfx=${ZINIT[HOME_DIR]}/polaris
 
 # Add completions directory to fpath.
 [[ -z ${fpath[(re)${ZINIT[COMPLETIONS_DIR]}]} ]] && fpath=( "${ZINIT[COMPLETIONS_DIR]}" "${fpath[@]}" )
@@ -215,10 +222,12 @@ if [[ -z $SOURCED && ( ${+terminfo} -eq 1 && -n ${terminfo[colors]} ) || ( ${+te
     col-ehi     $'\e[1m\e[38;5;210m'    col-meta    $'\e[38;5;57m'          col-pname   $'\e[1;4m\e[32m'     col-var     $'\e[38;5;81m'
     col-error   $'\e[1m\e[38;5;204m'    col-meta2   $'\e[38;5;147m'         col-pre     $'\e[38;5;135m'      col-version $'\e[3;38;5;87m'
     col-failure $'\e[38;5;204m'         col-msg     $'\e[0m'                col-profile $'\e[38;5;148m'      col-warn    $'\e[38;5;214m'
-
-    col-i $'\e[1m\e[38;5;82m'"==>"$'\e[0m' col-e $'\e[1m\e[38;5;204m'"Error: "$'\e[0m'
-    col-m $'\e[1m\e[38;5;135m'"==>"$'\e[0m' col-w $'\e[1;38;5;214m'"Warning: "$'\e[0m'
-    col-dbg $'\e[2m\e[38;47;108m'"[debug]"$'\e[0m'
+    
+    col-dbg $'\e[2m\e[38;47;107m'"[debug]"$'\e[0m'
+    col-e $'\e[1m\e[38;5;204m'"Error"$'\e[0m'":"
+    col-i $'\e[1m\e[38;5;82m'"==>"$'\e[0m' 
+    col-m $'\e[1m\e[38;5;135m'"==>"$'\e[0m' 
+    col-w $'\e[1m\e[38;5;214m'"Warning"$'\e[0m'":"
 
     col--…   "${${${(M)LANG:#*UTF-8*}:+⋯⋯}:-···}"    col-lr "${${${(M)LANG:#*UTF-8*}:+↔}:-"«-»"}"
     col-ndsh "${${${(M)LANG:#*UTF-8*}:+–}:-}"        col-…  "${${${(M)LANG:#*UTF-8*}:+…}:-...}"
@@ -1264,7 +1273,7 @@ builtin setopt noaliases
         # For compaudit.
         command chmod go-w "${ZINIT[HOME_DIR]}"
         # Also set up */bin and ZPFX in general.
-        command mkdir 2>/dev/null -p $ZPFX/bin
+        command mkdir -p "${ZPFX:-ZINIT[HOME_DIR]/polaris}/bin"
     }
     [[ ! -d ${ZINIT[PLUGINS_DIR]}/_local---zinit ]] && {
         command rm -rf "${ZINIT[PLUGINS_DIR]:-${TMPDIR:-/tmp}/132bcaCAB}/_local---zplugin"
@@ -1273,7 +1282,7 @@ builtin setopt noaliases
         command ln -s "${ZINIT[BIN_DIR]}/_zinit" "${ZINIT[PLUGINS_DIR]}/_local---zinit"
 
         # Also set up */bin and ZPFX in general.
-        command mkdir 2>/dev/null -p $ZPFX/bin
+        command mkdir -p "${ZPFX:-ZINIT[HOME_DIR]/polaris}/bin"
 
         (( ${+functions[.zinit-setup-plugin-dir]} )) || builtin source "${ZINIT[BIN_DIR]}/zinit-install.zsh" || return 1
         (( ${+functions[.zinit-confirm]} )) || builtin source "${ZINIT[BIN_DIR]}/zinit-autoload.zsh" || return 1
@@ -1289,7 +1298,7 @@ builtin setopt noaliases
         command ln -s "${ZINIT[PLUGINS_DIR]}/_local---zinit/_zinit" "${ZINIT[COMPLETIONS_DIR]}"
 
         # Also set up */bin and ZPFX in general.
-        command mkdir 2>/dev/null -p $ZPFX/bin
+        command mkdir -p "${ZPFX:-ZINIT[HOME_DIR]/polaris}/bin"
 
         (( ${+functions[.zinit-setup-plugin-dir]} )) || builtin source "${ZINIT[BIN_DIR]}/zinit-install.zsh" || return 1
         .zinit-compinit &>/dev/null
@@ -1304,7 +1313,7 @@ builtin setopt noaliases
         command chmod go-w "${ZINIT[SERVICES_DIR]}"
 
         # Also set up */bin and ZPFX in general.
-        command mkdir 2>/dev/null -p $ZPFX/bin
+        command mkdir -p "${ZPFX:-ZINIT[HOME_DIR]/polaris}/bin"
     }
     [[ ! -d ${~ZINIT[MAN_DIR]}/man9 ]] && {
         # Create ZINIT[MAN_DIR]/man{1..9}
@@ -1972,15 +1981,6 @@ builtin setopt noaliases
     builtin zle -F "$THEFD" +zinit-deploy-message
 } # ]]]
 
-# FUNCTION: .zinit-formatter-dbg [[[
-.zinit-formatter-dbg() {
-    builtin emulate -L zsh -o extendedglob
-    REPLY=
-    if (( ZINIT[DEBUG] )); then
-        REPLY="$ZINIT[col-dbg]$1"
-    fi
-} # ]]]
-
 # FUNCTION: .zinit-formatter-auto [[[
 .zinit-formatter-auto() {
     emulate -L zsh -o extendedglob -o warncreateglobal -o typesetsilent
@@ -2166,6 +2166,10 @@ builtin setopt noaliases
     ZINIT[__last-formatter-code]=
     msg=${${(j: :)${@:#--}}//\%/%%}
 
+    if [[ -z $ZINIT[DEBUG] ]] && [[ "$msg" = (#s){dbg}* ]]; then
+        return
+    fi
+
     # First try a dedicated formatter, marking its empty output with ←→, then
     # the general formatter and in the end filter-out the ←→ from the message.
     msg=${${msg//(#b)(([\\]|(%F))([\{]([^\}]##)[\}])|([\{]([^\}]##)[\}])([^\%\{\\]#))/\
@@ -2257,14 +2261,22 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
     integer retval
     local bit exts="${(j:|:)${(@)${(@Akons:|:)${ZINIT_EXTS[ice-mods]//\'\'/}}/(#s)<->-/}}"
     for bit; do
-        [[ $bit = (#b)(--|)(${~ZINIT[ice-list]}${~exts})(*) ]] && \
-            ZINIT_ICES[${match[2]}]+="${ZINIT_ICES[${match[2]}]:+;}${match[3]#(:|=)}" || \
-            break
+        [[ $bit = (#b)(--|)(${~ZINIT[ice-list]}${~exts})(*) ]] && ZINIT_ICES[${match[2]}]+="${ZINIT_ICES[${match[2]}]:+;}${match[3]#(:|=)}" || break
         retval+=1
     done
     [[ ${ZINIT_ICES[as]} = program ]] && ZINIT_ICES[as]=command
     [[ -n ${ZINIT_ICES[on-update-of]} ]] && ZINIT_ICES[subscribe]="${ZINIT_ICES[subscribe]:-${ZINIT_ICES[on-update-of]}}"
     [[ -n ${ZINIT_ICES[pick]} ]] && ZINIT_ICES[pick]="${ZINIT_ICES[pick]//\$ZPFX/${ZPFX%/}}"
+    if (( $+ZINIT_ICES[build] )); then
+        +zi-log -- "{dbg} {ice}build{rst}: setting configure & make ices"
+        ZINIT_ICES[configure]=
+        ZINIT_ICES[make]=
+    fi
+    if (( $+ZINIT_ICES[configure] || $+ZINIT_ICES[cmake] || $+ZINIT_ICES[make] )); then
+        ZINIT_ICES[null]=
+    fi
+    (( $+ZINIT_ICES[configure] )) && ZINIT_ICES[configure]=${ZINIT_ICES[configure]:---quiet}
+    (( $+ZINIT_ICES[make] )) && ZINIT_ICES[make]=${ZINIT_ICES[make]:-install}
     return retval
 } # ]]]
 # FUNCTION: .zinit-pack-ice [[[
@@ -2951,7 +2963,7 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                     .zinit-parse-opts update "$@"
                     builtin set -- "${reply[@]}"
                     if [[ ${OPTS[opt_-a,--all]} -eq 1 || ${OPTS[opt_-p,--parallel]} -eq 1 || ${OPTS[opt_-s,--snippets]} -eq 1 || ${OPTS[opt_-l,--plugins]} -eq 1 || -z $1$2${ICE[teleid]}${ICE[id-as]} ]]; then
-                        [[ -z $1$2 && $(( OPTS[opt_-a,--all] + OPTS[opt_-p,--parallel] + OPTS[opt_-s,--snippets] + OPTS[opt_-l,--plugins] )) -eq 0 ]] && { builtin print -r -- "Assuming --all is passed"; sleep 3; }
+                        [[ -z $1$2 && $(( OPTS[opt_-a,--all] + OPTS[opt_-p,--parallel] + OPTS[opt_-s,--snippets] + OPTS[opt_-l,--plugins] )) -eq 0 ]] && { builtin print -r -- "Assuming --all is passed"; }
                         (( OPTS[opt_-p,--parallel] )) && OPTS[value]=${1:-15}
                         .zinit-update-or-status-all update; ___retval=$?
                     else
@@ -2962,7 +2974,7 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                     ;;
                 (status)
                     if [[ $2 = --all || ( -z $2 && -z $3 ) ]]; then
-                        [[ -z $2 ]] && { builtin print -r -- "Assuming --all is passed"; sleep 3; }
+                        [[ -z $2 ]] && { builtin print -r -- "Assuming --all is passed"; }
                         .zinit-update-or-status-all status; ___retval=$?
                     else
                         .zinit-update-or-status status "${2%%(///|//|/)}" "${3%%(///|//|/)}"; ___retval=$?
@@ -2970,7 +2982,7 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                     ;;
                 (report)
                     if [[ $2 = --all || ( -z $2 && -z $3 ) ]]; then
-                        [[ -z $2 ]] && { builtin print -r -- "Assuming --all is passed"; sleep 4; }
+                        [[ -z $2 ]] && { builtin print -r -- "Assuming --all is passed"; }
                         .zinit-show-all-reports
                     else
                         .zinit-show-report "${2%%(///|//|/)}" "${3%%(///|//|/)}"; ___retval=$?
@@ -3055,7 +3067,7 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                 (compile)
                     (( ${+functions[.zinit-compile-plugin]} )) || builtin source "${ZINIT[BIN_DIR]}/zinit-install.zsh" || return 1
                     if [[ $2 = --all || ( -z $2 && -z $3 ) ]]; then
-                        [[ -z $2 ]] && { builtin print -r -- "Assuming --all is passed"; sleep 3; }
+                        [[ -z $2 ]] && { builtin print -r -- "Assuming --all is passed"; }
                         .zinit-compile-uncompile-all 1; ___retval=$?
                     else
                         .zinit-compile-plugin "${2%%(///|//|/)}" "${3%%(///|//|/)}"; ___retval=$?
@@ -3068,7 +3080,7 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                     ;;
                 (uncompile)
                     if [[ $2 = --all || ( -z $2 && -z $3 ) ]]; then
-                        [[ -z $2 ]] && { builtin print -r -- "Assuming --all is passed"; sleep 3; }
+                        [[ -z $2 ]] && { builtin print -r -- "Assuming --all is passed"; }
                         .zinit-compile-uncompile-all 0; ___retval=$?
                     else
                         .zinit-uncompile-plugin "${2%%(///|//|/)}" "${3%%(///|//|/)}"; ___retval=$?
@@ -3274,6 +3286,7 @@ if [[ -e ${${ZINIT[BIN_DIR]}}/zmodules/Src/zdharma/zplugin.so ]] {
 @zinit-register-hook "configure''" hook:no-e-\!atpull-post ∞zinit-configure-hook
 @zinit-register-hook "atpull" hook:no-e-\!atpull-post ∞zinit-atpull-hook
 @zinit-register-hook "make''" hook:no-e-\!atpull-post ∞zinit-make-hook
+@zinit-register-hook "cmake''" hook:no-e-\!atpull-post +zinit-cmake-hook
 # atpull-post.
 @zinit-register-hook "compile-plugin" hook:atpull-post ∞zinit-compile-plugin-hook
 @zinit-register-hook "ps-on-update" hook:%atpull-post ∞zinit-ps-on-update-hook
@@ -3290,6 +3303,7 @@ if [[ -e ${${ZINIT[BIN_DIR]}}/zmodules/Src/zdharma/zplugin.so ]] {
 @zinit-register-hook "configure''" hook:\!atclone-post ∞zinit-configure-hook
 @zinit-register-hook "atclone" hook:\!atclone-post ∞zinit-atclone-hook
 @zinit-register-hook "make''" hook:\!atclone-post ∞zinit-make-hook
+@zinit-register-hook "cmake''" hook:\!atclone-post +zinit-cmake-hook
 # atclone-post.
 @zinit-register-hook "compile-plugin" hook:atclone-post ∞zinit-compile-plugin-hook
 


### PR DESCRIPTION
- 'configure' and 'make' ices refactored
- new 'build' ice sets 'configure' and 'make ices if no flags are needed.
- new 'cmake' ice will build/install using 'cmake'
- Delete command now handles programs using 'make' and 'cmake' ices
- zunit tests added
- Setting `ZINIT[DEBUG]` enables debug logging (i.e., `+zi-log "{dbg} message ..."`) 

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [X] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [X] All new and existing tests passed.
- [X] I have added tests to cover my changes.
- [X] I have updated the documentation accordingly.
