### PR TITLE
fix: add markdownlint exceptions to linting

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -19,13 +19,15 @@ jobs:
       - uses: xt0rted/markdownlint-problem-matcher@v3
 
       - run: npm install -g markdownlint-cli
-
       # disabled checks:
-      # - MD013/line-length
-      # - MD033/no-inline-html
-      # - MD034/no-bare-urls
-      # - MD036/no-emphasis-as-heading
-      # - MD041/first-line-heading/first-line-h1
+      # MD013/line-length
+      # MD024/no-duplicate-heading
+      # MD033/no-inline-html
+      # MD034/no-bare-urls
+      # MD036/no-emphasis-as-heading
+      # MD041/first-line-heading/first-line-h1
+      # MD059/descriptive-link-text
+      # MD060/table-column-style
       - run: |
           markdownlint --version
 
@@ -33,9 +35,9 @@ jobs:
           ls *.md **/*.md
 
           markdownlint \
+            --disable MD013 MD024 MD029 MD033 MD034 MD036 MD041 MD059 MD060 \
             --ignore '**/CHANGELOG.md' \
-            --disable MD013 MD033 MD034 MD036 MD041 -- \
-            *.md **/*.md
+            -- *.md **/*.md
 
   zshlint:
     name: ZSH Lint

--- a/README.md
+++ b/README.md
@@ -677,9 +677,9 @@ your `~/.zshrc` there if it contains Zinit commands.
 You can also check out the [Gallery of Zinit Invocations](https://zdharma-continuum.github.io/zinit/wiki/GALLERY/) for
 some additional examples.
 
-Also, two articles on the Wiki present an example setup
-[here](https://zdharma-continuum.github.io/zinit/wiki/Example-Minimal-Setup/) and
-[here](https://zdharma-continuum.github.io/zinit/wiki/Example-Oh-My-Zsh-setup/).
+Also, two articles on the Wiki present a
+[Minimal Setup](https://zdharma-continuum.github.io/zinit/wiki/Example-Minimal-Setup/) and
+[Oh-My-Zsh Setup](https://zdharma-continuum.github.io/zinit/wiki/Example-Oh-My-Zsh-setup/).
 
 # How to Use<a name="how-to-use"></a>
 
@@ -1058,7 +1058,7 @@ skip_global_compinit=1
 On NixOS, the global `compinit` call can be disabled system-wide by setting the following option in your
 `/etc/nixos/configuration.nix`:
 
-```
+```nix
 # Disable global completion init to speed up `compinit` call in `~/.zshrc`.
 programs.zsh.enableGlobalCompInit = false;
 ```

--- a/doc/HACKING.md
+++ b/doc/HACKING.md
@@ -63,51 +63,51 @@ To add a new test case:
 
 1. Install [zunit](https://zunit.xyz) and [revolver](https://github.com/molovo/revolver):
 
-    ```zsh
-    zinit for \
-        as"program" \
-        atclone"ln -sfv revolver.zsh-completion _revolver" \
-        atpull"%atclone" \
-        pick"revolver" \
-      @molovo/revolver \
-        as"completion" \
-        atclone"./build.zsh; ln -sfv zunit.zsh-completion _zunit" \
-        atpull"%atclone" \
-        sbin"zunit" \
-      @zunit-zsh/zunit
-    ```
+```zsh
+zinit for \
+    as"program" \
+    atclone"ln -sfv revolver.zsh-completion _revolver" \
+    atpull"%atclone" \
+    pick"revolver" \
+  @molovo/revolver \
+    as"completion" \
+    atclone"./build.zsh; ln -sfv zunit.zsh-completion _zunit" \
+    atpull"%atclone" \
+    sbin"zunit" \
+  @zunit-zsh/zunit
+```
 
 2. Create a new `.zunit` file in the `tests/` dir. Here's a template:
 
-    ```zsh
-    #!/usr/bin/env zunit
+```zsh
+#!/usr/bin/env zunit
 
-    @setup {
-      load setup
-      setup
-    }
+@setup {
+  load setup
+  setup
+}
 
-    @teardown {
-      load teardown
-      teardown
-    }
+@teardown {
+  load teardown
+  teardown
+}
 
-    @test 'zinit-annex-bin-gem-node installation' {
-      # This spawns the official zinit container and executes a single zinit command
-      # inside it
-      run ./scripts/docker-run.sh --wrap --debug --zunit \
-        zinit light as"null" for zdharma-continuum/null
+@test 'zinit-annex-bin-gem-node installation' {
+  # This spawns the official zinit container and executes a single zinit command
+  # inside it
+  run ./scripts/docker-run.sh --wrap --debug --zunit \
+    zinit light as"null" for zdharma-continuum/null
 
-      # Verify the exit code of the command above
-      assert $state equals 0
-      assert "$output" contains "Downloading"
+  # Verify the exit code of the command above
+  assert $state equals 0
+  assert "$output" contains "Downloading"
 
-      local artifact="${PLUGINS_DIR}/zdharma-continuum---null/readme.md"
-      # Check if we downloaded the file correctly and if it is readable
-      assert "$artifact" is_file
-      assert "$artifact" is_readable
-    }
-    ```
+  local artifact="${PLUGINS_DIR}/zdharma-continuum---null/readme.md"
+  # Check if we downloaded the file correctly and if it is readable
+  assert "$artifact" is_file
+  assert "$artifact" is_readable
+}
+```
 
 You should, of course, also check out the existing tests ;)
 


### PR DESCRIPTION
Disabled following checks:

- MD024/no-duplicate-heading
- MD059/descriptive-link-text
- MD060/table-column-style

## Motivation and Context <!--- What problem does it solve? -->

Get CI to pass

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [X] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
