### PR TITLE
feat: configure, make, cmake, and build ices (#613)

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -72,30 +72,30 @@ jobs:
         shell: zsh {0}
         run: $HOME/.local/bin/zunit run --verbose tests/gh-r.zunit
       
-      - name: Run tests
-        shell: zsh {0}
-        run: |
-           command -p ls -1 ./tests/*zunit \
-             | parallel \
-             --jobs=2 \
-             --keep-order \
-             --line-buffer \
-             $HOME/.local/bin/zunit run
-
-      # - name: "annexes"
-      #   run: zunit run tests/annexes.zunit
+      - name: "annexes"
+        run: zunit run tests/annexes.zunit
       
-      # - name: "commands"
-      #   run: zunit run tests/commands.zunit
+      - name: "commands"
+        run: zunit run tests/commands.zunit
         
-      # - name: "gh-r"
-      #   run: zunit run --fail-fast --verbose tests/gh-r.zunit
+      - name: "gh-r"
+        run: zunit run tests/gh-r.zunit
       
-      # - name: "ices"
-      #   run: zunit run tests/ices.zunit
+      - name: "ices"
+        run: zunit run tests/ices.zunit
       
-      # - name: "plugins"
-      #   run: zunit run tests/plugins.zunit
+      - name: "plugins"
+        run: zunit run tests/plugins.zunit
       
-      # - name: "snippets"
-      #   run: zunit run tests/snippets.zunit
+      - name: "snippets"
+        run: zunit run tests/snippets.zunit
+
+      # - name: Run tests
+      #   shell: zsh {0}
+      #   run: |
+      #      command -p ls -1 ./tests/*zunit \
+      #        | parallel \
+      #        --jobs=2 \
+      #        --keep-order \
+      #        --line-buffer \
+      #        $HOME/.local/bin/zunit run

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,10 +1,11 @@
-name: Unit tests
+name: Unit Tests
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 env:
+  HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
   TERM: xterm-256color
 
 on:
@@ -39,40 +40,58 @@ jobs:
         id: setup-homebrew
         uses: Homebrew/actions/setup-homebrew@master
 
-      # - name: "install musl"
-      #   if: runner.os == 'Linux'
-      #   run: sudo apt-get install build-essential curl file gcc gcc-multilib glibc-source libc6 libc6-dev unzip xz-utils zsh
+      - name: "install musl"
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update --yes
+          sudo apt-get install --no-install-recommends --yes \
+            autoconf automake autotools-dev \
+            build-essential byacc\
+            file \
+            gcc gettext glibc-source grep \
+            libc6 libc6-dev libevent-dev libncurses5-dev libncursesw5-dev libtool libuvc0 lua5.1 \
+            m4 \
+            ninja-build \
+            pkg-config \
+            xz-utils
 
       - name: "install dependencies"
         id: install-deps
         run: |
-          export HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK=1
-          brew install --force --overwrite gnu-sed coreutils unzip xz zsh
+          brew install --force --overwrite autoconf automake binutils byacc cmake coreutils curl gettext gnu-sed libevent libtool libuv lua lua@5.1 make ncurses ninja parallel pkg-config texinfo unzip xz zsh
+          brew link --force --overwrite ncurses
 
       - name: "install zunit"
         id: install-zunit
         run: |
           mkdir -p "$HOME/.local/bin" && echo "$HOME/.local/bin" >> $GITHUB_PATH
           git clone --depth 1 https://github.com/zdharma-continuum/zunit; cd ./zunit
-          zsh -c -l './build.zsh' && sudo chmod u+x ./zunit && cp ./zunit "$HOME/.local/bin/"
+          zsh -l -c './build.zsh' && sudo chmod u+x ./zunit && cp ./zunit "$HOME/.local/bin/"
+      
+      - name: Run tests
+        shell: zsh {0}
+        run: |
+           command -p ls -1 ./tests/*zunit \
+             | parallel \
+             --jobs=0 \
+             --keep-order \
+             --line-buffer \
+             $HOME/.local/bin/zunit run
 
-      # - name: disable secssessment system policy security
-      #   run: sudo spctl --master-disable
-
-      - name: "annexes"
-        run: zunit run tests/annexes.zunit
-
-      - name: "commands"
-        run: zunit run tests/commands.zunit
-
-      - name: "gh-r"
-        run: zunit run --fail-fast --verbose tests/gh-r.zunit
-
-      - name: "ices"
-        run: zunit run tests/ices.zunit
-
-      - name: "plugins"
-        run: zunit run tests/plugins.zunit
-
-      - name: "snippets"
-        run: zunit run tests/snippets.zunit
+      # - name: "annexes"
+      #   run: zunit run tests/annexes.zunit
+      
+      # - name: "commands"
+      #   run: zunit run tests/commands.zunit
+        
+      # - name: "gh-r"
+      #   run: zunit run --fail-fast --verbose tests/gh-r.zunit
+      
+      # - name: "ices"
+      #   run: zunit run tests/ices.zunit
+      
+      # - name: "plugins"
+      #   run: zunit run tests/plugins.zunit
+      
+      # - name: "snippets"
+      #   run: zunit run tests/snippets.zunit

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -68,12 +68,16 @@ jobs:
           git clone --depth 1 https://github.com/zdharma-continuum/zunit; cd ./zunit
           zsh -l -c './build.zsh' && sudo chmod u+x ./zunit && cp ./zunit "$HOME/.local/bin/"
       
+      - name: "gh-r"
+        shell: zsh {0}
+        run: $HOME/.local/bin/zunit run --verbose tests/gh-r.zunit
+      
       - name: Run tests
         shell: zsh {0}
         run: |
            command -p ls -1 ./tests/*zunit \
              | parallel \
-             --jobs=0 \
+             --jobs=2 \
              --keep-order \
              --line-buffer \
              $HOME/.local/bin/zunit run

--- a/.zunit.yml
+++ b/.zunit.yml
@@ -3,5 +3,5 @@ directories:
   output: tests/_output
   support: tests/_support
   tests: tests
-fail_fast: true
+fail_fast: false
 verbose: true

--- a/doc/zsdoc/zinit-install.zsh.adoc
+++ b/doc/zsdoc/zinit-install.zsh.adoc
@@ -30,7 +30,6 @@ Documentation automatically generated with `zshelldoc'
  zicp
  ziextract
  zimv
- zpextract
  ∞zinit-atclone-hook
  ∞zinit-atpull-e-hook
  ∞zinit-atpull-hook
@@ -588,7 +587,6 @@ Called by:
  .zinit-extract
  .zinit-get-package
  .zinit-setup-plugin-dir
- zpextract
 
 ==== zimv
 
@@ -596,16 +594,6 @@ Has 3 line(s). Calls functions:
 
  zimv
  `-- zicp
-
-Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
-
-==== zpextract
-
-Has 1 line(s). Calls functions:
-
- zpextract
- `-- ziextract
-     `-- zinit.zsh/+zi-log
 
 Not called by script or any function (may be e.g. a hook, a Zle widget, etc.).
 

--- a/tests/_support/annex_test_assertions
+++ b/tests/_support/annex_test_assertions
@@ -8,3 +8,8 @@ is_annex() {
   assert ${PWD}/${${annex}//zinit-annex/z-a}.plugin.zsh is_file
   assert ${PWD}/${${annex}//zinit-annex/z-a}.plugin.zsh is_readable
 }
+
+load_bin_gem_node(){
+  run zinit load @zdharma-continuum/zinit-annex-bin-gem-node
+  zinit default-ice --quiet from'gh-r'
+}

--- a/tests/_support/bootstrap
+++ b/tests/_support/bootstrap
@@ -1,5 +1,5 @@
-#!/usr/bin/env zsh
-setopt NO_GLOBAL_RCS NO_GLOBAL_EXPORT NO_RCS
+emulate zsh
+setopt no_global_rcs no_rcs no_aliases extended_glob
 
 # Log functions [[[
 function error(){ print -P "%F{red}[ERROR]%f: ${1}" && return 1; }
@@ -19,24 +19,29 @@ if [[ ! -d ${TMP_ZUNIT} ]]; then
     exit 1
 fi
 
-typeset -gAH ZINIT;
-ZINIT[HOME_DIR]=${TMP_ZUNIT};
-ZINIT[BIN_DIR]=$ZINIT[HOME_DIR]/zinit.git;
-ZINIT[COMPLETIONS_DIR]=$ZINIT[HOME_DIR]/completions;
-ZINIT[PLUGINS_DIR]=$ZINIT[HOME_DIR]/plugins;
-ZINIT[SNIPPETS_DIR]=$ZINIT[HOME_DIR]/snippets;
-ZINIT[ZCOMPDUMP_PATH]=$ZINIT[HOME_DIR]/zcompdump;
-ZPFX=$ZINIT[HOME_DIR]/polaris;
+typeset -gx zi_test_dir="${TMP_ZUNIT}"
+typeset -gxAUH ZINIT
+# DEBUG           'true'
+ZINIT+=(
+  BIN_DIR         ${zi_test_dir}/zinit.git
+  COMPLETIONS_DIR ${zi_test_dir}/completions SNIPPETS_DIR ${zi_test_dir}/snippets
+  HOME_DIR        ${zi_test_dir}             PLUGINS_DIR  ${zi_test_dir}/plugins
+  ZCOMPDUMP_PATH  ${zi_test_dir}/zcompdump   ZPFX         ${zi_test_dir}/polaris
+  POLARIS         ${zi_test_dir}/polaris
+)
+typeset -gxH ZPFX=
+ZPFX="$zi_test_dir"/polaris
 
 command git diff > ${ZINIT[HOME_DIR]}/unstaged.diff
-info 'creating test env'
+# info 'creating test env'
 git clone \
+    --quiet \
     --depth=1 \
     --dissociate \
     --no-hardlinks \
     --reference "${GIT_REPO}" \
     file://${GIT_REPO:A} \
-    "${ZINIT[BIN_DIR]}"
+    "${ZINIT[BIN_DIR]}" >/dev/null
 if (( $? != 0 )); then
     error "Unable to copy ${GIT_REPO} to ${TMP_ZUNIT}" >&2
     exit 1
@@ -46,23 +51,28 @@ if [[ -s $ZINIT[HOME_DIR]/unstaged.diff ]]; then
     (
         git -C $ZINIT[BIN_DIR] apply $ZINIT[HOME_DIR]/unstaged.diff && \
             chmod g-rwX "${ZINIT[HOME_DIR]}" && \
-            zcompile "${ZINIT[BIN_DIR]}/zinit.zsh"
-    )
+            zcompile "${ZINIT[BIN_DIR]}/zinit.zsh" >/dev/null
+    ) >/dev/null
 fi
 (( $? != 0 )) && { error "Unable to copy ${GIT_REPO} to ${TMP_ZUNIT}" >&2; exit 1 }
 
-source $ZINIT[BIN_DIR]/zinit.zsh
-(( $? != 0 )) && { error "Unable to copy ${GIT_REPO} to ${TMP_ZUNIT}" >&2; exit 1 }
-# ]]]
-# Install Annexes [[[
-info 'installing test dependencies'
-for annex (binary-symlink default-ice); do
-  if [[ ! -d ${GIT_REPO}/tests/_support/$annex ]]; then;
-    git clone https://github.com/zdharma-continuum/zinit-annex-$annex ${GIT_REPO:A}/tests/_support/$annex
-  fi
-  zinit light ${GIT_REPO:A}/tests/_support/$annex
-  info "loaded $annex dependencies"
-done
-# ]]]
+hash -f
+builtin hash -d zinit=$zi_test_dir
+builtin hash -d zpfx=$zi_test_dir/polaris
+builtin hash -d plugins=$zi_test_dir/plugins
+source $zi_test_dir/zinit.git/zinit.zsh
+(( $? != 0 )) && { error "Unable to source zinit" >&2; exit 1 }
+hash -f
+builtin hash -d zinit=$zi_test_dir
+builtin hash -d zpfx=$zi_test_dir/polaris
+builtin hash -d plugins=$zi_test_dir/plugins
+{
+  zinit for \
+    @zdharma-continuum/zinit-annex-bin-gem-node \
+    @zdharma-continuum/zinit-annex-binary-symlink \
+    @zdharma-continuum/zinit-annex-default-ice \
+    @zdharma-continuum/zinit-annex-linkman
+}>/dev/null
 
-# vim:ft=zsh:sw=2:sts=2:et:foldmarker=[[[,]]]:foldmethod=marker
++zi-log "{m} loaded $annex dependencies"
+zinit zstatus

--- a/tests/commands.zunit
+++ b/tests/commands.zunit
@@ -51,12 +51,20 @@
   done
   run zinit -help
   assert $output contains 'Unknown subcommand'
-  assert $state equals 1  
+  assert $state equals 1
 }
 @test 'self-update' {
   run zinit self-update
   assert $output contains 'Already up-to-date.'
   assert $state equals 0
 }
-
-# vim:ft=zsh:sw=2:sts=2:et:foldmarker={,}:foldmethod=marker
+@test 'set-debug' {
+  ZINIT+=(DEBUG 'true')
+  run +zi-log -n '{dbg} message'
+  assert $output contains '[debug]'; assert $state equals 0
+}
+@test 'unset-dbg' {
+  run +zi-log -n '{dbg} message'; assert $output contains ''
+  run +zi-log -n '{m} message'
+  assert $output contains 'message'; assert $state equals 0
+}

--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -548,7 +548,7 @@
   run $mas version; assert $state equals 0
 }
 @test 'mcfly' { # Fly through your shell history. Great Scott
-  run zinit for @cantino/mcfly; assert $state equals 0
+  run zinit ver'v0.8.3' for @cantino/mcfly; assert $state equals 0
   local mcfly="$ZBIN/mcfly"; assert "$mcfly" is_executable
   run $mcfly --version; assert $state equals 0
 }

--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -1,11 +1,11 @@
 #!/usr/bin/env zunit
 
-
 @setup {
-  HOME="$ZPFX" # Stops programs creating directories in user home
-  export ZBIN="${ZPFX}/bin"
-  export os_type="${OSTYPE//[0-9\.]*/}"
-  zinit default-ice --quiet from'gh-r' lbin
+    load "${PWD}/tests/_support/annex_test_assertions"
+    HOME="$zi_test_dir" # Stops programs creating directories in user home
+    typeset -gx ZBIN="$zi_test_dir/polaris/bin" os_type="${OSTYPE//[0-9\.]*/}"
+    [[ ! -d $ZBIN ]] && mkdir -p "$ZBIN"
+    zinit default-ice --quiet from'gh-r' lbin'!' null
 }
 
 # @test 'atmos' {  Universal Tool for DevOps and Cloud Automation (works with terraform, helm, helmfile, etc)
