### PR TITLE
fix: trust archive permissions instead of `file(1)` heuristics in `ziextract`

### DIFF
--- a/tests/ices.zunit
+++ b/tests/ices.zunit
@@ -2,6 +2,21 @@
 
 @setup {
   ZPLUGINS=$ZINIT[PLUGINS_DIR]
+  function _zunit_assert_not_executable(){
+    local pathname=$1 filepath
+
+    # If filepath is relative, prepend the test directory
+    if [[ "${pathname:0:1}" != "/" ]]; then
+      filepath="$testdir/${pathname}"
+    else
+      filepath="$pathname"
+    fi
+
+    [[ ! -x "$filepath" ]] && return 0
+
+    echo "'$pathname' is executable but should not be"
+    exit 1
+  }
   function _zunit_assert_not_exists(){
     local file_path=$1
     if [[ "${file_path:0:1}" != "/" ]]; then # relative path - prepend the test directory
@@ -118,6 +133,39 @@
   assert "$workdir/file1.txt" is_file
   assert "$workdir/test.zip" is_file
   rm -rf "$workdir"
+}
+@test 'ziextract-permissions' {
+  # Build a zip with known permissions, call ziextract directly, and verify
+  # that only files with +x in the archive come out executable.
+  local srcdir workdir
+  srcdir=$(mktemp -d)
+  workdir=$(mktemp -d)
+
+  # run_me.sh: +x in archive, has shebang  → must be executable
+  printf '#!/bin/sh\necho run\n' > "$srcdir/run_me.sh"
+  chmod +x "$srcdir/run_me.sh"
+
+  # also_run.py: no +x in archive, has shebang  → must NOT be executable (shebang alone is not enough)
+  printf '#!/usr/bin/env python3\nprint("hi")\n' > "$srcdir/also_run.py"
+
+  # library.py: no +x, no shebang  → must NOT be executable
+  printf 'def foo(): pass\n' > "$srcdir/library.py"
+
+  # pre_marked.sh: +x in archive, no shebang  → must be executable (archive bit)
+  printf 'echo pre\n' > "$srcdir/pre_marked.sh"
+  chmod +x "$srcdir/pre_marked.sh"
+
+  # Build zip preserving permissions, then extract via ziextract
+  ( cd "$srcdir" && zip -q "$workdir/test.zip" run_me.sh also_run.py library.py pre_marked.sh )
+  (( ${+functions[ziextract]} )) || builtin source "${ZINIT[BIN_DIR]}/zinit-install.zsh"
+  ( builtin cd "$workdir" && ziextract test.zip )
+
+  assert "$workdir/run_me.sh"     is_executable
+  assert "$workdir/pre_marked.sh" is_executable
+  assert "$workdir/also_run.py"   not_executable
+  assert "$workdir/library.py"    not_executable
+
+  rm -rf "$srcdir" "$workdir"
 }
 
 # vim:ft=zsh:sw=2:sts=2:et:foldmarker=\ {,}:foldmethod=marker

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1514,9 +1514,9 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 } # ]]]
 # FUNCTION: ziextract [[[
 # If the file is an archive, it is extracted by this function.
-# Next stage is scanning of files with the common utility file
-# to detect executables. They are given +x mode. There are also
-# messages to the user on performed actions.
+# Executable permissions are determined solely by the execute bit already
+# stored in the archive — i.e. whatever the package author intended.
+# No heuristics (file(1), shebang scanning, etc.) are applied.
 #
 # $1 - url
 # $2 - file
@@ -1757,13 +1757,21 @@ ziextract() {
     }
     unfunction -- .zinit-extract-wrapper
 
+    # Glob qualifier legend:
+    #   (DN-.)  — D=include dotfiles, N=null glob (no error if empty),
+    #             -=no symlinks, .=regular files  → all regular files
+    #   (DN-*.) — same plus *=has execute bit set → files already marked
+    #             executable by the archive extractor
     local -aU execs
