### PR TITLE
WIP: fix(ls): fix missing ls command

### DIFF
--- a/tests/commands.zunit
+++ b/tests/commands.zunit
@@ -77,3 +77,7 @@
   run +zi-log -n '{m} message'
   assert $output contains 'message'; assert $state equals 0
 }
+@test 'ls' {
+  run zinit ls
+  assert $state equals 0
+}


### PR DESCRIPTION
## Description

## Related Issue(s)

This PR is fixes #670

## Motivation and Context <!--- What problem does it solve? -->

Fix missing `zinit ls` command

## Usage examples

```zsh
zunit tests/ls.zunit
```

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [ ] All new and existing tests passed. ⚠️ No, test for `zinit ls` currently fails
- [x] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