@@ -36,7 +36,7 @@
 @test 'act' { # Run your GitHub Actions locally
   run zinit for @nektos/act; assert $state equals 0
   local act="$ZBIN/act"; assert "$act" is_executable
-  $act --version; assert $state equals 0
+  run "$act" --version; assert $state equals 0
 }
 @test 'akamai' { # Manage and configure Akamai from the Command Line.
   run zinit id-as'akamai' lbin'akamai*->akamai' for @akamai/cli; assert $state equals 0
@@ -78,7 +78,7 @@
   [[ $OSTYPE =~ 'darwin*' ]] && skip "on $os_type"
   run zinit for @imsnif/bandwhich; assert $state equals 0
   local bandwhich="$ZBIN/bandwhich"; assert "$bandwhich" is_executable
-  run $bandwhich --help; assert $state equals 0
+  run "$bandwhich" --version; assert $state equals 0
 }
 @test 'bat' { # A cat(1) clone with wings
   run zinit for @sharkdp/bat; assert $state equals 0
@@ -473,12 +473,12 @@
   local just="$ZBIN/just"; assert "$just" is_executable
   run $just --version; assert $state equals 0
 }
-@test 'keepassxc' { # a cross-platform community-driven port of the Windows application Keepass Password Safe
-  [[ $OSTYPE =~ 'linux*' ]] && skip "skipped on $os_type"
-  run zinit for lbin'!*-cli -> keepassxc-cli' @keepassxreboot/keepassxc; assert $state equals 0
-  local keepassxc="$ZBIN/keepassxc-cli"; assert "$keepassxc" is_executable
-  run $keepassxc --version; assert $state equals 0
-}
+# @test 'keepassxc' { # a cross-platform community-driven port of the Windows application Keepass Password Safe
+#   [[ $OSTYPE =~ 'linux*' ]] && skip "skipped on $os_type"
+#   run zinit for lbin'!*-cli -> keepassxc-cli' @keepassxreboot/keepassxc; assert $state equals 0
+#   local keepassxc="$ZBIN/keepassxc-cli"; assert "$keepassxc" is_executable
+#   run $keepassxc --version; assert $state equals 0
+# }
 @test 'ko' { # Build and deploy Go applications on Kubernetes
   run zinit for @ko-build/ko; assert $state equals 0
   local ko="$ZBIN/ko"; assert "$ko" is_executable
@@ -498,6 +498,16 @@
   run zinit for id-as'kubedb' lbin'*->kubedb' @kubedb/cli; assert $state equals 0
   local cli="$ZBIN/kubedb"; assert "$cli" is_executable
   run "$cli" version; assert $state equals 0
+}
+@test 'kubectl-plugins' { # Faster way to switch between clusters and namespaces in kubectl
+  [[ $OSTYPE =~ 'darwin*' ]] && skip "skipped on $os_type"
+  load_bin_gem_node
+  run zinit for bpick'kubectx;kubens' sbin'kubectx;kubens' @ahmetb/kubectx
+  local bin prog
+  for bin in 'kubectx' 'kubens'; do
+    prog="$ZBIN/${bin}"; assert "$prog" is_executable;
+    run "$prog" --help; assert $state equals 0
+  done
 }
 @test 'lazygit' { # simple terminal UI for git commands
   run zinit for @jesseduffield/lazygit; assert $state equals 0
@@ -550,12 +560,36 @@
 @test 'mcfly' { # Fly through your shell history. Great Scott
   run zinit ver'v0.8.3' for @cantino/mcfly; assert $state equals 0
   local mcfly="$ZBIN/mcfly"; assert "$mcfly" is_executable
-  run $mcfly --version; assert $state equals 0
+  run "$mcfly" --version; assert $state equals 0
 }
-@test 'mdbook' { # Create book from markdown files. Like Gitbook but implemented in Rust
-  run zinit for @rust-lang/mdBook; assert $state equals 0
-  local mdbook="$ZBIN/mdbook"; assert "$mdbook" is_executable
-  run $mdbook --version; assert $state equals 0
+@test 'mdbook-lbin' { # Create book from markdown files. Like Gitbook but implemented in Rust
+  local mdbook="$ZBIN/mdbook";
+  run zinit for @rust-lang/mdBook; assert $state equals 0 assert "$mdbook" is_executable
+
+  run "$mdbook" --version; assert $state equals 0
+
+  run command file "$(command realpath ${mdbook})"; assert $output contains 'executable'
+
+  run zinit delete --yes rust-lang/mdBook; assert $state equals 0
+
+  run "$mdbook" --version;
+  assert $state equals 127; assert $output contains 'no such file or directory'
+}
+@test 'mdbook-sbin' { # Create book from markdown files. Like Gitbook but implemented in Rust
+  load_bin_gem_node
+  local mdbook="$ZBIN/mdbook";
+
+  run zinit from'gh-r' sbin"mdbook" for @rust-lang/mdBook; assert $state equals 0 assert "$mdbook" is_executable
+
+  run "$mdbook" --version; assert $state equals 0
+
+  run command file "$(command realpath ${mdbook})";
+  assert $output contains 'zsh script'; assert $output contains 'ASCII text'
+
+  run zinit delete --yes rust-lang/mdBook; assert $state equals 0
+
+  run "$mdbook" --version;
+  assert $state equals 127; assert $output contains 'no such file or directory'
 }
 @test 'mdcat' { # cat for markdown
   run zinit for @swsnr/mdcat; assert $state equals 0

--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -540,48 +540,23 @@
 @test 'mdbook-lbin' { # Create book from markdown files. Like Gitbook but implemented in Rust
   local mdbook="$ZBIN/mdbook";
   run zinit for @rust-lang/mdBook; assert $state equals 0 assert "$mdbook" is_executable
-
   run "$mdbook" --version; assert $state equals 0
-
   run command file "$(command realpath ${mdbook})"; assert $output contains 'executable'
-
   run zinit delete --yes rust-lang/mdBook; assert $state equals 0
-
   run "$mdbook" --version;
   assert $state equals 127; assert $output contains 'no such file or directory'
 }
-@test 'mdbook-lbin' { # Create book from markdown files. Like Gitbook but implemented in Rust
-  run zinit for @rust-lang/mdBook; assert $state equals 0
-  local mdbook="$ZBIN/mdbook"; assert "$mdbook" is_executable
-  run "$mdbook" --version; assert $state equals 0
-  run file "$mdbook"; assert $output contains 'executable'
-  zinit delete --yes rust-lang/mdBook;
-  run "$mdbook" --version; assert $state equals 127; assert $output contains 'no such file or directory'
-}
 @test 'mdbook-sbin' { # Create book from markdown files. Like Gitbook but implemented in Rust
   load_bin_gem_node
-  run zinit from'gh-r' sbin"mdbook" for @rust-lang/mdBook; assert $state equals 0
-  local mdbook="$ZBIN/mdbook"; assert "$mdbook" is_executable
+  local mdbook="$ZBIN/mdbook";
+  run zinit from'gh-r' sbin"mdbook" for @rust-lang/mdBook; assert $state equals 0 assert "$mdbook" is_executable
   run "$mdbook" --version; assert $state equals 0
-  run file "$mdbook"; assert $output contains 'zsh script'; assert $output contains 'ASCII text'
-  zinit delete --yes rust-lang/mdBook; assert $state equals 0
-  run "$mdbook" --version; assert $state equals 127; assert $output contains 'no such file or directory'
-# @test 'mdbook-sbin' { # Create book from markdown files. Like Gitbook but implemented in Rust
-#   load_bin_gem_node
-#   local mdbook="$ZBIN/mdbook";
-
-#   run zinit from'gh-r' sbin"mdbook" for @rust-lang/mdBook; assert $state equals 0 assert "$mdbook" is_executable
-
-#   run "$mdbook" --version; assert $state equals 0
-
-#   run command file "$(command realpath ${mdbook})";
-#   assert $output contains 'zsh script'; assert $output contains 'ASCII text'
-
-#   run zinit delete --yes rust-lang/mdBook; assert $state equals 0
-
-#   run "$mdbook" --version;
-#   assert $state equals 127; assert $output contains 'no such file or directory'
-# }
+  run command file "$(command realpath ${mdbook})";
+  assert $output contains 'zsh script'; assert $output contains 'ASCII text'
+  run zinit delete --yes rust-lang/mdBook; assert $state equals 0
+  run "$mdbook" --version;
+  assert $state equals 127; assert $output contains 'no such file or directory'
+}
 @test 'mdcat' { # cat for markdown
   run zinit for @swsnr/mdcat; assert $state equals 0
   local mdcat="$ZBIN/mdcat"; assert "$mdcat" is_executable

--- a/tests/ices.zunit
+++ b/tests/ices.zunit
@@ -34,7 +34,7 @@
   assert "$ZPLUGINS/test---atclone/readme.md" not_exists
 }
 @test 'make' {
-  run zinit as"null" id-as"test/make" atclone"printf 'all:\n\ttouch whatever\n' > Makefile" make"" for zdharma-continuum/null
+  run zinit as"null" id-as"test/make" atclone"printf 'all:\n\ttouch whatever\n' > Makefile" make"all" for zdharma-continuum/null
   assert $state equals 0
   assert "$ZPLUGINS/test---make/whatever" is_file
 }

--- a/tests/plugins.zunit
+++ b/tests/plugins.zunit
@@ -1,55 +1,125 @@
 #!/usr/bin/env zunit
 
-
 @setup {
-  zinit default-ice as'null' light-mode nocompile nocompletions
-  ZBIN=$ZPFX/bin
-  export LC_CTYPE=C
-  export LANG=C
+  HOME="$zi_test_dir"
+  typeset -gx ZBIN="$zi_test_dir/polaris/bin"
 }
 
-# @test 'nnn' {
-#   run zinit light-mode for jarun/nnn
-#   zinit cd jarun/nnn
-#   run PREFIX=$ZPFX make install; assert $state equals 0
-#   local nnn="$ZPFX/bin/nnn";     assert $nnn   is_executable
-#   $nnn -V;                       assert $state equals 0
+# @test 'cmatrix' {
+#   run zinit build for @abishekvashok/cmatrix;
+#   local cmatrix="$ZBIN/cmatrix"; assert "$cmatrix" is_executable
+#   run "$cmatrix" -V; assert $state equals 0
+#   # ensure cmake artifacts are deleted
+#   zinit delete --yes abishekvashok/cmatrix; assert $state equals 0
+#   run "$cmatrix"; assert $state equals 127
 # }
-@test 'pipes' {
-  run zinit for @pipeseroni/pipes.sh
-  # zinit cd pipeseroni/pipes.sh
-  run zinit run pipeseroni/pipes.sh make PREFIX=$ZPFX install; assert $state equals 0
-  local pipes="$ZBIN/pipes.sh"; assert $pipes is_executable
-  $pipes -v; assert $state equals 0
+@test 'figlet' {
+  run zinit make for @cmatsuoka/figlet; assert $state equals 0
+  local figlet="$ZBIN/figlet"; assert "$figlet" is_executable
+  run "$figlet" -I 1; assert $state equals 0
 }
-@test 'tree' {
-  run zinit light-mode for Old-Man-Programmer/tree
-  zinit cd Old-Man-Programmer/tree
-  run make PREFIX=$ZPFX install; assert $state equals 0
-  local tree="$ZBIN/tree";   assert $tree  is_executable
-  $tree -v;                      assert $state equals 0
+@test 'htop' {
+  run zinit build for @htop-dev/htop; assert $state equals 0
+  local htop="$ZBIN/htop"; assert "$htop" is_executable
+  run "$htop" --version; assert $state equals 0
+}
+@test 'bash' {
+  run zinit build for @bminor/bash; assert $state equals 0
+  local bash="$ZBIN/bash"; assert $bash is_executable
+  run "$bash" --version; assert $state equals 0
+}
+@test 'ctags' {
+  run zinit build for @universal-ctags/ctags; assert $state equals 0
+  local ctags="$ZBIN/ctags"; assert "$ctags" is_executable
+  run "$ctags" --version; assert $state equals 0
+}
+@test 'lua-format' {
+  run zinit cmake for @Koihik/LuaFormatter; assert $state equals 0
+  local lua_format="$ZBIN/lua-format"; assert "$lua_format" is_executable
+  run "$lua_format" --version; assert $state equals 0
+  run zinit delete --yes Koihik/LuaFormatter; assert $state equals 0
+  run "$lua_format" --version; assert $state equals 127
+}
+@test 'jq' {
+  run zinit build for @jqlang/jq; assert $state equals 0
+  local jq="$ZBIN/jq"; assert "$jq" is_executable
+  run "$jq" --version; assert $state equals 0
+}
+@test 'ncurses' {
+  run zinit configure'--enable-widec --enable-termcap' make for @mirror/ncurses; assert $state equals 0
+  local ncurses="$ZBIN/clear"; assert "$ncurses" is_executable
+  run "$ncurses" -V; assert $state equals 0
+  run zinit delete --yes mirror/ncurses; assert $state equals 0
+  run "$ncurses" -V; assert $state equals 127
+}
+@test 'neofetch' {
+  run zinit make for @dylanaraps/neofetch; assert $state equals 0
+  local neofetch="$ZBIN/neofetch"; assert "$neofetch" is_executable
+  run "$neofetch" --version; assert $state equals 1; assert $output contains 'Neofetch'
+}
+@test 'neovim-make' {
+  run zinit make for @neovim/neovim; assert $state equals 0
+  local neovim="$ZBIN/nvim"; assert $neovim is_executable
+  run "$neovim" --version; assert $state equals 0
+
+  nvim_ver="$($neovim --version | head -n1 | awk '{print $2}')";
+  nvim_commit="$(git --work-tree=$ZINIT[PLUGINS_DIR]/neovim---neovim rev-parse --short HEAD)";
+  print -lPr " " "nvim ver: %F{blue}$nvim_ver%f" "nvim commit sha: %F{blue}$nvim_commit%f" "check: [[ %F{blue}$nvim_ver%f = %F{blue}*$nvim_commit(#e)%f ]]"
+  [[ $nvim_ver = *$nvim_commit(#e) ]] && print -P "%F{green}ok%f"
+  run zinit delete --yes neovim/neovim; assert $state equals 0
+  run "$neovim" --version; assert $state equals 127
+}
+# @test 'neovim-cmake' {
+#   run zinit cmake for @neovim/neovim; assert $state equals 0
+#   local neovim="$ZBIN/nvim"; assert $neovim is_executable
+#   run "$neovim" --version; assert $state equals 0
+#
+#   nvim_ver="$($neovim --version | head -n1 | awk '{print $2}')";
+#   nvim_commit="$(git --work-tree=$ZINIT[PLUGINS_DIR]/neovim---neovim rev-parse --short HEAD)";
+#   print -lPr " " "nvim ver: %F{blue}$nvim_ver%f" "nvim commit sha: %F{blue}$nvim_commit%f" "check: [[ %F{blue}$nvim_ver%f = %F{blue}*$nvim_commit(#e)%f ]]"
+#   [[ $nvim_ver = *$nvim_commit(#e) ]] && print -P "%F{green}ok%f"
+#
+#   run zinit delete --yes neovim/neovim; assert $state equals 0
+# }
+@test 'tmux' {
+  if [[ $OSTYPE =~ 'darwin*' ]]; then
+    run zinit configure'--disable-utf8proc' make for @tmux/tmux; assert $state equals 0
+  else
+    run zinit build for @tmux/tmux; assert $state equals 0
+  fi
+  local tmux="$ZBIN/tmux"; assert $tmux is_executable
+  run "$tmux" -V; assert $state equals 0
+  run zinit delete --yes tmux/tmux; assert $state equals 0
+  run "$tmux" -V; assert $state equals 127
 }
 @test 'vim' {
-  run zinit light-mode for vim/vim
-  zinit cd vim/vim
-  run ./configure --prefix=$ZPFX && make PREFIX=$ZPFX install
-  assert $state equals 0
+  run zinit build for @vim/vim; assert $state equals 0
   local vim="$ZBIN/vim"; assert $vim is_executable
-  $vim --version; assert $state equals 0
+  run "$vim" --version; assert $state equals 0
+  # run zinit delete --yes vim/vim; assert $state equals 0
 }
-@test 'zsh-completions' {
-  run zinit light-mode for zsh-users/zsh-completions
-  zinit cd zsh-users/zsh-completions
-  run zinit creinstall -q .; assert $state equals 0
-  local broken_completions=($(echo "$ZINIT[COMPLETIONS_DIR]"/*(-@))); assert "${#broken_completions[@]}" equals 0
+@test 'zsh' {
+  # run zinit configure'--with-tcsetpgrp' make'install.bin' for @zsh-users/zsh; assert $state equals 0
+  run zinit configure'--with-tcsetpgrp' atclone"./Util/preconfig"  make'install.bin' for @zsh-users/zsh; assert $state equals 0
+  local zsh="$ZBIN/zsh"; assert $zsh is_executable
+  run "$zsh" --version; assert $state equals 0
+  run zinit delete --yes zsh-users/zsh; assert $state equals 0
+  run "$zsh" --version; assert $state equals 127
 }
-# @test 'zsh_bin' {
-#   run zinit as'null' sbin'bin/zsh' for @romkatv/zsh-bin
-#   assert $state equals 0
-#   local zsh_static="$ZPFX/bin/zsh"
-#   assert "$zsh_static" is_executable
-#   $zsh_static --help
-#   assert $state equals 0
+
+# ===========
+# Flaky tests
+# ===========
+# @test 'stow' {
+#   run zinit configure'--without-pmdir' make for @aspiers/stow; assert $state equals 0
+#   local stow="$ZBIN/stow"; assert "$stow" is_executable
+#   run "$stow" --version; assert $state equals 0
+# }
+# @test 'zsh-completions' {
+#   run zinit light-mode for zsh-users/zsh-completions
+#   zinit cd zsh-users/zsh-completions
+#   run zinit creinstall -q .; assert $state equals 0
+#   local broken_completions=($(echo "$ZINIT[COMPLETIONS_DIR]"/*(-@N))); assert "$#broken_completions[@]" equals 0
 # }
 
-# vim:ft=zsh:sw=2:sts=2:et:foldmarker=@test,}:foldmethod=marker
+# vim:ft=zsh:sw=2:sts=2:et:foldmarker={,}:foldmethod=indent

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -1199,76 +1199,79 @@ EOF
 #
 # $1 - snippet url or plugin
 .zinit-delete () {
-    emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
-    setopt extendedglob noksharrays nokshglob nullglob typesetsilent warncreateglobal
+    setopt local_options extended_glob no_ksh_arrays no_ksh_glob null_glob typeset_silent warn_create_global
     local o_all o_clean o_debug o_help o_verbose o_yes rc
     local -a usage=(
-      'Usage:'
-      '  zinit delete [options] [plugins...]'
-      ' '
-      'Options:'
-      '  -a, --all      Delete all installed plugins, snippets, and completions'
-      '  -c, --clean    Delete unloaded plugins and snippets'
-      '  -h, --help     Show list of command-line options'
-      '  -y, --yes      Don´t prompt for user confirmation'
+        'Usage:'
+        '  zinit delete [options] [plugins...]'
+        ' '
+        'Options:'
+        '  -a, --all      Delete all installed plugins, snippets, and completions'
+        '  -c, --clean    Delete unloaded plugins and snippets'
+        '  -h, --help     Show list of command-line options'
+        '  -y, --yes      Don´t prompt for user confirmation'
     )
     zmodload zsh/zutil
     zparseopts -D -E -F -K -- \
-      {a,-all}=o_all \
-      {c,-clean}=o_clean \
-      {d,-dry-run}=o_debug \
-      {h,-help}=o_help \
-      {y,-yes}=o_yes \
+        {a,-all}=o_all \
+        {c,-clean}=o_clean \
+        {d,-dry-run}=o_debug \
+        {h,-help}=o_help \
+        {y,-yes}=o_yes \
     || return 1
     (( $#o_help )) && {
-      print -l -- $usage
-      return 0
+        print -l -- $usage
+        return 0
     }
     (( $#o_clean && $#o_all )) && {
         +zi-log "{e} Invalid usage: Options --all and --clean are mutually exclusive"
         return 1
     }
     (( $#o_clean )) && {
-      local -a unld_plgns
-      local -aU ld_snips unld_snips del_list
-      local snip plugin _retval dir=${${ZINIT[SNIPPETS_DIR]%%[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/xyzcba231}
-
-      unld_snips=( $dir/*/*/*(ND/) $dir/*/*(ND/) $dir/*(ND/) )
-      ld_snips=(${${ZINIT_SNIPPETS[@]% <*>}/(#m)*/$(.zinit-get-object-path snippet "$MATCH" && builtin print -rn -- $REPLY; )})
-      del_list=(${unld_snips[@]:#*/(${(~j:|:)ld_snips}|*/plugins|._backup|._zinit|.svn|.git)(|/*)})
-      del_list=(${del_list[@]//(#m)*/$( .zinit-get-object-path snippet "${${${MATCH##${dir}[/[:space:]]#}/(#i)(#b)(http(s|)|ftp(s|)|ssh|rsync)--/${match[1]##--}://}//--//}" && builtin print -r -- $REPLY)})
-      del_list=(${del_list[@]:#(${(~j:|:)ld_snips}|*/plugins|*/._backup|*/._zinit|*/.svn|*/.git)(|/*)})
-      unld_snips=(${${${(@)${(@)del_list##$dir/#}//(#i)(#m)(http(s|)|ftp(s|)|ssh|rsync)--/${MATCH%--}://}//--//}//(#b)(*)\/([^\/]##)(#e)/$match[1]/$ZINIT[col-file]$match[2]$ZINIT[col-rst]})
-      unld_snips=(${unld_snips[@]//(#m)(#s)[^\/]##(#e)/$ZINIT[col-file]$MATCH$ZINIT[col-rst]})
-      del_list=(${${${(@)${(@)del_list##$dir/#}//(#i)(#m)(http(s|)|ftp(s|)|ssh|rsync)--/${MATCH%--}://}//--//}//(#b)(*)\/([^\/]##)(#e)/$match[1]/$match[2]})
-      unld_plgns=(${${ZINIT[PLUGINS_DIR]%%[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/abcEFG312}/*~*/(${(~j:|:)${ZINIT_REGISTERED_PLUGINS[@]//\//---}})(ND/))
-      unld_plgns=(${(@)${unld_plgns[@]##$ZINIT[PLUGINS_DIR]/#}//---//})
-      # delete unloaded snippets & plugins
-      (( $#del_list || $#unld_plgns )) && {
-        +zi-log "{m} Deleting {num}${#unld_snips}{rst} unloaded snippets:" $unld_snips
-        +zi-log "{m} Deleting {num}${#unld_plgns}{rst} unloaded plugins:" $unld_plgns
-        if (( $#o_yes )) || ( .zinit-prompt "delete ${#unld_snips} snippets and ${#unld_plgns} plugins?"); then
-          for snip in $del_list $unld_plgns ; do
-            zinit delete --yes "$snip"
-            _retval+=$?
-          done
-          return _retval
-        fi
-      } || {
-        +zi-log "{m} No unloaded plugins or snippets to delete"
-        return 0
-      }
+        local -a unld_plgns
+        local -aU ld_snips unld_snips del_list
+        local snip plugin _retval dir=${${ZINIT[SNIPPETS_DIR]%%[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/xyzcba231}
+        unld_snips=($dir/*/*/*(ND/) $dir/*/*(ND/) $dir/*(ND/))
+        ld_snips=(${${ZINIT_SNIPPETS[@]% <*>}/(#m)*/$(.zinit-get-object-path snippet "$MATCH" && builtin print -rn -- $REPLY; )})
+        del_list=(${unld_snips[@]:#*/(${(~j:|:)ld_snips}|*/plugins|._backup|._zinit|.svn|.git)(|/*)})
+        del_list=(${del_list[@]//(#m)*/$( .zinit-get-object-path snippet "${${${MATCH##${dir}[/[:space:]]#}/(#i)(#b)(http(s|)|ftp(s|)|ssh|rsync)--/${match[1]##--}://}//--//}" && builtin print -r -- $REPLY)})
+        del_list=(${del_list[@]:#(${(~j:|:)ld_snips}|*/plugins|*/._backup|*/._zinit|*/.svn|*/.git)(|/*)})
+        unld_snips=(${${${(@)${(@)del_list##$dir/#}//(#i)(#m)(http(s|)|ftp(s|)|ssh|rsync)--/${MATCH%--}://}//--//}//(#b)(*)\/([^\/]##)(#e)/$match[1]/$ZINIT[col-file]$match[2]$ZINIT[col-rst]})
+        unld_snips=(${unld_snips[@]//(#m)(#s)[^\/]##(#e)/$ZINIT[col-file]$MATCH$ZINIT[col-rst]})
+        unld_snips+=($(builtin print -- "${ZINIT[HOME_DIR]}"/snippets/*(/N^F:t)))
+        del_list=(${${${(@)${(@)del_list##$dir/#}//(#i)(#m)(http(s|)|ftp(s|)|ssh|rsync)--/${MATCH%--}://}//--//}//(#b)(*)\/([^\/]##)(#e)/$match[1]/$match[2]})
+        unld_plgns=(${${ZINIT[PLUGINS_DIR]%%[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/abcEFG312}/*~*/(${(~j:|:)${ZINIT_REGISTERED_PLUGINS[@]//\//---}})(ND/))
+        unld_plgns=(${(@)${unld_plgns[@]##$ZINIT[PLUGINS_DIR]/#}//---//})
+        (( $#del_list || $#unld_plgns || $#unld_snips )) && {
+            (( $#unld_snips )) && +zi-log "{m} Deleting {num}${#unld_snips}{rst} unloaded snippets:" $unld_snips
+            (( $#unld_plgns )) && +zi-log "{m} Deleting {num}${#unld_plgns}{rst} unloaded plugins:" $unld_plgns
+            if (( $#o_yes )) || (.zinit-prompt "Delete ${#unld_snips} snippets and ${#unld_plgns} plugins?"); then
+                for snip in $del_list $unld_plgns $unld_snips; do
+                    zinit delete --yes "$snip"
+                    _retval+=$?
+                done
+                return _retval
+            else
+                return 0
+            fi
+        } || {
+            +zi-log "{m} No unloaded plugins or snippets to delete"
+            return 0
+        }
     }
+    local i
     if (( $#o_all && !$#o_clean )); then
-        local -a all_installed=(${${ZINIT[PLUGINS_DIR]}%%[/[:space:]]##}/*~*/_local---zinit(/ND) ${${ZINIT[SNIPPETS_DIR]}%%[/[:space:]]##}/*~*/plugins(/ND))
-        if (( $#o_yes )) || ( .zinit-prompt "Delete all plugins and snippets (${#all_installed} total)"); then
-            command rm -rf -- ${(@)all_installed}
-            command rm -f -- $ZINIT[HOME_DIR]/**/*(-@N)
+        local -a all_installed=($(cat "${ZINIT[HOME_DIR]}"/{'snippets','plugins'}/*/(*/)#teleid(N)))
+        if (( $#o_yes )) || (.zinit-prompt "Delete all plugins and snippets (${#all_installed} total)"); then
+            for i in $all_installed; do
+                zinit delete --yes "${i}"
+            done
+            command rm -f -- "${ZINIT[HOME_DIR]}"/**/*(-@N)
             for f in ${(M)${(k)ZINIT[@]}:##STATES__*~*local/zinit*}; do
-              builtin unset "ZINIT[$f]"
+                builtin unset "ZINIT[$f]"
             done
             local rc=$?
-            +zi-log "{m} Deleted all completed with return code {num}${rc}{rst}"
+            +zi-log "{m} Delete completed with return code {num}${rc}{rst}"
             return $rc
         fi
         return 1
@@ -1277,14 +1280,13 @@ EOF
         +zi-log "{e} Invalid usage: This command requires at least 1 plugin or snippet argument."
         return 0
     }
-    local i
-    if (( $#o_yes )) || ( .zinit-prompt "Delete ${(j:, :)@}"); then
+    if (( $#o_yes )) || (.zinit-prompt "Delete ${(j:, :)@}"); then
         for i in $@; do
             local -A ICE=() ICE2=()
             local the_id="${${i:#(%|/)*}}" filename is_snippet local_dir
             .zinit-compute-ice "$the_id" "pack" ICE2 local_dir filename is_snippet || return 1
             if [[ "$local_dir" != /* ]]; then
-                +zi-log "{w} No available plugin or snippet with the name '$i'"
+                +zi-log "{w} No available plugin or snippet with the name '{b}$i{rst}'"
                 return 1
             fi
             ICE2[teleid]="${ICE2[teleid]:-${ICE2[id-as]}}"
@@ -1300,12 +1302,12 @@ EOF
                     .zinit-any-to-user-plugin "${ICE2[teleid]}"
                     .zinit-run-delete-hooks plugin "${reply[-2]}" "${reply[-1]}" "$the_id" "$local_dir"
                 }
-                command rm -rf -- ${(q)${${local_dir:#[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/abcYZX321}}(N) # delete files
-                command rm -f -- $ZINIT[HOME_DIR]/**/*(-@N) # delete broken symlins
+                command rm -rf -- ${(q)${${local_dir:#[/[:space:]]##}:-${TMPDIR:-${TMPDIR:-/tmp}}/abcYZX321}}(N)
+                command rm -f -- $ZINIT[HOME_DIR]/**/*(-@N)
                 builtin unset "ZINIT[STATES__${ICE2[id-as]}]" || builtin unset "ZINIT[STATES__${ICE2[teleid]}]"
-                +zi-log "{m} Uninstalled $i"
+                (( quiet )) || +zi-log "{m} Uninstalled {b}$i{rst}"
             else
-                +zi-log "{w} No available plugin or snippet with the name '$i'"
+                +zi-log "{w} No available plugin or snippet with the name '{b}$i{rst}'"
                 return 1
             fi
         done

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -1279,8 +1279,8 @@ EOF
     }
     local i
     if (( $#o_yes )) || ( .zinit-prompt "Delete ${(j:, :)@}"); then
-        local -A ICE ICE2
         for i in $@; do
+            local -A ICE=() ICE2=()
             local the_id="${${i:#(%|/)*}}" filename is_snippet local_dir
             .zinit-compute-ice "$the_id" "pack" ICE2 local_dir filename is_snippet || return 1
             if [[ "$local_dir" != /* ]]; then
@@ -1697,24 +1697,38 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
     done
 } # ]]]
 # FUNCTION: .zinit-run-delete-hooks [[[
-.zinit-run-delete-hooks() {
-    if [[ -n ${ICE[atdelete]} ]]; then
-        .zinit-countdown "atdelete" && ( (( ${+ICE[nocd]} == 0 )) && \
-                { builtin cd -q "$5" && eval "${ICE[atdelete]}"; ((1)); } || \
-                eval "${ICE[atdelete]}" )
+.zinit-run-delete-hooks () {
+    local make_path=$5/Makefile mfest_path=$5/build/install_manifest.txt quiet='2>/dev/null 1>&2' 
+    if [[ -f $make_path ]] && grep '^uninstall' $make_path &> /dev/null; then
+        +zi-log -n "{m} Make uninstall... "
+        eval 'command make -C ${make_path:h} {prefix,{,CMAKE_INSTALL_}PREFIX}=$ZINIT[ZPFX] --ignore-errors uninstall' 2>/dev/null 1>&2
+        if (( $? == 0 )); then
+            +zi-log " [{happy}OK{rst}]"
+        else
+            +zi-log " [{error}Failed{rst}]"
+        fi
+    elif [[ -f $mfest_path ]]; then
+        +zi-log -n "{m} Cmake uninstall... "
+        if { command cmake --build ${mfest_path:h} --target uninstall || xargs rm -rf < "$mfest_path" } &>/dev/null ; then
+            +zi-log " [{happy}OK{rst}]"
+        else
+            +zi-log " [{error}Failed{rst}]"
+        fi
     fi
-
+    eval 'find $ZINIT[ZPFX] -depth -type d -empty -delete' &> /dev/null
+    if [[ -n ${ICE[atdelete]} ]]; then
+        (
+            (( ${+ICE[nocd]} == 0 )) && {
+                builtin cd -q "$5" && eval "${ICE[atdelete]}"
+                ((1))
+            } || eval "${ICE[atdelete]}"
+        )
+    fi
     local -a arr
     local key
-
-    # Run annexes' atdelete hooks
-    reply=(
-        ${(on)ZINIT_EXTS2[(I)zinit hook:atdelete-pre <->]}
-        ${(on)ZINIT_EXTS[(I)z-annex hook:atdelete-<-> <->]}
-        ${(on)ZINIT_EXTS2[(I)zinit hook:atdelete-post <->]}
-    )
+    reply=(${(on)ZINIT_EXTS2[(I)zinit hook:atdelete-pre <->]} ${(on)ZINIT_EXTS[(I)z-annex hook:atdelete-<-> <->]} ${(on)ZINIT_EXTS2[(I)zinit hook:atdelete-post <->]}) 
     for key in "${reply[@]}"; do
-        arr=( "${(Q)${(z@)ZINIT_EXTS[$key]:-$ZINIT_EXTS2[$key]}[@]}" )
+        arr=("${(Q)${(z@)ZINIT_EXTS[$key]:-$ZINIT_EXTS2[$key]}[@]}") 
         "${arr[5]}" "$1" "$2" $3 "$4" "$5" "${${key##(zinit|z-annex) hook:}%% <->}" delete:TODO
     done
 } # ]]]

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1713,7 +1713,7 @@ ziextract() {
 
     case "${${ext:+.$ext}:-$file}" in
         ((#i)*.zip)
-            →zinit-extract() { →zinit-check unzip "$file" || return 1; command unzip -o "$file"; }
+            →zinit-extract() { →zinit-check unzip "$file" || return 1; command unzip -qq -o "$file"; }
             ;;
         ((#i)*.rar)
             →zinit-extract() { →zinit-check unrar "$file" || return 1; command unrar x "$file"; }

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1923,10 +1923,6 @@ ziextract() {
         }
     )
 } # ]]]
-# FUNCTION: zpextract [[[
-zpextract() {
-  ziextract "$@"
-} # ]]]
 # FUNCTION: .zinit-at-eval [[[
 .zinit-at-eval() {
     local atpull="$1" atclone="$2"

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1194,7 +1194,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                     "accessible (wrong permissions).{rst}"
                 retval=4
             }
-            if ! (( ${+ICE[link] )) {
+            if ! (( ${+ICE[link]} )) {
                 if (( !OPTS[opt_-q,--quiet] )) && [[ $url != /dev/null ]] {
                     +zi-log "{msg}Copying {file}$filename{msg}{…}{rst}"
                     command cp -vf "$url" "$local_dir/$dirname/$filename" || \

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -341,9 +341,8 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     if [[ $tpe != tarball ]] {
         if [[ -z $update ]] {
             .zinit-any-colorify-as-uspl2 "$user" "$plugin"
-            local pid_hl='{pid}' id_msg_part=" (at label{ehi}:{rst} {id-as}$id_as{rst}{…})"
-            (( $+ICE[pack] )) && local infix_m="({b}{ice}pack{apo}''{rst}) "
-            +zi-log "{nl}Downloading $infix_m{pid}$user${user:+/}$plugin{…}${${${id_as:#$user/$plugin}}:+$id_msg_part}"
+            local pid_hl='{pid}' id_msg_part=" (at label: {id-as}$id_as{rst})"
+            +zi-log "{nl}{i} Downloading {b}{file}$user${user:+/}$plugin{rst} ${${${id_as:#$user/$plugin}}:+$id_msg_part}{rst}"
         }
 
         local site
@@ -378,7 +377,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                         { local old_version="$(<$local_path/._zinit/is_release${count:#1})"; } 2>/dev/null
                         old_version=${old_version/(#b)(\/[^\/]##)(#c4,4)\/([^\/]##)*/${match[2]}}
                     }
-                    +zi-log "(Requesting \`${REPLY:t}'${version:+, version $version}{…}${old_version:+ Current version: $old_version.})"
+                    +zi-log "{m} Requesting ${REPLY:t} ${version:+, version $version} ${old_version:+ Current version: $old_version.}{rst}"
                     if { ! .zinit-download-file-stdout "$url" 0 1 >! "${REPLY:t}" } {
                         if { ! .zinit-download-file-stdout "$url" 1 1 >! "${REPLY:t}" } {
                             command rm -f "${REPLY:t}"
@@ -830,7 +829,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     .zinit-compute-ice "$id_as" "pack" \
         ICE plugin_dir filename is_snippet || return 1
 
-    # when from"gh-r" ice set, skip compile unless compile ice is set 
+    # when from"gh-r" ice set, skip compile unless compile ice is set
     if [[ ${ICE[from]} = gh-r ]] && (( ${+ICE[compile]} == 0 )); then
         +zi-log '{dbg} from"gh-r" detected, skipping compile'
         return 0
@@ -992,7 +991,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
             (
                 () { setopt localoptions noautopushd; builtin cd -q "$local_dir"; } || return 4
 
-                (( !OPTS[opt_-q,--quiet] )) && +zi-log "Downloading {apo}\`{url}$sname{apo}\`{rst}${${ICE[svn]+" (with Subversion)"}:-" (with curl, wget, lftp)"}{…}"
+                (( !OPTS[opt_-q,--quiet] )) && +zi-log "{i} Downloading {file}$sname{rst} ${${ICE[svn]+" (with Subversion)"}:-" (with curl, wget, lftp)"}{rst}"
 
                 if (( ${+ICE[svn]} )) {
                     if [[ $update = -u ]] {
@@ -1503,7 +1502,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
       _sys='pc-windows-gnu'
       ;;
     (*)
-      +zi-log "{info}[{pre}gh-r{info}]{error} Unsupported OS: {obj}${_os}{rst}"
+      +zi-log "{e} {b}gh-r{rst}Unsupported OS: {obj}$_os{rst}"
       ;;
   esac
   case "$_cpu" in
@@ -1520,7 +1519,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
       _os=${_os}eabihf
       ;;
     (*)
-      +zi-log "{info}[{pre}ziextract{info}]{error} Unsupported CPU: {obj}$_cpu{rst}"
+      +zi-log "{e} {b}gh-r{rst}Unsupported CPU: {obj}$_cpu{rst}"
       ;;
   esac
   echo "${_sys};${_cpu};${_os}"
@@ -1535,7 +1534,6 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
   local plugin="$2" urlpart="$3" user="$1"
   local -a bpicks filtered init_list list parts
   parts=(${(@s:;:)$(.zi::get-architecture)})
-  # +zi-log "{info}[{pre}gh-r{info}]{rst} filters -> {glob}${(@)parts}{rst}"
   if [[ -z $urlpart ]]; then
     local tag_version=${ICE[ver]}
     if [[ -z $tag_version ]]; then
@@ -1558,18 +1556,16 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     if [[ -n $bpick ]]; then
       list=( ${(M)list[@]:#(#i)*/$~bpick} )
       if (( !$#list )); then
-        +zi-log "{info}[{pre}gh-r{info}] {error}Error{rst}: {ice}bpick{rst} ice found no release assets{rst}. To fix, modify the {ice}bpick{rst} glob pattern {glob}${bpick}{rst}"
+        +zi-log "{e} {b}gh-r{rst}: {ice}bpick{rst} ice found no release assets To fix, modify the {ice}bpick{rst} glob pattern {glob}$bpick{rst}"
       fi
+    else
+      local junk="(386|md5|sig|asc|txt|vsix|sum|sha256*|pkg|([\.]apk|deb|json|rpm|sh))"
+      filtered=( ${list[@]:#(#i)*${~junk}*} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} )
     fi
-
-    local junk="(md5|sig|asc|txt|vsix|sum|sha256*|pkg|.(apk|deb|json|rpm|sh(#e)))"
-    filtered=( ${list[@]:#(#i)*${~junk}*} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} )
 
     local -a array=( $(print -rm "*(${MACHTYPE}|${VENDOR}|)*~^*(${parts[1]}|${(L)$(uname)})*" $list[@]) )
     (( ${#array} > 0 )) && list=( ${array[@]} )
-    +zi-log -- "{dbg} filtered ${#filtered} to ${#array} release assets"
 
-    +zi-log -- "{dbg}${(@pj:\n  - :)list[1,2]}{nl}"
     for part in "${parts[@]}"; do
       if (( $#list > 1 )); then
         filtered=( ${(M)list[@]:#(#i)*${~part}*} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} )
@@ -1581,7 +1577,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     if (( $#list > 1 )) { filtered=( ${list[@]:#(#i)*.(sha[[:digit:]]#|asc)} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} ); }
 
     if (( !$#list )); then
-      +zi-log "{nl}{info}[{pre}gh-r{info}] {error}Error{rst}: No GitHub release assets found for {glob}${tag_version}{rst}"
+      +zi-log "{e} {b}gh-r{rst}: No GitHub release assets found for {glob}$tag_version{rst}"
       return 1
     fi
     reply+=( "${list[1]}" )
@@ -1600,7 +1596,7 @@ ziextract() {
     builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt extendedglob typesetsilent noshortloops # warncreateglobal
 
-    local -a opt_move opt_move2 opt_norm opt_auto opt_nobkp
+    local -aU opt_move opt_move2 opt_norm opt_auto opt_nobkp
     zparseopts -D -E -move=opt_move -move2=opt_move2 -norm=opt_norm \
             -auto=opt_auto -nobkp=opt_nobkp || \
         { +zi-log "{info}[{pre}ziextract{info}]{error} Incorrect options given to" \
@@ -1617,7 +1613,7 @@ ziextract() {
 
     if (( auto )) {
         # First try known file extensions
-        local -a files
+        local -aU files
         integer ret_val
         files=( (#i)**/*.(zip|rar|7z|tgz|tbz|tbz2|tar.gz|tar.bz2|tar.7z|txz|tar.xz|gz|xz|tar|dmg|exe)~(*/*|.(_backup|git))/*(-.DN) )
         for file ( $files ) {
@@ -1833,7 +1829,7 @@ ziextract() {
     }
     unfunction -- .zinit-extract-wrapper
 
-    local -a execs
+    local -aU execs
     execs=( **/*~(._zinit(|/*)|.git(|/*)|.svn(|/*)|.hg(|/*)|._backup(|/*))(DN-.) )
     if [[ ${#execs} -gt 0 && -n $execs ]] {
         execs=( ${(@f)"$( file ${execs[@]} )"} )
@@ -1901,7 +1897,7 @@ ziextract() {
                       "(\`{file}$local_dir{msg2}') isn't accessible.{rst}"
                 return 1
             }
-        local -a files
+        local -aU files
         files=( ${(@)${(@s: :)${extract##(\!-|-\!|\!|-)}}//(#b)(((#s)|([^\\])[\\]([\\][\\])#)|((#s)|([^\\])([\\][\\])#)) /${match[2]:+$match[3]$match[4] }${match[5]:+$match[6]${(l:${#match[7]}/2::\\:):-} }} )
         if [[ ${#files} -eq 0 && -n ${extract##(\!-|-\!|\!|-)} ]] {
                 +zi-log "{error}ERROR:{msg2} The files" \
@@ -2000,7 +1996,7 @@ ziextract() {
     # Download the package
     #
 
-    +zi-log "{info}Downloading{ehi}: {file}${url:t}{info}{…}{rst}"
+    +zi-log "{nl}{i} Downloading {b}{file}${url:t}{rst}"
     retry=2
     while (( retry -- )) {
         integer retval=0
@@ -2058,81 +2054,6 @@ zimv() {
     local dir
     if [[ $1 = (-d|--dir) ]] { dir=$2; shift 2; }
     zicp --mv ${dir:+--dir} $dir "$@"
-} # ]]]
-# FUNCTION: .zinit-configure-run-autoconf [[[
-# Called if # passed to configure ice or no ./configure found
-# Runs autoconf, autoreconf, and autogen.sh
-.zinit-configure-run-autoconf() {
-    local dir=$1 flags=$2
-    integer q
-    local msg="{pre} ({flag}#{pre} flag given){…}" msg_="{pre}{…}"
-    # Custom script
-    if [[ -f $dir/autogen.sh ]]; then
-        q=1
-        m {pre}Running {cmd}./autogen.sh${${${(M)flags:#*\#*}:+$msg}:-$msg_}
-        .zinit-countdown ./autogen.sh && \
-            (
-                cd -q $dir
-                chmod +x ./autogen.sh
-                ./autogen.sh
-            )
-    # Autoreconf only if available in PATH
-    elif [[ -f $dir/configure && -f $dir/configure.ac && \
-            $+commands[autoreconf] = 1 ]]; then
-        q=1
-        m {pre}Running {cmd}autoreconf {opt}-f${${${(M)flags:#*\#*}:+$msg}:-$msg_}
-        .zinit-countdown autoreconf\ -f\ -i\ … && \
-            (
-                cd -q $dir
-                rm -f aclocal.m4
-                aclocal -I m4 --force
-                libtoolize --copy --force
-                autoreconf -f -i -I m4
-            )
-    # Manual reproduction of autoreconf run
-    elif [[ -f $dir/configure && -f $dir/configure.ac ]]; then
-        q=1
-        m {pre}Running {cmd}aclocal{pre}, {cmd}autoconf{pre} and {cmd}automake\
-${${${(M)flags:#*\#*}:+$msg}:-$msg_}
-        .zinit-countdown aclocal,\ autoconf,\ automake && \
-            (
-                cd -q $dir
-                rm -f aclocal.m4
-                aclocal -I m4 --force
-                libtoolize --copy --force
-                aclocal -I m4 --force
-                autoconf -I m4 -f
-                autoheader -I m4 -f
-                automake --add-missing -c --force-missing
-            )
-    # Only autoconf if no existing ./configure
-    elif [[ ! -f $dir/configure && -f $dir/configure.ac ]]; then
-        q=1
-        m {pre}Running {cmd}autoconf {opt}-f${${${(M)flags:#*\#*}:+$msg}:-$msg_}
-        .zinit-countdown autoconf\ -f && \
-            (
-                cd -q $dir
-                autoconf -f -I m4
-            )
-    elif [[ $flags == *\#* ]]; then
-        m {ehi}WARNING:{error}: No {cmd}autogen.sh{error} nor {file}configure.ac \
-            {error}on disk while the {flag}\# \
-            {error}flag given to the {ice}configure{apo}\'\'{error} ice, skipping \
-            further {cmd}./configure{error}-generation related actions{…}
-        ((1))
-    fi
-    if [[ ! -f $dir/configure ]]; then
-        if (( q )); then
-            m {error}WARNING:some input files existed \({file}configure.ac{error}, \
-                etc.\) however running {cmd}Autotools{error} didn\'t yield a \
-                {cmd}./configure{error} script, meaning that it won\'t be run\! \
-                Please check if you have packages such as {pkg}autoconf{error}, \
-                {pkg}autmake{error} and similar installed.
-        else
-            # No output – lacking both configure.ac and configure → a no-op
-            :
-        fi
-    fi
 } # ]]]
 # FUNCTION: ∞zinit-reset-hook [[[
 ∞zinit-reset-hook() {
@@ -2215,14 +2136,61 @@ ${${${(M)flags:#*\#*}:+$msg}:-$msg_}
             ZINIT[-r/--reset-opt-hook-has-been-run]=1
         }
     } else {
-        # If there's no -r/--reset, pretend that it already has been served.
+        # If theres no -r/--reset, pretend that it already has been served.
         ZINIT[-r/--reset-opt-hook-has-been-run]=1
     }
 } # ]]]
+# FUNCTION: ∞zinit-configure-base-hook [[[
+# A base common implementation of the configure ice
+∞zinit-configure-base-hook () {
+    emulate -L zsh
+    setopt extendedglob
+    if [[ "$1" = plugin ]]; then
+        local dir="${5#%}" hook="$6" subtype="$7" ex="$8"
+    else
+        local dir="${4#%}" hook="$5" subtype="$6" ex="$7"
+    fi
+    local flags configure eflags aflags ice='{b}configure{rst}:'
+    configure=${ICE[configure]}
+    @zinit-substitute configure
+    (( ${+ICE[configure]} )) || return 0
+    flags=${(M)configure##[smc0\!\#]##}
+    configure=${configure##$flags([[:space:]]##|(#e))}
+    eflags=${(SM)flags##[\!]##}
+    aflags=${(SM)flags##[smc0]##}
+    [[ $eflags == $ex ]] || return 0
+    typeset -aU configure_opt=(${(@s; ;)configure})
+    configure_opt+=("--prefix=${ZPFX:-${ZINIT[HOME_DIR]}/polaris}")
+    {
+        builtin cd -- "$dir" || return 1
+        if [[ -n *(#i)makefile(#qN) ]]; then
+            return 0
+        elif [[ -z *(#i)configure(#qN) ]]; then
+            +zi-log "{m} ${ice} Attempting to generate configure script... "
+            local c
+            for c in "[[ -e autogen.sh ]] && sh ./autogen.sh" "[[ -n *.a[mc](#qN.) ]] && autoreconf -ifm" "git clean -fxd; aclocal --force; autoconf --force; automake --add-missing --copy --force-missing"; do
+                +zi-log -PrD "{dbg} ${ice} {faint}${c}{rst}"
+                {
+                    eval "${c}" 2> /dev/null >&2
+                } always {
+                    [[ -n *(#i)configure(#qN) ]] && break
+                    (( TRY_BLOCK_ERROR = 0 ))
+                }
+            done
+        fi
+        +zi-log "{m} ${ice} Generating Makefile"
+        +zi-log "{dbg} ${ice} {faint}./configure $(builtin print -PDn -- ${(Ds; ;)configure_opt[@]//prefix /prefix=}){rst}"
+        eval "./configure ${(S)configure_opt[@]//prefix /prefix=}" 2> /dev/null >&2
+        if [[ -n *(#i)makefile(#qN) ]]; then
+            +zi-log "{m} ${ice} Successfully generated Makefile"
+            return 0
+        else
+            +zi-log "{e} ${ice} Failed project configuration"
+            return 1
+        fi
+    }
+} # ]]]
 # FUNCTION: ∞zinit-configure-e-hook [[[
-# The !-version of configure'' ice. Runs in between
-# of make'!!' and make'!'. Configure naturally runs
-# before make.
 ∞zinit-configure-e-hook() {
     ∞zinit-configure-base-hook "$@" "!"
 } # ]]]
@@ -2231,148 +2199,117 @@ ${${${(M)flags:#*\#*}:+$msg}:-$msg_}
 # of make'!' and make''. Configure script naturally runs
 # before make.
 ∞zinit-configure-hook() {
-    ∞zinit-configure-base-hook "$@"
+    ∞zinit-configure-base-hook "$@" ""
 } # ]]]
-# FUNCTION: ∞zinit-configure-base-hook [[[
-# A base common implementation of configure'', as all
-# the starting steps are rigid and the same in all
-# hooks, hence the idea. TODO: use in make'' and other
-# places.
-∞zinit-configure-base-hook() {
-    [[ "$1" = plugin ]] && \
-        local dir="${5#%}" hook="$6" subtype="$7" ex="$8" || \
+
+# FUNCTION: ∞zinit-make-base-hook [[[
+# A base common implementation of the make ice
+∞zinit-make-base-hook () {
+    emulate -L zsh
+    setopt extendedglob
+    [[ -z $ICE[make] ]] && return 0
+    if [[ "$1" = plugin ]]; then
+        local dir="${5#%}" hook="$6" subtype="$7" ex="$8"
+    else
         local dir="${4#%}" hook="$5" subtype="$6" ex="$7"
-
-    emulate -L zsh -o extendedglob
-
-    local configure=${ICE[configure]}
-    @zinit-substitute configure
-
-    # c-cmake, s-scons, m-meson, 0-default (configure)
-    local flags=${(M)configure##[smc0\!\#]##}
-    configure=${configure##$flags([[:space:]]##|(#e))}
-    (( ${+ICE[configure]} )) || return 0
-    # !-only flags
-    local eflags=${(SM)flags##[\!]##} aflags=${(SM)flags##[smc0]##}
-    [[ $eflags == $ex ]] || return 0
-
-    # Conditionally run autogen.sh/autoconf/aclocal/etc. to
-    # see if we got an output ./configure file (or preexisting
-    # if no autotools have been resolved to run from the optional
-    # # flag and the .ac/.m4 input files) ready to run
-    [[ $flags == *\#* || ! -f $dir/configure ]] &&
-        .zinit-configure-run-autoconf "$dir" $flags
-
-    if [[ $flags == (#b)*([^smc0\!\#]##)* || ${flags//[\!\#]##/} == (#b)(([smc0](#c2,))) ]]; then
-        m {error}ERROR: improper ${match[2]:+\(multiple of s,m,c\?\)} flag\(s\) \({flag}${match[1]}{error}\) \
-            given, skipping further build system actions processing{…}
-        return 1
+    fi
+    local make=${ICE[make]} ice='{b}make{rst}:'
+    @zinit-substitute make
+    (( ${+ICE[make]} )) || return 0
+    local eflags=${(M)make##[\!]##}
+    make=${make##$eflags}
+    [[ $ex == $eflags ]] || return 0
+    local make_prefix='prefix'
+    if grep -w -- "PREFIX =" ${dir}/[Mm]akefile >/dev/null; then
+        make_prefix="PREFIX"
     fi
 
-    local -a files=( $dir/CMakeLists.txt(N) $dir/*/CMakeLists.txt(N) )
-    if [[ $#files -gt 0 && -z $aflags || $flags == [^a-z0]#c[^a-z0]# ]]; then
-        if (( ${+commands[cmake]} )); then
-            command mkdir -p $dir/_build-zinit
-            m {pre}Running {cmd}cmake{pre} ${${${${#files}:#0}:+for \
-            its found {file}CMakeLists.txt{pre} input file{…}}:-\
-because {flag}c{pre} flag given}
-           .zinit-countdown cmake && \
-             ( cd -q $dir/_build-zinit; cmake -DCMAKE_INSTALL_PREFIX=$ZPFX .. ${(@s; ;)configure} )
-        else
-            m {error}Error: no {cmd}cmake{error} binary found and \
-                ${${${${#files}:#0}:+its input file exists \
-                   \({file}CMakeLists.txt{error}\)}:-and {flag}c{error} \
-                   flag given}! Skipping{…}
+    local src=($dir/[Cc][Mm]ake*(N.om[1]))
+    if (( $#src )); then
+      +zi-log "{m} ${ice} Detected Cmake project, using CMAKE_INSTALL_PREFIX={file}\$ZPFX{rst}"
+      make_prefix="CMAKE_INSTALL_PREFIX"
+    else
+      +zi-log -ru2 -- "{dbg} ${dir:t}: No Cmake files found in ${dir}"
+    fi
+    local prefix="${ZINIT[ZPFX]}"
+    if [[ -n OPTS[opt_-q,--quiet] || -n ${ZINIT[DEBUG]:#1} ]]; then
+        +zi-log "{dbg} ${ice} setting quiet mode"
+        local quiet='2>/dev/null 1>&2'
+    fi
+    local -i ret=0
+    {
+        build="make -C ${dir} --jobs 4"
+        +zi-log "{m} ${ice} Building..."
+        # +zi-log "{m} ${ice} {faint}${(Ds; ;)build} $make_prefix=$(builtin print -Pnf '%s' ${(D)ZINIT[ZPFX]}){rst}"
+        +zi-log "{dbg} ${ice} eval ${build} $make_prefix=$prefix 2>/dev/null 1>&2"
+        eval "${build} $make_prefix=$prefix" 2>/dev/null 1>&2
+        ret=$?
+    } always {
+        if (( ret )); then
+            +zi-log "{w} ${ice} Build returned {num}${ret}{rst}"
         fi
-    fi
-    local -a files=( $dir/SConstruct(N) $dir/*/SConstruct(N) )
-    if [[ $#files -gt 0 && -z $aflags || $flags == [^a-z0]#s[^a-z0]# ]]; then
-        if (( ${+commands[scons]} )); then
-            m {pre}Running {cmd}scons{pre} for its found {file}SConstruct{pre} input file{…}
-            .zinit-countdown scons && \
-                 ( cd $dir; scons RELEASE=yes --prefix=$ZPFX ${(@s; ;)configure} )
-        else
-            m {error}Error: no {cmd}scons{error} binary found and \
-                ${${${${#files}:#0}:+its input file exists \
-                    ({file}SConstruct{error})}:-and {flag}s{error} \
-                    flag given}! Skipping{…}
+        (( TRY_BLOCK_ERROR = 0 ))
+    }
+    {
+        install="${build} ${make}"
+        # +zi-log "{m} ${ice} {faint}${(Ds; ;)build} $make_prefix=$(builtin print -Pnf '%s' ${ZINIT[POLARIS]}) ${make} {rst}"
+        +zi-log "{m} ${ice} Installing in ${(D)ZINIT[ZPFX]}"
+        +zi-log "{dbg} ${ice} eval ${build} $make_prefix=$prefix ${make} 2>/dev/null 1>&2"
+        eval "${(s; ;)install} $make_prefix=$prefix" 2>/dev/null 1>&2
+        ret=$?
+    } always {
+        if (( ret )); then
+            +zi-log "{w} ${ice} Install returned {num}${ret}{rst}"
         fi
-    fi
-    local -a files=( $dir/meson.build(N) $dir/*/meson.build(N) )
-    if [[ $#files -gt 0 && -z $aflags || $flags == [^a-z0]#m[^a-z0]# ]]; then
-        if (( ${+commands[meson]} )); then
-            m {pre}Running {cmd}meson setup{pre} ${${${${#files}:#0}:+\
-for its found {file}meson.build{pre} input file}:-because {flag}m{pre} \
-                flag given}{…}
-            .zinit-countdown meson\ setup && \
-                ( cd $dir; command meson setup --prefix=$ZPFX _build-zinit ${(@s; ;)configure} )
-        else
-            m {error}Error: no {cmd}meson{error} binary found and \
-            ${${${${#files}:#0}:+its input file exists \
-                ({file}meson.build{error})}:-{flag}m{error} \
-                flag given}! Skipping{…}
-        fi
-    fi
-    if [[ -f $dir/configure && -z $aflags || $flags == [^a-z0]#0[^a-z0]# ]]; then
-        m {pre}Running {cmd}./configure {opt}--prefix{meta}={b}{dir}$ZPFX{nb}{…}
-        .zinit-countdown ./configure && \
-            (
-                cd -q $dir
-                chmod +x ./configure
-                ./configure --prefix=$ZPFX ${(@s; ;)configure}
-            )
-    fi
-} # ]]]
-# FUNCTION: ∞zinit-make-ee-hook [[[
-∞zinit-make-ee-hook() {
-    ∞zinit-make-base-hook "$@" "!!"
+        (( TRY_BLOCK_ERROR = 0 ))
+    }
+    return $ret
 } # ]]]
 # FUNCTION: ∞zinit-make-e-hook [[[
 ∞zinit-make-e-hook() {
     ∞zinit-make-base-hook "$@" "!"
 } # ]]]
+# FUNCTION: ∞zinit-make-ee-hook [[[
+∞zinit-make-ee-hook() {
+    ∞zinit-make-base-hook "$@" "!!"
+} # ]]]
 # FUNCTION: ∞zinit-make-hook [[[
 ∞zinit-make-hook() {
     ∞zinit-make-base-hook "$@" ""
 } # ]]]
-# FUNCTION: ∞zinit-make-base-hook [[[
-∞zinit-make-base-hook() {
-    [[ "$1" = plugin ]] && \
-        local dir="${5#%}" hook="$6" subtype="$7" ex="$8" || \
-        local dir="${4#%}" hook="$5" subtype="$6" ex="$7"
 
-    local make=${ICE[make]}
-    @zinit-substitute make
-
-    # Save preceding ! only
-    local eflags=${(M)make##[\!]##}
-    make=${make##$eflags}
-    (( ${+ICE[make]} )) || return 0
-    [[ $ex == $eflags ]] || return 0
-
-    # For meson and cmake
-    [[ -d $dir/_build-zinit ]] && dir+=/_build-zinit
-
-    # Run either `make` or `meson compile`
-    if [[ -f $dir/Makefile ]]; then
-        m {pre}Running {apo}\`{cmd}make{opt} ${(@s; ;)make}{apo}\`{pre}{…}
-        .zinit-countdown make &&
-            command make -C "$dir" ${(@s; ;)make}
-    elif [[ -f $dir/build.ninja ]]; then
-        m {pre}Running {apo}\`{cmd}meson{opt} compile{apo}\`{pre}{…}
-        .zinit-countdown meson\ compile &&
-            meson compile -C "$dir"
-        [[ $make == ([[:space:]]|(#s))install([[:space:]]|(#e)) ]] &&
-        {
-            m {pre}Running {apo}\`{cmd}meson{opt} ${(@s; ;)make}{apo}\`{pre}{…}
-            .zinit-countdown meson\ ${(@s; ;)make} &&
-                meson ${(@s; ;)make} -C "$dir"
-        }
-    else
-        m {error}ERROR: No {file}Makefile{error} nor {cmd}meson{error} \
-            build dir found, {cmd}make{error}/{cmd}meson{error} isn\'t run\!
+# FUNCTION: __zinit-cmake-base-hook [[[
+# A base common implementation of the cmake ice
+__zinit-cmake-base-hook () {
+    emulate -L zsh
+    setopt extended_glob
+    (( ${+ICE[cmake]} )) || return 0
+    if (( ! ${+commands[cmake]} )); then
+        +zi-log "{e} {cmd}cmake{rst} required to use {ice}cmake{rst} ice"
+        return 0
     fi
+    if [[ "$1" = plugin ]]; then
+        local dir="${5#%}" hook="$6" subtype="$7" ex="$8"
+    else
+        local dir="${4#%}" hook="$5" subtype="$6" ex="$7"
+    fi
+    (( OPTS[opt_-q,--quiet] || ZINIT[DEBUG] )) && local QUIET='2>/dev/null 1>&2'
+    local c ret=0 ice='{b}cmake{rst}:'
+    for c in "-S ${dir} -B ${dir}/build -DCMAKE_BUILD_TYPE=Release --install-prefix ${ZINIT[ZPFX]} ${QUIET}" "--build ${dir}/build --parallel $(nproc) ${QUIET}" "--install ${dir}/build ${QUIET}"; do
+      +zi-log "{m} ${ice} {faint}cmake ${(Ds; ;)c} {rst}"
+        eval "cmake ${c}" 2> /dev/null >&2
+        if (( $? )); then
+            +zi-log "{e} ${ice} Failure cmake ${c}{rst}"
+            ret=$?
+        fi
+    done
+    return $?
 } # ]]]
+# FUNCTION: +zinit-cmake-hook [[[
++zinit-cmake-hook() {
+    __zinit-cmake-base-hook "$@"
+} # ]]]
+
 # FUNCTION: ∞zinit-atclone-hook [[[
 ∞zinit-atclone-hook() {
     [[ "$1" = plugin ]] && \

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -75,8 +75,8 @@ fi
 ZINIT[ice-list]="\
 \!bash|\!csh|\!ksh|\!sh|\
 aliases|as|atclone|atdelete|atinit|atload|atpull|autoload|\
-bash|binary|bindmap|blockf|bpick|\
-cloneonly|cloneopts|compile|completions|configure|countdown|cp|csh|\
+bash|binary|bindmap|blockf|bpick|build|\
+cloneonly|cloneopts|cmake|compile|completions|configure|countdown|cp|csh|\
 debug|depth|\
 extract|\
 from|git|\
@@ -97,7 +97,7 @@ ZINIT[nval-ice-list]="\
 \!bash|\!csh|\!ksh|\!sh|\
 aliases|\
 bash|binary|blockf|\
-cloneonly|cloneopts|countdown|csh|\
+cloneonly|cloneopts|cmake|configure|countdown|csh|\
 debug|\
 git|\
 is-snippet|\
@@ -133,13 +133,15 @@ zstatus"
 # Can be customized.
 : ${ZINIT[COMPLETIONS_DIR]:=${ZINIT[HOME_DIR]}/completions}
 : ${ZINIT[MODULE_DIR]:=${ZINIT[HOME_DIR]}/module}
-: ${ZINIT[PACKAGES_REPO]:=zdharma-continuum/zinit-packages}
 : ${ZINIT[PACKAGES_BRANCH]:=HEAD}
+: ${ZINIT[PACKAGES_REPO]:=zdharma-continuum/zinit-packages}
 : ${ZINIT[PLUGINS_DIR]:=${ZINIT[HOME_DIR]}/plugins}
+: ${ZINIT[POLARIS_DIR]:=${ZINIT[HOME_DIR]}/polaris}
 : ${ZINIT[SERVICES_DIR]:=${ZINIT[HOME_DIR]}/services}
 : ${ZINIT[SNIPPETS_DIR]:=${ZINIT[HOME_DIR]}/snippets}
+: ${ZINIT[ZPFX]:=${ZINIT[HOME_DIR]}/polaris}
 typeset -g ZPFX
-: ${ZPFX:=${ZINIT[HOME_DIR]}/polaris}
+: ${ZPFX:=${ZINIT[ZPFX]}}
 : ${ZINIT[ALIASES_OPT]::=${${options[aliases]:#off}:+1}}
 : ${ZINIT[MAN_DIR]:=${ZPFX}/man}
 
@@ -149,6 +151,11 @@ export ZPFX=${~ZPFX} ZSH_CACHE_DIR="${ZSH_CACHE_DIR:-${XDG_CACHE_HOME:-$HOME/.ca
     PMSPEC=0uUpiPsf
 [[ -z ${path[(re)$ZPFX/bin]} ]] && [[ -d "$ZPFX/bin" ]] && path=( "$ZPFX/bin" "${path[@]}" )
 [[ -z ${path[(re)$ZPFX/sbin]} ]] && [[ -d "$ZPFX/sbin" ]] && path=( "$ZPFX/sbin" "${path[@]}" )
+
+hash -f
+hash -d zinit=${ZINIT[HOME_DIR]}
+hash -d plugins=${ZINIT[PLUGINS_DIR]}
+hash -d zpfx=${ZINIT[HOME_DIR]}/polaris
 
 # Add completions directory to fpath.
 [[ -z ${fpath[(re)${ZINIT[COMPLETIONS_DIR]}]} ]] && fpath=( "${ZINIT[COMPLETIONS_DIR]}" "${fpath[@]}" )
@@ -215,10 +222,12 @@ if [[ -z $SOURCED && ( ${+terminfo} -eq 1 && -n ${terminfo[colors]} ) || ( ${+te
     col-ehi     $'\e[1m\e[38;5;210m'    col-meta    $'\e[38;5;57m'          col-pname   $'\e[1;4m\e[32m'     col-var     $'\e[38;5;81m'
     col-error   $'\e[1m\e[38;5;204m'    col-meta2   $'\e[38;5;147m'         col-pre     $'\e[38;5;135m'      col-version $'\e[3;38;5;87m'
     col-failure $'\e[38;5;204m'         col-msg     $'\e[0m'                col-profile $'\e[38;5;148m'      col-warn    $'\e[38;5;214m'
-
-    col-i $'\e[1m\e[38;5;82m'"==>"$'\e[0m' col-e $'\e[1m\e[38;5;204m'"Error: "$'\e[0m'
-    col-m $'\e[1m\e[38;5;135m'"==>"$'\e[0m' col-w $'\e[1;38;5;214m'"Warning: "$'\e[0m'
-    col-dbg $'\e[2m\e[38;47;108m'"[debug]"$'\e[0m'
+    
+    col-dbg $'\e[2m\e[38;47;107m'"[debug]"$'\e[0m'
+    col-e $'\e[1m\e[38;5;204m'"Error"$'\e[0m'":"
+    col-i $'\e[1m\e[38;5;82m'"==>"$'\e[0m' 
+    col-m $'\e[1m\e[38;5;135m'"==>"$'\e[0m' 
+    col-w $'\e[1m\e[38;5;214m'"Warning"$'\e[0m'":"
 
     col--…   "${${${(M)LANG:#*UTF-8*}:+⋯⋯}:-···}"    col-lr "${${${(M)LANG:#*UTF-8*}:+↔}:-"«-»"}"
     col-ndsh "${${${(M)LANG:#*UTF-8*}:+–}:-}"        col-…  "${${${(M)LANG:#*UTF-8*}:+…}:-...}"
@@ -1264,7 +1273,7 @@ builtin setopt noaliases
         # For compaudit.
         command chmod go-w "${ZINIT[HOME_DIR]}"
         # Also set up */bin and ZPFX in general.
-        command mkdir 2>/dev/null -p $ZPFX/bin
+        command mkdir -p "${ZPFX:-ZINIT[HOME_DIR]/polaris}/bin"
     }
     [[ ! -d ${ZINIT[PLUGINS_DIR]}/_local---zinit ]] && {
         command rm -rf "${ZINIT[PLUGINS_DIR]:-${TMPDIR:-/tmp}/132bcaCAB}/_local---zplugin"
@@ -1273,7 +1282,7 @@ builtin setopt noaliases
         command ln -s "${ZINIT[BIN_DIR]}/_zinit" "${ZINIT[PLUGINS_DIR]}/_local---zinit"
 
         # Also set up */bin and ZPFX in general.
-        command mkdir 2>/dev/null -p $ZPFX/bin
+        command mkdir -p "${ZPFX:-ZINIT[HOME_DIR]/polaris}/bin"
 
         (( ${+functions[.zinit-setup-plugin-dir]} )) || builtin source "${ZINIT[BIN_DIR]}/zinit-install.zsh" || return 1
         (( ${+functions[.zinit-confirm]} )) || builtin source "${ZINIT[BIN_DIR]}/zinit-autoload.zsh" || return 1
@@ -1289,7 +1298,7 @@ builtin setopt noaliases
         command ln -s "${ZINIT[PLUGINS_DIR]}/_local---zinit/_zinit" "${ZINIT[COMPLETIONS_DIR]}"
 
         # Also set up */bin and ZPFX in general.
-        command mkdir 2>/dev/null -p $ZPFX/bin
+        command mkdir -p "${ZPFX:-ZINIT[HOME_DIR]/polaris}/bin"
 
         (( ${+functions[.zinit-setup-plugin-dir]} )) || builtin source "${ZINIT[BIN_DIR]}/zinit-install.zsh" || return 1
         .zinit-compinit &>/dev/null
@@ -1304,7 +1313,7 @@ builtin setopt noaliases
         command chmod go-w "${ZINIT[SERVICES_DIR]}"
 
         # Also set up */bin and ZPFX in general.
-        command mkdir 2>/dev/null -p $ZPFX/bin
+        command mkdir -p "${ZPFX:-ZINIT[HOME_DIR]/polaris}/bin"
     }
     [[ ! -d ${~ZINIT[MAN_DIR]}/man9 ]] && {
         # Create ZINIT[MAN_DIR]/man{1..9}
@@ -1972,15 +1981,6 @@ builtin setopt noaliases
     builtin zle -F "$THEFD" +zinit-deploy-message
 } # ]]]
 
-# FUNCTION: .zinit-formatter-dbg [[[
-.zinit-formatter-dbg() {
-    builtin emulate -L zsh -o extendedglob
-    REPLY=
-    if (( ZINIT[DEBUG] )); then
-        REPLY="$ZINIT[col-dbg]$1"
-    fi
-} # ]]]
-
 # FUNCTION: .zinit-formatter-auto [[[
 .zinit-formatter-auto() {
     emulate -L zsh -o extendedglob -o warncreateglobal -o typesetsilent
@@ -2166,6 +2166,10 @@ builtin setopt noaliases
     ZINIT[__last-formatter-code]=
     msg=${${(j: :)${@:#--}}//\%/%%}
 
+    if [[ -z $ZINIT[DEBUG] ]] && [[ "$msg" = (#s){dbg}* ]]; then
+        return
+    fi
+
     # First try a dedicated formatter, marking its empty output with ←→, then
     # the general formatter and in the end filter-out the ←→ from the message.
     msg=${${msg//(#b)(([\\]|(%F))([\{]([^\}]##)[\}])|([\{]([^\}]##)[\}])([^\%\{\\]#))/\
@@ -2257,14 +2261,22 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
     integer retval
     local bit exts="${(j:|:)${(@)${(@Akons:|:)${ZINIT_EXTS[ice-mods]//\'\'/}}/(#s)<->-/}}"
     for bit; do
-        [[ $bit = (#b)(--|)(${~ZINIT[ice-list]}${~exts})(*) ]] && \
-            ZINIT_ICES[${match[2]}]+="${ZINIT_ICES[${match[2]}]:+;}${match[3]#(:|=)}" || \
-            break
+        [[ $bit = (#b)(--|)(${~ZINIT[ice-list]}${~exts})(*) ]] && ZINIT_ICES[${match[2]}]+="${ZINIT_ICES[${match[2]}]:+;}${match[3]#(:|=)}" || break
         retval+=1
     done
     [[ ${ZINIT_ICES[as]} = program ]] && ZINIT_ICES[as]=command
     [[ -n ${ZINIT_ICES[on-update-of]} ]] && ZINIT_ICES[subscribe]="${ZINIT_ICES[subscribe]:-${ZINIT_ICES[on-update-of]}}"
     [[ -n ${ZINIT_ICES[pick]} ]] && ZINIT_ICES[pick]="${ZINIT_ICES[pick]//\$ZPFX/${ZPFX%/}}"
+    if (( $+ZINIT_ICES[build] )); then
+        +zi-log -- "{dbg} {ice}build{rst}: setting configure & make ices"
+        ZINIT_ICES[configure]=
+        ZINIT_ICES[make]=
+    fi
+    if (( $+ZINIT_ICES[configure] || $+ZINIT_ICES[cmake] || $+ZINIT_ICES[make] )); then
+        ZINIT_ICES[null]=
+    fi
+    (( $+ZINIT_ICES[configure] )) && ZINIT_ICES[configure]=${ZINIT_ICES[configure]:---quiet}
+    (( $+ZINIT_ICES[make] )) && ZINIT_ICES[make]=${ZINIT_ICES[make]:-install}
     return retval
 } # ]]]
 # FUNCTION: .zinit-pack-ice [[[
@@ -2951,7 +2963,7 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                     .zinit-parse-opts update "$@"
                     builtin set -- "${reply[@]}"
                     if [[ ${OPTS[opt_-a,--all]} -eq 1 || ${OPTS[opt_-p,--parallel]} -eq 1 || ${OPTS[opt_-s,--snippets]} -eq 1 || ${OPTS[opt_-l,--plugins]} -eq 1 || -z $1$2${ICE[teleid]}${ICE[id-as]} ]]; then
-                        [[ -z $1$2 && $(( OPTS[opt_-a,--all] + OPTS[opt_-p,--parallel] + OPTS[opt_-s,--snippets] + OPTS[opt_-l,--plugins] )) -eq 0 ]] && { builtin print -r -- "Assuming --all is passed"; sleep 3; }
+                        [[ -z $1$2 && $(( OPTS[opt_-a,--all] + OPTS[opt_-p,--parallel] + OPTS[opt_-s,--snippets] + OPTS[opt_-l,--plugins] )) -eq 0 ]] && { builtin print -r -- "Assuming --all is passed"; }
                         (( OPTS[opt_-p,--parallel] )) && OPTS[value]=${1:-15}
                         .zinit-update-or-status-all update; ___retval=$?
                     else
@@ -2962,7 +2974,7 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                     ;;
                 (status)
                     if [[ $2 = --all || ( -z $2 && -z $3 ) ]]; then
-                        [[ -z $2 ]] && { builtin print -r -- "Assuming --all is passed"; sleep 3; }
+                        [[ -z $2 ]] && { builtin print -r -- "Assuming --all is passed"; }
                         .zinit-update-or-status-all status; ___retval=$?
                     else
                         .zinit-update-or-status status "${2%%(///|//|/)}" "${3%%(///|//|/)}"; ___retval=$?
@@ -2970,7 +2982,7 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                     ;;
                 (report)
                     if [[ $2 = --all || ( -z $2 && -z $3 ) ]]; then
-                        [[ -z $2 ]] && { builtin print -r -- "Assuming --all is passed"; sleep 4; }
+                        [[ -z $2 ]] && { builtin print -r -- "Assuming --all is passed"; }
                         .zinit-show-all-reports
                     else
                         .zinit-show-report "${2%%(///|//|/)}" "${3%%(///|//|/)}"; ___retval=$?
@@ -3055,7 +3067,7 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                 (compile)
                     (( ${+functions[.zinit-compile-plugin]} )) || builtin source "${ZINIT[BIN_DIR]}/zinit-install.zsh" || return 1
                     if [[ $2 = --all || ( -z $2 && -z $3 ) ]]; then
-                        [[ -z $2 ]] && { builtin print -r -- "Assuming --all is passed"; sleep 3; }
+                        [[ -z $2 ]] && { builtin print -r -- "Assuming --all is passed"; }
                         .zinit-compile-uncompile-all 1; ___retval=$?
                     else
                         .zinit-compile-plugin "${2%%(///|//|/)}" "${3%%(///|//|/)}"; ___retval=$?
@@ -3068,7 +3080,7 @@ You can try to prepend {apo}${___q}{lhi}@{apo}'{error} to the ID if the last ice
                     ;;
                 (uncompile)
                     if [[ $2 = --all || ( -z $2 && -z $3 ) ]]; then
-                        [[ -z $2 ]] && { builtin print -r -- "Assuming --all is passed"; sleep 3; }
+                        [[ -z $2 ]] && { builtin print -r -- "Assuming --all is passed"; }
                         .zinit-compile-uncompile-all 0; ___retval=$?
                     else
                         .zinit-uncompile-plugin "${2%%(///|//|/)}" "${3%%(///|//|/)}"; ___retval=$?
@@ -3274,6 +3286,7 @@ if [[ -e ${${ZINIT[BIN_DIR]}}/zmodules/Src/zdharma/zplugin.so ]] {
 @zinit-register-hook "configure''" hook:no-e-\!atpull-post ∞zinit-configure-hook
 @zinit-register-hook "atpull" hook:no-e-\!atpull-post ∞zinit-atpull-hook
 @zinit-register-hook "make''" hook:no-e-\!atpull-post ∞zinit-make-hook
+@zinit-register-hook "cmake''" hook:no-e-\!atpull-post +zinit-cmake-hook
 # atpull-post.
 @zinit-register-hook "compile-plugin" hook:atpull-post ∞zinit-compile-plugin-hook
 @zinit-register-hook "ps-on-update" hook:%atpull-post ∞zinit-ps-on-update-hook
@@ -3290,6 +3303,7 @@ if [[ -e ${${ZINIT[BIN_DIR]}}/zmodules/Src/zdharma/zplugin.so ]] {
 @zinit-register-hook "configure''" hook:\!atclone-post ∞zinit-configure-hook
 @zinit-register-hook "atclone" hook:\!atclone-post ∞zinit-atclone-hook
 @zinit-register-hook "make''" hook:\!atclone-post ∞zinit-make-hook
+@zinit-register-hook "cmake''" hook:\!atclone-post +zinit-cmake-hook
 # atclone-post.
 @zinit-register-hook "compile-plugin" hook:atclone-post ∞zinit-compile-plugin-hook
 


### PR DESCRIPTION
* Refactored 'configure' and 'make' ices
* New 'build' ice sets 'configure' and 'make ices if no flags are needed.
* New 'cmake' ice will build/install using 'cmake'
* Delete command now handles programs using 'make' and 'cmake' ices
* Zunit tests added
* Setting `$ZINIT[DEBUG]` enables debug logging (i.e., `+zi-log "{dbg} message ..."`)

## Description

## Related Issue(s)

<!--- If it fixes an open issue, add a link the issue -->

## Motivation and Context <!--- What problem does it solve? -->

## Usage examples

```zsh

```

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [ ] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
