### PR TITLE
Allows the user to provide multiple files in the `cp` / `mv` ICE separated by `;`

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -2252,78 +2252,68 @@ __zinit-cmake-base-hook () {
 
     .zinit-extract plugin "$extract" "$dir"
 } # ]]]
+# FUNCTION: ∞zinit-cp-mv-operation-hook [[[
+∞zinit-file-cp-mv-operation() {
+    local cmd="$1" # Either "cp" or "mv"
+    local ice_key="$cmd"
+
+    [[ -z $ICE[$ice_key] ]] && return 0
+
+    [[ "$2" = plugin ]] && \
+      local dir="${6#%}" hook="$7" subtype="$8" || \
+      local dir="${5#%}" hook="$6" subtype="$7"
+
+    # Parse and clean up the ICE directive
+    local -a pairs
+    pairs=( ${(s[;])ICE[$ice_key]} ) # Split on semicolons
+    pairs=( "${pairs[@]//((#s)[[:space:]]##|[[:space:]]##(#e))/}" ) # Trim spaces
+
+    local retval=0
+    for pair in "${pairs[@]}"; do
+        if [[ $pair == *("->"|"→")* ]]; then
+            local from="${pair%%[[:space:]]#(->|→)*}"
+            local to="${pair##*(->|→)[[:space:]]#}"
+        else
+            local from="${pair%%[[:space:]]##*}"
+            local to="${pair##*[[:space:]]##}"
+        fi
+
+        @zinit-substitute from to
+
+        local -a cmd_args=("-f")
+        local -a afr
+
+        (
+            () { setopt localoptions noautopushd; builtin cd -q "$dir"; } || return 1
+            afr=( ${~from}(DN) ) # Expand glob patterns
+
+            if (( ! ${#afr} )); then
+                +zi-log "{warn}Warning: $ice_key ice didn't match any file. [{error}$pair{warn}]" \
+                               "{nl}{warn}Available files:{nl}{obj}$(ls -1)"
+                retval=1
+                continue
+            fi
+            if (( !OPTS[opt_-q,--quiet] )); then
+                cmd_args+=("-v")
+            fi
+
+            for file in "${afr[@]}"; do
+                command "$cmd" "${cmd_args[@]}" "$file" "$to" || retval=$?
+                # Handle .zwc files if they exist
+                command "$cmd" "${cmd_args[@]}" "$file.zwc" "$to.zwc" 2>/dev/null
+            done
+        )
+    done
+
+    return $retval
+} # ]]]
 # FUNCTION: ∞zinit-mv-hook [[[
 ∞zinit-mv-hook() {
-    [[ -z $ICE[mv] ]] && return 0
-
-    [[ "$1" = plugin ]] && \
-        local dir="${5#%}" hook="$6" subtype="$7" || \
-        local dir="${4#%}" hook="$5" subtype="$6"
-
-    if [[ $ICE[mv] == *("->"|"→")* ]] {
-        local from=${ICE[mv]%%[[:space:]]#(->|→)*} to=${ICE[mv]##*(->|→)[[:space:]]#} || \
-    } else {
-        local from=${ICE[mv]%%[[:space:]]##*} to=${ICE[mv]##*[[:space:]]##}
-    }
-
-    @zinit-substitute from to
-
-    local -a mv_args=("-f")
-    local -a afr
-
-    (
-        () { setopt localoptions noautopushd; builtin cd -q "$dir"; } || return 1
-        afr=( ${~from}(DN) )
-
-        if (( ! ${#afr} )) {
-            +zi-log "{warn}Warning: mv ice didn't match any file. [{error}$ICE[mv]{warn}]" \
-                           "{nl}{warn}Available files:{nl}{obj}$(ls -1)"
-            return 1
-        }
-        if (( !OPTS[opt_-q,--quiet] )) {
-            mv_args+=("-v")
-        }
-
-        command mv "${mv_args[@]}" "${afr[1]}" "$to"
-        local retval=$?
-        command mv "${mv_args[@]}" "${afr[1]}".zwc "$to".zwc 2>/dev/null
-        return $retval
-    )
+    ∞zinit-file-cp-mv-operation "mv" "$@"
 } # ]]]
 # FUNCTION: ∞zinit-cp-hook [[[
 ∞zinit-cp-hook() {
-    [[ -z $ICE[cp] ]] && return
-
-    [[ "$1" = plugin ]] && \
-        local dir="${5#%}" hook="$6" subtype="$7" || \
-        local dir="${4#%}" hook="$5" subtype="$6"
-
-    if [[ $ICE[cp] == *("->"|"→")* ]] {
-        local from=${ICE[cp]%%[[:space:]]#(->|→)*} to=${ICE[cp]##*(->|→)[[:space:]]#} || \
-    } else {
-        local from=${ICE[cp]%%[[:space:]]##*} to=${ICE[cp]##*[[:space:]]##}
-    }
-
-    @zinit-substitute from to
-
-    local -a afr retval
-    ( () { setopt localoptions noautopushd; builtin cd -q "$dir"; } || return 1
-      afr=( ${~from}(DN) )
-      if (( ${#afr} )) {
-          if (( !OPTS[opt_-q,--quiet] )) {
-              command cp -vf "${afr[1]}" "$to"
-              retval=$?
-              # ignore errors if no compiled file is found
-              command cp -vf "${afr[1]}".zwc "$to".zwc 2>/dev/null
-          } else {
-              command cp -f "${afr[1]}" "$to"
-              retval=$?
-              # ignore errors if no compiled file is found
-              command cp -f "${afr[1]}".zwc "$to".zwc 2>/dev/null
-          }
-      }
-      return $retval
-    )
+    ∞zinit-file-cp-mv-operation "cp" "$@"
 } # ]]]
 # FUNCTION: ∞zinit-compile-plugin-hook [[[
 ∞zinit-compile-plugin-hook () {


### PR DESCRIPTION
## Description

- [Improved maintanability / reducing boilerplate code] Refactored code to share the same code basis for ICE `cp` and `mv`
- [New feature] Allows the user to provide multiple files in the `cp` / `mv` ICE separated by `;` This aligns with other ICE options, where the user can provide multiple files.