### PR TITLE
ci: disable container builds for old versions of zsh

### DIFF
--- a/.github/workflows/containers.yaml
+++ b/.github/workflows/containers.yaml
@@ -15,12 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         zsh_version:
-          - 5.2.4
-          - 5.3.1
-          - 5.4.2
-          - 5.5.1
-          - 5.6.2
-          - 5.7.1
           - 5.8
           - 5.9
     steps:


### PR DESCRIPTION
Ref #687 