### PR TITLE
fix: `gh-r` ignores `pkg` archives by default

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1561,9 +1561,8 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
         +zi-log "{info}[{pre}gh-r{info}] {error}Error{rst}: {ice}bpick{rst} ice found no release assets{rst}. To fix, modify the {ice}bpick{rst} glob pattern {glob}${bpick}{rst}"
       fi
     fi
-
-    local junk='(386|asc|b3|deb|md5|rpm|vsix|([\.]apk|json|pkg|txt|s(h(a|)|ig|um)*)(#e))'
-    filtered=( ${list[@]:#(#i)*${~junk}*} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} )
+    local junk='*((s(ha256|ig|um)|386|asc|md5|txt|vsix)*|(apk|b3|deb|json|pkg|rpm|sh|zst)(#e))';
+    filtered=( ${(m@)list:#(#i)${~junk}} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} )
 
     local -a array=( $(print -rm "*(${MACHTYPE}|${VENDOR}|)*~^*(${parts[1]}|${(L)$(uname)})*" $list[@]) )
     (( ${#array} > 0 )) && list=( ${array[@]} )
@@ -1619,7 +1618,7 @@ ziextract() {
         # First try known file extensions
         local -a files
         integer ret_val
-        files=( (#i)**/*.(7z|dmg|exe|gz|rar|tar|tar.7z|tar.bz2|tar.gz|tar.xz|tbz|tbz2|tgz|txz|xz|zip|zst)~(*/*|.(_backup|git))/*(-.DN) )
+        files=( (#i)**/*.(7z|dmg|exe|gz|rar|tar|tar.7z|tar.bz2|tar.gz|tar.xz|tbz|tbz2|tgz|txz|xz|zip)~(*/*|.(_backup|git))/*(-.DN) )
         for file ( $files ) {
             ziextract "$file" $opt_move $opt_move2 $opt_norm $opt_nobkp ${${${#files}:#1}:+--nobkp}
             ret_val+=$?
@@ -1714,9 +1713,6 @@ ziextract() {
     case "${${ext:+.$ext}:-$file}" in
         ((#i)*.zip)
             →zinit-extract() { →zinit-check unzip "$file" || return 1; command unzip -qq -o "$file"; }
-            ;;
-        ((#i)*.tar.zst)
-            →zinit-extract() { →zinit-check unzstd "$file" || return 1; command tar --use-compress-program=unzstd -xvf "$file"; }
             ;;
         ((#i)*.rar)
             →zinit-extract() { →zinit-check unrar "$file" || return 1; command unrar x "$file"; }

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1562,7 +1562,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
       fi
     fi
 
-    local junk='(386|asc|md5|sha256|sig|sum|vsix|[\.](deb|rpm)(#e|[\.]*)|[\.](apk|json|pkg|sh|txt)(#e))'
+    local junk='(386|512|asc|b3|deb|md5|rpm|sha(256|sig|sum[?s]|)|vsix|([\.]apk|json|pkg|sh|txt)(#e))'
     filtered=( ${list[@]:#(#i)*${~junk}*} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} )
 
     local -a array=( $(print -rm "*(${MACHTYPE}|${VENDOR}|)*~^*(${parts[1]}|${(L)$(uname)})*" $list[@]) )

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1562,7 +1562,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
       fi
     fi
 
-    local junk="(md5|sig|asc|txt|vsix|sum|sha256*|pkg|.(apk|deb|json|rpm|sh(#e)))"
+    local junk='(386|md5|sig|asc|vsix|sum|sha256|[\.](apk|deb|json|rpm|sh|pkg|txt)(#e))'
     filtered=( ${list[@]:#(#i)*${~junk}*} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} )
 
     local -a array=( $(print -rm "*(${MACHTYPE}|${VENDOR}|)*~^*(${parts[1]}|${(L)$(uname)})*" $list[@]) )

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1562,7 +1562,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
       fi
     fi
 
-    local junk='(386|512|asc|b3|deb|md5|rpm|sha(256|sig|sum[?s]|)|vsix|([\.]apk|json|pkg|sh|txt)(#e))'
+    local junk='(386|512|asc|b3|deb|md5|rpm|vsix|([\.]apk|json|pkgtxt|s(h[?a]|ig|um)*)(#e))'
     filtered=( ${list[@]:#(#i)*${~junk}*} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} )
 
     local -a array=( $(print -rm "*(${MACHTYPE}|${VENDOR}|)*~^*(${parts[1]}|${(L)$(uname)})*" $list[@]) )

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1619,7 +1619,7 @@ ziextract() {
         # First try known file extensions
         local -a files
         integer ret_val
-        files=( (#i)**/*.(zip|rar|7z|tgz|tbz|tbz2|tar.gz|tar.bz2|tar.7z|txz|tar.xz|gz|xz|tar|dmg|exe)~(*/*|.(_backup|git))/*(-.DN) )
+        files=( (#i)**/*.(7z|dmg|exe|gz|rar|tar|tar.7z|tar.bz2|tar.gz|tar.xz|tbz|tbz2|tgz|txz|xz|zip|zst)~(*/*|.(_backup|git))/*(-.DN) )
         for file ( $files ) {
             ziextract "$file" $opt_move $opt_move2 $opt_norm $opt_nobkp ${${${#files}:#1}:+--nobkp}
             ret_val+=$?
@@ -1714,6 +1714,9 @@ ziextract() {
     case "${${ext:+.$ext}:-$file}" in
         ((#i)*.zip)
             →zinit-extract() { →zinit-check unzip "$file" || return 1; command unzip -qq -o "$file"; }
+            ;;
+        ((#i)*.tar.zst)
+            →zinit-extract() { →zinit-check unzstd "$file" || return 1; command tar --use-compress-program=unzstd -xvf "$file"; }
             ;;
         ((#i)*.rar)
             →zinit-extract() { →zinit-check unrar "$file" || return 1; command unrar x "$file"; }

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1562,7 +1562,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
       fi
     fi
 
-    local junk='(386|512|asc|b3|deb|md5|rpm|vsix|([\.]apk|json|pkgtxt|s(h[?a]|ig|um)*)(#e))'
+    local junk='(386|asc|b3|deb|md5|rpm|vsix|([\.]apk|json|pkg|txt|s(h(a|)|ig|um)*)(#e))'
     filtered=( ${list[@]:#(#i)*${~junk}*} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} )
 
     local -a array=( $(print -rm "*(${MACHTYPE}|${VENDOR}|)*~^*(${parts[1]}|${(L)$(uname)})*" $list[@]) )

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1562,7 +1562,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
       fi
     fi
 
-    local junk='(386|md5|sig|asc|vsix|sum|sha256|[\.](apk|deb|json|rpm|sh|pkg|txt)(#e))'
+    local junk='(386|asc|md5|sha256|sig|sum|vsix|[\.](apk|deb|json|pkg|rpm|sh|txt)*(#e|[\.]*))'
     filtered=( ${list[@]:#(#i)*${~junk}*} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} )
 
     local -a array=( $(print -rm "*(${MACHTYPE}|${VENDOR}|)*~^*(${parts[1]}|${(L)$(uname)})*" $list[@]) )

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1562,7 +1562,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
       fi
     fi
 
-    local junk='(386|asc|md5|sha256|sig|sum|vsix|[\.](apk|deb|json|pkg|rpm|sh|txt)*(#e|[\.]*))'
+    local junk='(386|asc|md5|sha256|sig|sum|vsix|[\.](deb|rpm)(#e|[\.]*)|[\.](apk|json|pkg|sh|txt)(#e))'
     filtered=( ${list[@]:#(#i)*${~junk}*} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} )
 
     local -a array=( $(print -rm "*(${MACHTYPE}|${VENDOR}|)*~^*(${parts[1]}|${(L)$(uname)})*" $list[@]) )


### PR DESCRIPTION
## Description

The [latest starship release](https://github.com/starship/starship/releases/tag/v1.17.1) added a `pkg` file for only aarch64 macOS, but zinit does not support the archive type because it requires sudo rights.

If a user wants to use the `pkg` type, it is still possible by using `bpick`.

```zsh
zinit for \
    from'gh-r' \
    bpick'*pkg' \
  @starship/starship
```

## Usage examples

<img width="1719" alt="Screenshot 2024-01-02 at 6 29 07 PM" src="https://github.com/zdharma-continuum/zinit/assets/10052309/b14aa4ba-ff68-4c78-9b27-b8acd1215b47">

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [X] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.