### PR TITLE
fix: resolves a bug with github action trying to push updated docs back to external forks

### DIFF
--- a/.github/workflows/documentation.yaml
+++ b/.github/workflows/documentation.yaml
@@ -9,6 +9,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'zinit*.zsh'
   workflow_dispatch:
 
 jobs:
@@ -19,15 +21,16 @@ jobs:
       - name: checkout repository
         uses: actions/checkout@v6
         with:
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}
+          ref: ${{ github.event.pull_request.head.ref || github.ref }}
 
       - name: re-generate documentation
         run: |
           make doc/container
           sudo chown -R "$(id -u):$(id -g)" .
 
-      - name: commit changes to the current branch
+      - name: commit and push updated docs
+        if: github.event_name != 'pull_request'
         uses: EndBug/add-and-commit@v9
         with:
           add: 'doc'


### PR DESCRIPTION
## Summary

Fix the documentation workflow (`zshelldoc`) failing on pull requests from forks.

## The problem

When someone opens a pull request from a fork, the documentation workflow:

1. Checks out the code from the fork
2. Regenerates the documentation using zshelldoc
3. Tries to push the updated docs back to the fork

Step 3 always fails because GitHub's built-in bot (`github-actions[bot]`) only has permission to write to the main repository, not to external forks. This produces the error:

```
remote: Permission to <fork>.git denied to github-actions[bot].
fatal: unable to access 'https://github.com/<fork>/': The requested URL returned error: 403
```

## The fix

The workflow now behaves differently depending on how it was triggered:

- **On pull requests**: The workflow still runs zshelldoc to verify that the documentation can be generated without errors. This acts as a CI check — if a code change breaks zshelldoc, the PR will show a failure. However, it **skips** the commit-and-push step, avoiding the permissions error.

- **On pushes to `main`** (i.e., after a PR is merged): The workflow runs zshelldoc **and** commits the updated docs back to the repository, as before.

This is achieved with a single line added to the commit step:

```yaml
if: github.event_name != 'pull_request'
```

This tells GitHub Actions: "only run this step when the trigger is not a pull request."

## Additional improvement

Added a `paths` filter to the push trigger, so documentation is only regenerated when `zinit*.zsh` files are actually modified. Previously, any push to `main` would trigger a doc rebuild even if only unrelated files changed. The pull request trigger already had this filter.
