### PR TITLE
style: change log message prefix color to blue

### DIFF
--- a/zinit.zsh
+++ b/zinit.zsh
@@ -226,7 +226,6 @@ if [[ -z $SOURCED && ( ${+terminfo} -eq 1 && -n ${terminfo[colors]} ) || ( ${+te
     col-dbg $'\e[2m\e[38;47;107m'"[debug]"$'\e[0m'
     col-e $'\e[1m\e[38;5;204m'"Error"$'\e[0m'":"
     col-i $'\e[1m\e[38;5;82m'"==>"$'\e[0m'
-    col-m $'\e[1m\e[38;5;135m'"==>"$'\e[0m'
     col-m $'\e[38;5;4m'"==>"$'\e[0m'
     col-w $'\e[1m\e[38;5;214m'"Warning"$'\e[0m'":"
 

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -222,11 +222,12 @@ if [[ -z $SOURCED && ( ${+terminfo} -eq 1 && -n ${terminfo[colors]} ) || ( ${+te
     col-ehi     $'\e[1m\e[38;5;210m'    col-meta    $'\e[38;5;57m'          col-pname   $'\e[1;4m\e[32m'     col-var     $'\e[38;5;81m'
     col-error   $'\e[1m\e[38;5;204m'    col-meta2   $'\e[38;5;147m'         col-pre     $'\e[38;5;135m'      col-version $'\e[3;38;5;87m'
     col-failure $'\e[38;5;204m'         col-msg     $'\e[0m'                col-profile $'\e[38;5;148m'      col-warn    $'\e[38;5;214m'
-    
+
     col-dbg $'\e[2m\e[38;47;107m'"[debug]"$'\e[0m'
     col-e $'\e[1m\e[38;5;204m'"Error"$'\e[0m'":"
-    col-i $'\e[1m\e[38;5;82m'"==>"$'\e[0m' 
-    col-m $'\e[1m\e[38;5;135m'"==>"$'\e[0m' 
+    col-i $'\e[1m\e[38;5;82m'"==>"$'\e[0m'
+    col-m $'\e[1m\e[38;5;135m'"==>"$'\e[0m'
+    col-m $'\e[38;5;4m'"==>"$'\e[0m'
     col-w $'\e[1m\e[38;5;214m'"Warning"$'\e[0m'":"
 
     col--…   "${${${(M)LANG:#*UTF-8*}:+⋯⋯}:-···}"    col-lr "${${${(M)LANG:#*UTF-8*}:+↔}:-"«-»"}"


### PR DESCRIPTION
Not sure when this got changed, but reverting to blue to follow Homebrew log colors.


<img width="1668" alt="Screenshot 2024-01-13 at 10 15 16" src="https://github.com/zdharma-continuum/zinit/assets/10052309/1a1f3ec2-1082-43cd-8269-b7edef5cefa3">