-    execs=( **/*~(._zinit(|/*)|.git(|/*)|.svn(|/*)|.hg(|/*)|._backup(|/*))(DN-.) )
-    if [[ ${#execs} -gt 0 && -n $execs ]] {
-        execs=( ${(@f)"$( file ${execs[@]} )"} )
-        execs=( "${(M)execs[@]:#[^(:]##:*executable*}" )
-        execs=( "${execs[@]/(#b)([^(:]##):*/${match[1]}}" )
-    }
+    # Collect files that already have the execute bit set in the archive.
+    # This is the authoritative signal: if the package author wanted a file
+    # executable, they set +x when creating the archive. Any file that lacks
+    # +x in the archive (library, documentation, data file, …) should stay
+    # non-executable regardless of its content or extension.
+    # If a poorly maintained package fails to set permissions correctly,
+    # the user can fix it with the atclone/atpull ices — there is no need
+    # for zinit to second-guess the archive on every install.
+    execs=( **/*~(._zinit(|/*)|.git(|/*)|.svn(|/*)|.hg(|/*)|._backup(|/*))(DN-*.) )
 
     builtin print -rl -- ${execs[@]} >! ${TMPDIR:-/tmp}/zinit-execs.$$.lst
     if [[ ${#execs} -gt 0 ]] {


### PR DESCRIPTION
## Problem

This PR fixes a bug in `ziextract`, the function responsible for unpacking archives
when installing plugins via `from'gh-r'` or any tarball download.

The original developer added a well-intentioned feature: after extracting an archive,
zinit would automatically detect which files are executables and set the `+x` permission
on them, so the user would not have to do it manually. To detect executables, the code
used the standard Unix utility `file(1)`, which can inspect file contents and report
what kind of file each one is.

The problem is that `file(1)` does not actually tell you whether a file *should* be
executable. It tells you what *kind* of content a file contains. In practice, `file(1)`
labels any file containing common Python syntax — including documentation files, Vim
scripts, and test data — as `"Python script text executable"`. Zinit's code then sees
the word `"executable"` in that output and dutifully applies `chmod +x` to all of them,
including files that have no business being executable at all.

**Reproduction** — install Neovim from its GitHub nightly release:

```zsh
zinit lucid as'null' from'gh-r' for @neovim/neovim
```

The archive contains exactly 9 files with the execute bit set (`bin/nvim`,
`lib/nvim/parser/*.so`, `share/nvim/runtime/scripts/less.sh`). After installation,
`fd -t=x` reveals that many additional files have been marked executable:

```
bin/nvim
lib/nvim/parser/c.so
lib/nvim/parser/lua.so
lib/nvim/parser/markdown.so
lib/nvim/parser/markdown_inline.so
lib/nvim/parser/query.so
lib/nvim/parser/vim.so
lib/nvim/parser/vimdoc.so
share/nvim/runtime/autoload/python3complete.vim
share/nvim/runtime/autoload/pythoncomplete.vim
share/nvim/runtime/doc/if_pyth.txt
share/nvim/runtime/doc/remote_plugin.txt
share/nvim/runtime/indent/testdir/bash.in
share/nvim/runtime/indent/testdir/bash.ok
share/nvim/runtime/indent/testdir/bitbake.in
share/nvim/runtime/indent/testdir/bitbake.ok
share/nvim/runtime/scripts/less.sh
```

## Root Cause

The `file(1)` magic database emits `"Python script text executable"` for **any file
whose content matches common Python syntax patterns** — `import`, `class`, `def`,
`try/except` — regardless of shebangs or filesystem permissions. A Vim documentation
file (`if_pyth.txt`) that merely documents the Python interface is enough to trigger it:

```
$ file share/nvim/runtime/doc/if_pyth.txt
share/nvim/runtime/doc/if_pyth.txt: Python script text executable, ASCII text
```

The word `"executable"` in `file(1)` output means *"this is a file written in a
language that can be run"* — not *"this file should have the execute permission bit"*.
Zinit's filter was asking the wrong question. To make matters worse, `file(1)` applies
this label even to Python files with **no shebang line** — files that the kernel would
refuse to execute directly anyway, since there is no interpreter specified.

## Fix

Replace the `file(1)`-based detection with a single glob that collects only files
whose execute bit is **already set in the archive**:

```zsh
execs=( **/*~(._zinit(|/*)|.git(|/*)|.svn(|/*)|.hg(|/*)|._backup(|/*))(DN-*.) )
# Glob qualifier legend:
#   (DN-.)  — D=include dotfiles, N=null glob, -=no symlinks, .=regular files
#   (DN-*.) — same plus *=has execute bit set
```

This is the authoritative signal: if the package author wanted a file executable, they
set `+x` when creating the archive. Any file that lacks `+x` in the archive — library
module, documentation, data file — should stay non-executable regardless of its
content. If a plugin or app is packaged with wrong permissions — rare but possible —
the best course of action is for the user to correct them via `atclone`/`atpull`,
rather than having zinit apply heuristics that will assign wrong permissions far more
often than they fix anything.

## Discussion: shebang-based detection

An alternative considered during this fix is to additionally mark executable any file
that has a shebang (`#!`) but was not `+x` in the archive — to compensate for packages
that forget to set permissions. Eventually, this was deliberately left out for two reasons:

1. A shebang does not reliably indicate that a file *should* be `+x`. The
   `#!/hint/zsh` pattern, common in the zinit ecosystem, is used purely as an editor
   syntax hint and is explicitly not meant to make a file executable.
2. If a plugin or app is packaged with wrong permissions — rare but possible — the
   best course of action is for the user to correct them via `atclone`/`atpull`,
   rather than having zinit apply heuristics that will assign wrong permissions far
   more often than they fix anything.

Feedback on this decision is welcome.