### PR TITLE
Feature: Add configurable non-interactive pager for updates

### DIFF
--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -683,6 +683,10 @@ ZINIT[EXTENDED_GLOB]=""
     .zinit-compinit >/dev/null
 } # ]]]
 
+#
+# User-exposed functions
+#
+
 # FUNCTION: .zinit-pager [[[
 # BusyBox less lacks the -X and -i options, so it can use more
 .zinit-pager() {


### PR DESCRIPTION

### Description

#### 1. The Problem This Solves

The default behavior of `zinit update` is to use an interactive pager (`less`) to display the `git log` for each updated plugin. This has several drawbacks for user experience:

*   **It's Blocking**: The entire update process halts, waiting for user input (`q`) for every single plugin that has new commits.
*   **It's Disruptive**: The pager takes over the full terminal screen, causing the user to lose the context of which plugin is currently being updated.
*   **It's Inefficient**: When updating many plugins, this requires constant manual intervention.

This PR introduces a new, configurable non-interactive mode for the pager to provide a much smoother and more efficient update experience.

#### 2. The Solution

This PR enhances the `.zinit-pager` function by introducing two new `ZINIT` hash keys that allow users to globally configure the pager's behavior:

*   **`ZINIT[NO_PAGER]`**: When set to a truthy value (`1`, `true`, `on`, `yes`), it enables a non-interactive mode, similar to always running `zinit update --no-pager`.

*   **`ZINIT[NO_PAGER_MAX_LINES]`**: This key works in conjunction with `ZINIT[NO_PAGER]` to refine the output:
    *   If set to a **positive integer** (e.g., `10`), it will show only the first `10` lines of the log using `head`.
    *   If set to **`0`**, it will completely suppress the log output by piping it to `/dev/null`.
    *   If **not set**, the full log will be shown via `cat`.

This logic is nested, meaning `NO_PAGER_MAX_LINES` only has an effect when the non-interactive mode is enabled.

#### 3. How to Use the New Configuration

Users can add these settings to their `.zshrc` after sourcing Zinit to customize the update process:

**Example 1: Show the first 7 lines of logs, non-interactively.**
This is the recommended setting for a non-blocking but informative update.
```zsh
# In .zshrc
ZINIT[NO_PAGER]=1
ZINIT[NO_PAGER_MAX_LINES]=7
```

**Example 2: Completely suppress all update logs for a silent experience.**
```zsh
# In .zshrc
ZINIT[NO_PAGER]=1
ZINIT[NO_PAGER_MAX_LINES]=0
```

**Example 3: Show all logs without any interactive pausing (full scroll).**
```zsh
# In .zshrc
ZINIT[NO_PAGER]=1
```

#### 4. Backward Compatibility

This change is **fully backward-compatible**. If neither of the new `ZINIT` keys are set, the `.zinit-pager` function falls back to its original behavior of using an interactive `less` or `more` command. The existing `--no-pager` command-line flag is also still respected.

---

#### A Note on the `git log` Behavior

It's worth noting that the motivation for this feature is partly due to the sometimes confusing output of Zinit's current `git log` implementation. The command `git log ..FETCH_HEAD` is used to generate the changelog.

When a plugin is checked out to a specific tag (e.g., via the `ver` ice), it enters a "detached HEAD" state. During an update, `FETCH_HEAD` points to the tip of the remote's default branch. The resulting log shows *all* commits between the old tag and the branch tip, which can be a very long and irrelevant history.

While this PR does not change the log generation itself, it provides users with the necessary tools to effectively manage and suppress this verbose output, significantly improving the `update` experience.