### PR TITLE
ci: disable navi gh-r test on mac os

### DIFF
--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -582,6 +582,7 @@
   run $moonwalk --version; assert $state equals 0
 }
 @test 'navi' { # An interactive cheatsheet tool for the command-line
+  [[ $OSTYPE =~ 'darwin*' ]] && skip "skipped on $os_type"
   run zinit lbin'!* -> navi' for @denisidoro/navi; assert $state equals 0
   local navi="$ZBIN/navi"; assert "$navi" is_executable
   run $navi --version; assert $state equals 0


### PR DESCRIPTION
There's no mac-os release: https://github.com/denisidoro/navi/releases/tag/v2.24.0