### PR TITLE
fix:  `plugins` command correctly handles keyword argument

### DIFF
--- a/tests/commands.zunit
+++ b/tests/commands.zunit
@@ -37,12 +37,17 @@
 }
 
 @test 'plugins' {
-  run zinit plugins
-  assert $output contains 'Plugins'
-  assert $output contains 'Unloaded: '
-  assert $output contains 'Loaded: '
+  run perl -pe 's/\x1b\[[0-9;]*[mG]//g' <(zinit plugins)
   assert $state equals 0
+  assert $output contains "==> 5 Plugins"
+  assert $output contains 'Loaded: L | Unloaded: U'
 }
+@test 'plugins with keyword' {
+  run perl -pe 's/\x1b\[[0-9;]*[mG]//g' <(zinit plugins zdharma)
+  assert $state equals 0
+  assert $output contains "==> 4 Plugins matching 'zdharma'"
+}
+
 @test 'help' {
   for cmd in 'help' '-h' '--help'; do
     run zinit $cmd

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -1563,29 +1563,29 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
     done
 } # ]]]
 # FUNCTION: .zinit-list-plugins [[[
-# Lists loaded plugins (subcommands list, lodaded)
-.zinit-list-plugins() {
-    builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
+# Lists loaded plugins
+.zinit-list-plugins () {
+    builtin emulate -LR zsh
     setopt extended_glob warn_create_global typeset_silent no_short_loops
     typeset -a filtered
-    local keyword="$1"
-     keyword="${keyword## ##}"
-     keyword="${keyword%% ##}"
-     if [[ -n "$keyword" ]]; then
-         +zi-log "{i} Installed plugins matching {info}$keyword{rst}:"
-         filtered=( "${(M)ZINIT[@]:#STATES__*$keyword*}" )
-     else
-         filtered=(${${(M)${(k)ZINIT[@]}:##STATES__*}//[A-Z]*__/})
-     fi
-     local i
-     +zi-log '{m} {b}Plugins{rst}'
-     for i in "${(o)filtered[@]}"; do
-         [[ "$i" = "local/zinit" ]] && continue
-         local is_loaded='{error}U'
-         (( ZINIT[STATES__${i}] )) && is_loaded="{happy}L"
-         +zi-log -C2 -- $is_loaded{rst} $i
-     done
-     +zi-log -- '{nl}Loaded: {happy}L{rst} | Unloaded: {error}U{rst}'
+    local keyword="${${${1}## ##}%% ##}"
+    if [[ -n "$keyword" ]]; then
+        +zi-log "{dbg} ${(qqq)1} -> ${(qqq)keyword}{rst}"
+        filtered=(${${(k)ZINIT[(I)STATES__*${keyword}*~*(local/zinit)*]}//[A-Z]*__/})
+        +zi-log "{m} ${#filtered} {b}Plugins{rst} matching '{glob}${keyword}{rst}'"
+    else
+        filtered=(${${(M)${(k)ZINIT[@]}:##STATES__*~*local/zinit*}//[A-Z]*__/})
+        +zi-log "{m} ${#filtered} {b}Plugins{rst}"
+    fi
+    local i
+    local -i idx=1
+    for i in "${(o)filtered[@]}"; do
+        local is_loaded='{error}U'
+        (( ZINIT[STATES__${i}] )) && is_loaded="{happy}L"
+        +zi-log "$(print -f "%2d %s %s\n" ${idx} ${is_loaded} {b}${(D)i//[%]/}{rst})"
+        (( idx+=1 ))
+    done
+    +zi-log -- '{nl}Loaded: {happy}L{rst} | Unloaded: {error}U{rst}'
 } # ]]]
 # FUNCTION: .zinit-list-snippets [[[
 .zinit-list-snippets() {


### PR DESCRIPTION
## Description

<img width="1404" alt="Screenshot 2024-01-18 at 7 53 46 PM" src="https://github.com/zdharma-continuum/zinit/assets/10052309/17382b83-b062-4cff-b28c-f5d07e6f4c56">

---

<img width="1342" alt="Screenshot 2024-01-18 at 7 56 23 PM" src="https://github.com/zdharma-continuum/zinit/assets/10052309/3ff83c45-03c1-45d6-b193-7cf733b409e0">

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [X] All new and existing tests passed.
- [x] I have added tests to cover my changes.
- [X] I have updated the documentation accordingly.
