### PR TITLE
fix: global variable in ∞zinit-file-cp-mv-operation

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -2268,7 +2268,7 @@ __zinit-cmake-base-hook () {
     pairs=( ${(s[;])ICE[$ice_key]} ) # Split on semicolons
     pairs=( "${pairs[@]//((#s)[[:space:]]##|[[:space:]]##(#e))/}" ) # Trim spaces
 
-    local retval=0
+    local pair retval=0
     for pair in "${pairs[@]}"; do
         if [[ $pair == *("->"|"→")* ]]; then
             local from="${pair%%[[:space:]]#(->|→)*}"


### PR DESCRIPTION
## Description
"pair" variable was not localized within ∞zinit-file-cp-mv-operation function
## Related Issue(s)

<!--- If it fixes an open issue, add a link the issue -->

## Motivation and Context <!--- What problem does it solve? -->
Fixes `∞zinit-file-cp-mv-operation:16: scalar parameter pair created globally in function ∞zinit-file-cp-mv-operation` message during mv/cp operations using this function
## Usage examples
![image](https://github.com/user-attachments/assets/8c8005d8-f42b-4b52-8efd-3a0704b291bd)

## How Has This Been Tested?
Rerunning the operation that caused the error:
![image](https://github.com/user-attachments/assets/67276734-eb78-4237-8581-82f11cead640)

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [ ] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
