### PR TITLE
Fix: Timeout on downloading from GH releases

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -67,8 +67,7 @@ jobs:
       - name: "install dependencies"
         id: install-deps
         run: |
-          brew uninstall -f cmake || true
-          brew install --force --overwrite autoconf automake binutils byacc cmake coreutils curl gettext gnu-sed libevent libtool libuv lua lua@5.4 make ncurses ninja parallel pkg-config texinfo unzip xz zsh
+          brew install --force --overwrite autoconf automake binutils byacc coreutils curl gettext gnu-sed libevent libtool libuv lua lua@5.4 make ncurses ninja parallel pkg-config texinfo unzip xz zsh
           brew link --force --overwrite ncurses
 
       - name: "install zunit"

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -67,6 +67,7 @@ jobs:
       - name: "install dependencies"
         id: install-deps
         run: |
+          brew uninstall -f cmake || true
           brew install --force --overwrite autoconf automake binutils byacc cmake coreutils curl gettext gnu-sed libevent libtool libuv lua lua@5.4 make ncurses ninja parallel pkg-config texinfo unzip xz zsh
           brew link --force --overwrite ncurses
 

--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -6,6 +6,7 @@
   HOME="$zi_test_dir" # Stops programs creating directories in user home
   typeset -gx ZBIN="$zi_test_dir/polaris/bin" os_type="${OSTYPE//[0-9\.]*/}"
   [[ ! -d $ZBIN ]] && mkdir -p "$ZBIN"
+  arch=$(uname -m)
   zinit default-ice --quiet from'gh-r' lbin'!' null
 }
 
@@ -104,7 +105,7 @@
   run "$certificates" --version; assert $state equals 0
 }
 @test 'checkmake' { # experimental linter/analyzer for Makefiles
-  run zinit lbin'!checkmake* -> checkmake' for @mrtazz/checkmake; assert $state equals 0
+  run zinit lbin'!checkmake* -> checkmake' for @checkmake/checkmake; assert $state equals 0
   local checkmake="$ZBIN/checkmake"; assert "$checkmake" is_executable
   run $checkmake --version; assert $state equals 0
 }
@@ -197,7 +198,7 @@
 }
 @test 'dysk' { # A linux utility to get information on filesystems, like df but better
   [[ $OSTYPE =~ 'darwin*' ]] && skip "skipped on $os_type"
-  run zinit lbin'!**/x86_64-linux/* -> dysk' for @Canop/dysk; assert $state equals 0
+  run zinit lbin"!**/$arch*$os_type/* -> dysk" for @Canop/dysk; assert $state equals 0
   local dysk="$ZBIN/dysk"; assert "$dysk" is_executable
   run $dysk --version; assert $state equals 0
 }
@@ -298,7 +299,7 @@
   run "$git_sizer" --version; assert $state equals 0
 }
 @test 'gitui' { # Blazing fast terminal-ui for git written in rust
-  run zinit for @extrawurst/gitui; assert $state equals 0
+  run zinit for @gitui-org/gitui; assert $state equals 0
   local gitui="$ZBIN/gitui"; assert "$gitui" is_executable
   run "$gitui" --version; assert $state equals 0
 }
@@ -814,6 +815,7 @@
   run $yq --version; assert $state equals 0
 }
 @test 'zed' { # Tooling for super-structured data: a new and easier way to manipulate data
+  skip "Official Doc: SuperDB is still under development so there's not yet a GA release."
   run zinit for @brimdata/super; assert $state equals 0
   local zed="$ZBIN/zed"; assert "$zed" is_executable
   run $zed --version; assert $state equals 0

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -356,7 +356,8 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
         if [[ $site = */releases ]] {
             local tag_version=${ICE[ver]}
             if [[ -z $tag_version ]]; then
-                tag_version="$({.zinit-download-file-stdout $site/latest || .zinit-download-file-stdout $site/latest 1;} 2>/dev/null | command grep -i -m 1 -o 'href=./'$user'/'$plugin'/releases/tag/[^"]\+')"
+                local url="https://$site/latest"
+                tag_version="$({.zinit-download-file-stdout $url || .zinit-download-file-stdout $url 1;} 2>/dev/null | command grep -i -m 1 -o 'href=./'$user'/'$plugin'/releases/tag/[^"]\+')"
                 tag_version=${tag_version##*/}
             fi
             local url=$site/expanded_assets/$tag_version


### PR DESCRIPTION
## Description

Fix the single point where `zinit-download-file-stdout` is called without a scheme. Because of this, curl defaults to `http://` and attempts to connect to port 80. The GitHub release isn't responding to the `http` scheme, and after a while, curl fails with a timeout error.

## Related Issue(s)
[[bug]: Downloading from GH releases seems to be broken](https://github.com/zdharma-continuum/zinit/issues/736)

## Changes

- Concatenate `https://` with `site` before call `.zinit-download-file-stdout` function. This prevents `curl` from hanging when attempting to connect to `github.com:80`.  
- Fix unit test errors
  - **checkmake**: project has changed  
  - **dysk**: fix path pattern  
  - **gitui**: project has changed  
  - **zed**: skipped. The project's README includes a warning that there's no GitHub Release yet.  
- Remove `cmake` from Homebrew installation  
  - All tests on macOS were not working 

## Usage examples

### Before
```zsh
zinit light-mode lucid from"gh-r" completions for \
        wait \
        atclone"cp -f **/bat.1 $ZPFX/man/man1/bat.1" \
        atpull'%atclone' \
        atload"alias cat='bat'" \
        cp"**/autocomplete/bat.zsh -> _bat" \
        lbin"**/bat" \
        id-as"bat" \
    @sharkdp/bat

# result
==> Downloading sharkdp/bat (at label: bat)
Error: gh-r: No GitHub release assets found for
```

### After
```zsh
zinit light-mode lucid from"gh-r" completions for \
        wait \
        atclone"cp -f **/bat.1 $ZPFX/man/man1/bat.1" \
        atpull'%atclone' \
        atload"alias cat='bat'" \
        cp"**/autocomplete/bat.zsh -> _bat" \
        lbin"**/bat" \
        id-as"bat" \
    @sharkdp/bat

#result
==> Downloading sharkdp/bat (at label: bat)
==> Requesting bat-v0.25.0-x86_64-unknown-linux-gnu.tar.gz
###################################################################100.0%
[ziextract] Unpacking the files from: `bat-v0.25.0-x86_64-unknown-linux-gnu.tar.gz'…
[ziextract] Successfully extracted and assigned +x chmod to the file: bat-v0.25.0-x86_64-unknown-linux-gnu/bat.
'bat-v0.25.0-x86_64-unknown-linux-gnu/autocomplete/bat.zsh' -> '_bat'
==> linkbin: Created bat hard link & set +x on the bat binary
==> linkbin: Created bat hard link & set +x on the bat binary
==> Skipped re-installing 1 completion
```

## Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist

- [x] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.

## Additional context

I couldn't reproduce this error in the `Unit Test` GitHub Workflow, but I was able to reproduce it on my local machine and in a Docker container built from [.docker/Dockerfile](https://github.com/zdharma-continuum/zinit/blob/main/docker/Dockerfile).