### PR TITLE
test(fx): pin version to 32.0.0

### DIFF
--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -84,7 +84,7 @@
 }
 @test 'broot' { # A new way to see and navigate directory trees
   [[ $OSTYPE =~ 'darwin*' ]] && skip " on $os_type"
-  run zinit lbin'!*${OSTYPE}*/* -> broot' for @Canop/broot; assert $state equals 0
+  run zinit for @Canop/broot; assert $state equals 0
   local broot="$ZBIN/broot"; assert "$broot" is_executable
   run "$broot" --version; assert $state equals 0
 }

--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -233,7 +233,7 @@
   run $fogg version; assert $state equals 0
 }
 @test 'fx' { # Terminal JSON viewer
-  run zinit lbin'!* -> fx' for @antonmedv/fx; assert $state equals 0
+  run zinit lbin'!* -> fx' ver'32.0.0' for @antonmedv/fx; assert $state equals 0
   local fx="$ZBIN/fx"; assert "$fx" is_executable
   run $fx -v; assert $state equals 0
 }


### PR DESCRIPTION
The latest [`fx` release `33.0.0`](https://github.com/antonmedv/fx/releases/tag/33.0.0) has no assets (as of 1710805662) breaking zunit tests.

## Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist:

- [X] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
