### PR TITLE
fix(zinit-install): simplify protocol pattern

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -414,7 +414,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
             ) || return $?
         } elif [[ $tpe = github ]] {
             case ${ICE[proto]} in
-                (|https|git|http|ftp|ftps|rsync|ssh)
+                (|ftp(|s)|git|http(|s)|rsync|ssh)
                     :zinit-git-clone() {
                         command git clone --progress ${(s: :)ICE[cloneopts]---recursive} \
                             ${(s: :)ICE[depth]:+--depth ${ICE[depth]}} \
@@ -886,8 +886,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     ZINIT[annex-multi-flag:pull-active]=${${${(M)update:#-u}:+${ZINIT[annex-multi-flag:pull-active]}}:-2}
 
     (
-        if [[ $url = (http|https|ftp|ftps|scp)://* ]] {
-            # URL
+        if [[ $url = (ftp(|s)|http(|s)|scp)://* ]] {
             (
                 () { setopt localoptions noautopushd; builtin cd -q "$local_dir"; } || return 4
 


### PR DESCRIPTION
## Description

Simplify `.zinit-setup-plugin-dir` protocol pattern

## How Has This Been Tested?

```zsh
test_patterns=(' ' '' 'fgit' 'ftp' 'ftps' 'ftpx' 'ghttps' 'git' 'http' 'https' 'httpss' 'httpx' '  http' 'ssh' 'rsync')
protocol_pattern='(|ftp(|s)|git|http(|s)|rsync|ssh)'
for p in $test_patterns[@]; do
  url="${p}://test-url.com";
  if [[ ${url} = ${~protocol_pattern}://* ]]; then
    P -P "%F{green}pass%f: ${(qqq)p}"
  else
    P -P "%F{red}fail%f: ${(qqq)p}"
  fi
done
```

```console
fail: " "
fail: "fgit"
pass: "ftp"
pass: "ftps"
fail: "ftpx"
fail: "ghttps"
pass: "git"
pass: "http"
pass: "https"
fail: "httpss"
fail: "httpx"
fail: "  http"
pass: "ssh"
pass: "rsync"
```

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [X] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
