### PR TITLE
fix: remove `local -A OPTS` that shadows caller's parallel flag

### DIFF
--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -3398,10 +3398,12 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
 
     local -F2 SECONDS=0
 
-    # Always run quietly during bulk updates
-    local -A OPTS
+    # Silence self-update during bulk updates, then restore the original quiet state
+    # (avoid re-declaring OPTS as local — it would shadow the caller's flags like --parallel)
+    local _saved_quiet=${OPTS[opt_-q,--quiet]:-0}
     OPTS[opt_-q,--quiet]=1
     .zinit-self-update
+    OPTS[opt_-q,--quiet]=$_saved_quiet
 
     [[ $2 = restart ]] && \
         +zi-log "{msg2}Restarting the update with the new codebase loaded.{rst}"$'\n'


### PR DESCRIPTION
## Summary

- Fix `zinit update --parallel` falling through to the sequential code path since commit 95ba7d1d

## Root cause

Commit 95ba7d1d refactored `.zinit-update-or-status-all()` to silence `self-update` output during bulk updates by replacing `.zinit-self-update -q` with:

```zsh
local -A OPTS
OPTS[opt_-q,--quiet]=1
.zinit-self-update
```

The `local -A OPTS` declaration shadows the caller's `OPTS` associative array — the one populated by `.zinit-parse-opts` with `opt_-p,--parallel=1` when `--parallel` is passed. So the parallel check at line 3435 always evaluates to false.

## Fix

Save and restore the quiet key instead of re-declaring `OPTS` as local, preserving all caller flags (including `--parallel`):

```zsh
local _saved_quiet=${OPTS[opt_-q,--quiet]:-0}
OPTS[opt_-q,--quiet]=1
.zinit-self-update
OPTS[opt_-q,--quiet]=$_saved_quiet
```

Closes #772