### PR TITLE
fix: correct SSH URL format for private repos

### DIFF
--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -416,9 +416,15 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
             case ${ICE[proto]} in
                 (|ftp(|s)|git|http(|s)|rsync|ssh)
                     :zinit-git-clone() {
+                        local clone_url
+                        if [[ ${ICE[proto]} == "ssh" ]]; then
+                            clone_url="git@${site:-${ICE[from]:-github.com}}:$remote_url_path"
+                        else
+                            clone_url="${ICE[proto]:-https}://${site:-${ICE[from]:-github.com}}/$remote_url_path"
+                        fi
                         command git clone --progress ${(s: :)ICE[cloneopts]---recursive} \
                             ${(s: :)ICE[depth]:+--depth ${ICE[depth]}} \
-                            "${ICE[proto]:-https}://${site:-${ICE[from]:-github.com}}/$remote_url_path" \
+                            "$clone_url" \
                             "$local_path" \
                             --config transfer.fsckobjects=false \
                             --config receive.fsckobjects=false \


### PR DESCRIPTION
## Description
Fixed an issue with SSH protocol URL formatting for private repositories. The code now properly handles SSH URLs when cloning private repositories.

## Related Issue(s)
Does not fix an open issue.

## Motivation and Context 
When trying to load some custom zsh plugins I created from a private repo, zinit was unable to clone from the private repo.

## Usage examples

```zsh
# Using SSH protocol with private repository (existing functionality now works)
zinit ice proto"ssh"
zinit load "username/private-repo"
```

## How Has This Been Tested?

## Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
