### PR TITLE
feat: validate ice arguments

### DIFF
--- a/tests/ice-validation.zunit
+++ b/tests/ice-validation.zunit
@@ -139,7 +139,7 @@
     assert $state equals 0
     assert $output contains 'wait'
     assert $output contains 'x'
-    assert $output contains 'a'
+    assert $output contains 'Expected one of: a, b, c'
 }
 
 @test 'wait-invalid-suffix-d' {
@@ -271,6 +271,7 @@
 
 @test 'for-invalid-as' {
     run zinit for as'none' @zdharma-continuum/null
+    assert $state equals 0
     assert $output contains 'as'
     assert $output contains 'none'
 }

--- a/tests/ice-validation.zunit
+++ b/tests/ice-validation.zunit
@@ -1,0 +1,263 @@
+#!/usr/bin/env zunit
+# vim:ft=zsh:sw=2:sts=2:et:foldmarker={,}:foldmethod=marker
+#
+# Tests for ice value validation in .zinit-validate-ice()
+#
+
+@test 'as-valid-null' {
+    run zinit ice as'null'
+    assert $state equals 0
+}
+
+@test 'as-valid-command' {
+    run zinit ice as'command'
+    assert $state equals 0
+}
+
+@test 'as-valid-program' {
+    run zinit ice as'program'
+    assert $state equals 0
+}
+
+@test 'as-valid-completion' {
+    run zinit ice as'completion'
+    assert $state equals 0
+}
+
+@test 'as-empty' {
+    run zinit ice as''
+    assert $state equals 0
+}
+
+@test 'as-invalid-none' {
+    run zinit ice as'none'
+    assert $state equals 0
+    assert $output contains 'as'
+    assert $output contains 'none'
+    assert $output contains 'null'
+}
+
+@test 'as-invalid-banana' {
+    run zinit ice as'banana'
+    assert $state equals 0
+    assert $output contains 'as'
+    assert $output contains 'banana'
+}
+
+@test 'wait-valid-0' {
+    run zinit ice wait'0'
+    assert $state equals 0
+
+}
+
+@test 'wait-valid-3' {
+    run zinit ice wait'3'
+    assert $state equals 0
+
+}
+
+@test 'wait-valid-0a' {
+    run zinit ice wait'0a'
+    assert $state equals 0
+
+}
+
+@test 'wait-valid-3b' {
+    run zinit ice wait'3b'
+    assert $state equals 0
+
+}
+
+@test 'wait-valid-1c' {
+    run zinit ice wait'1c'
+    assert $state equals 0
+
+}
+
+@test 'wait-valid-bang' {
+    run zinit ice wait'!0'
+    assert $state equals 0
+
+}
+
+@test 'wait-valid-bang-a' {
+    run zinit ice wait'!2a'
+    assert $state equals 0
+
+}
+
+@test 'wait-valid-decimal' {
+    run zinit ice wait'3.5'
+    assert $state equals 0
+
+}
+
+@test 'wait-empty' {
+    run zinit ice wait
+    assert $state equals 0
+
+}
+
+@test 'wait-cond-command-exists' {
+    run zinit ice wait'[[ -n $commands[fzf] ]]'
+    assert $state equals 0
+
+}
+
+@test 'wait-cond-arithmetic' {
+    run zinit ice wait'(( $+commands[kubectl] ))'
+    assert $state equals 0
+
+}
+
+@test 'wait-cond-variable' {
+    run zinit ice wait'[[ -n $MY_VAR ]]'
+    assert $state equals 0
+
+}
+
+@test 'wait-cond-always-false' {
+    run zinit ice wait'[[ 1 = 0 ]]'
+    assert $state equals 0
+
+}
+
+@test 'wait-cond-single-command' {
+    run zinit ice wait'type fzf &>/dev/null'
+    assert $state equals 0
+
+}
+
+@test 'wait-invalid-suffix-x' {
+    run zinit ice wait'0x'
+    assert $state equals 0
+    assert $output contains 'wait'
+    assert $output contains 'x'
+    assert $output contains 'a'
+}
+
+@test 'wait-invalid-suffix-d' {
+    run zinit ice wait'3d'
+    assert $state equals 0
+    assert $output contains 'wait'
+    assert $output contains 'd'
+}
+
+@test 'wait-invalid-suffix-z' {
+    run zinit ice wait'1z'
+    assert $state equals 0
+    assert $output contains 'wait'
+    assert $output contains 'z'
+}
+
+@test 'wait-invalid-bang-suffix' {
+    run zinit ice wait'!2x'
+    assert $state equals 0
+    assert $output contains 'wait'
+    assert $output contains 'x'
+}
+
+@test 'wait-invalid-suffix-A' {
+    run zinit ice wait'0A'
+    assert $state equals 0
+    assert $output contains 'wait'
+    assert $output contains 'A'
+}
+
+@test 'depth-valid-1' {
+    run zinit ice depth'1'
+    assert $state equals 0
+
+}
+
+@test 'depth-valid-10' {
+    run zinit ice depth'10'
+    assert $state equals 0
+
+}
+
+@test 'depth-empty' {
+    run zinit ice depth''
+    assert $state equals 0
+
+}
+
+@test 'depth-invalid-text' {
+    run zinit ice depth'abc'
+    assert $state equals 0
+    assert $output contains 'depth'
+    assert $output contains 'abc'
+}
+
+@test 'depth-invalid-negative' {
+    run zinit ice depth'-1'
+    assert $state equals 0
+    assert $output contains 'depth'
+    assert $output contains '-1'
+}
+
+@test 'depth-invalid-decimal' {
+    run zinit ice depth'1.5'
+    assert $state equals 0
+    assert $output contains 'depth'
+    assert $output contains '1.5'
+}
+
+@test 'combined-all-valid' {
+    run zinit ice as'null' wait'0a' depth'1'
+    assert $state equals 0
+
+}
+
+@test 'combined-some-invalid' {
+    run zinit ice as'none' wait'0a'
+    assert $state equals 0
+    assert $output contains 'as'
+    assert $output contains 'none'
+}
+
+@test 'combined-all-invalid' {
+    run zinit ice as'none' wait'3x' depth'abc'
+    assert $state equals 0
+    assert $output contains 'as'
+    assert $output contains 'wait'
+    assert $output contains 'depth'
+}
+
+@test 'dash-prefix-valid' {
+    run zinit ice --as'null'
+    assert $state equals 0
+
+}
+
+@test 'dash-prefix-invalid' {
+    run zinit ice --as'none'
+    assert $state equals 0
+    assert $output contains 'as'
+    assert $output contains 'none'
+}
+
+@test 'as-invalid-NULL-case' {
+    run zinit ice as'NULL'
+    assert $state equals 0
+    assert $output contains 'as'
+    assert $output contains 'NULL'
+}
+
+@test 'as-colon-valid' {
+    run zinit ice as:null
+    assert $state equals 0
+}
+
+@test 'as-colon-invalid' {
+    run zinit ice as:none
+    assert $state equals 0
+    assert $output contains 'as'
+    assert $output contains 'none'
+}
+
+@test 'for-invalid-as' {
+    run zinit for as'none' @zdharma-continuum/null
+    assert $output contains 'as'
+    assert $output contains 'none'
+}

--- a/tests/ice-validation.zunit
+++ b/tests/ice-validation.zunit
@@ -35,6 +35,7 @@
     assert $output contains 'as'
     assert $output contains 'none'
     assert $output contains 'null'
+    assert $output contains 'program'
 }
 
 @test 'as-invalid-banana' {

--- a/tests/ice-validation.zunit
+++ b/tests/ice-validation.zunit
@@ -86,6 +86,12 @@
 
 }
 
+@test 'wait-valid-bang-no-suffix' {
+    run zinit ice wait'!3'
+    assert $state equals 0
+
+}
+
 @test 'wait-valid-decimal' {
     run zinit ice wait'3.5'
     assert $state equals 0
@@ -174,6 +180,13 @@
     run zinit ice depth'10'
     assert $state equals 0
 
+}
+
+@test 'depth-invalid-zero' {
+    run zinit ice depth'0'
+    assert $state equals 0
+    assert $output contains 'depth'
+    assert $output contains '0'
 }
 
 @test 'depth-empty' {

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -455,7 +455,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
                     }
                     ;;
                 (*)
-                    builtin print -Pr "${ZINIT[col-error]}Unknown protocol:%f%b ${ICE[proto]}."
+                    builtin print -Pr "${ZINIT[col-error]}Unknown protocol:%f%b ${ICE[proto]}. Expected one of: git, http, https, ssh, ftp, ftps, rsync."
                     return 1
             esac
 

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -2314,9 +2314,10 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
     if (( $+ZINIT_ICES[wait] )) && [[ -n ${ZINIT_ICES[wait]} ]]; then
         local w="${ZINIT_ICES[wait]#\!}"
         w="${w%%.[0-9]##}"
-        if [[ ${w%%[^0-9]*} = <-> && -n ${w##[0-9]##} && ${w##[0-9]##} != [abc] ]]; then
+        local suffix="${w##[0-9]##}"
+        if [[ ${w%%[^0-9]*} = <-> && -n $suffix && $suffix != [abc] ]]; then
             +zi-log "{warn}Warning{b-warn}:{rst} {ice}wait{rst} ice received invalid" \
-                "suffix letter {apo}\`{data}${w##[0-9]##}{apo}\`{rst}." \
+                "suffix letter {apo}\`{data}${suffix}{apo}\`{rst}." \
                 "Expected one of: {data2}a{rst}, {data2}b{rst}, {data2}c{rst}, or none."
         fi
     fi

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -2307,7 +2307,7 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
                 +zi-log "{warn}Warning{b-warn}:{rst} {ice}as{rst} ice received invalid" \
                     "value {apo}\`{data}${ZINIT_ICES[as]}{apo}\`{rst}." \
                     "Expected one of: {data2}null{rst}, {data2}command{rst}," \
-                    "{data2}completion{rst}."
+                    "{data2}program{rst}, {data2}completion{rst}."
                 ;;
         esac
     fi

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -2299,7 +2299,7 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
 # Validates ice values at parse time.
 # Warns (not errors) about invalid values — behavior is unchanged.
 .zinit-validate-ice() {
-    builtin setopt localoptions noksharrays extendedglob warncreateglobal typesetsilent noshortloops
+    builtin setopt localoptions noksharrays extendedglob typesetsilent noshortloops
     if (( $+ZINIT_ICES[as] )) && [[ -n ${ZINIT_ICES[as]} ]]; then
         case ${ZINIT_ICES[as]} in
             (command|program|null|completion) ;;
@@ -2307,7 +2307,7 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
                 +zi-log "{warn}Warning{b-warn}:{rst} {ice}as{rst} ice received invalid" \
                     "value {apo}\`{data}${ZINIT_ICES[as]}{apo}\`{rst}." \
                     "Expected one of: {data2}null{rst}, {data2}command{rst}," \
-                    "{data2}program{rst}, {data2}completion{rst}."
+                    "{data2}completion{rst}."
                 ;;
         esac
     fi
@@ -2321,7 +2321,7 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
         fi
     fi
     if (( $+ZINIT_ICES[depth] )) && [[ -n ${ZINIT_ICES[depth]} ]]; then
-        if [[ ${ZINIT_ICES[depth]} != <-> ]]; then
+        if [[ ${ZINIT_ICES[depth]} != <1-> ]]; then
             +zi-log "{warn}Warning{b-warn}:{rst} {ice}depth{rst} ice received invalid" \
                 "value {apo}\`{data}${ZINIT_ICES[depth]}{apo}\`{rst}." \
                 "Expected a positive integer."

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -2292,7 +2292,41 @@ $match[7]}:-${ZINIT[__last-formatter-code]}}}:+}}}//←→}
     fi
     (( $+ZINIT_ICES[configure] )) && ZINIT_ICES[configure]="${ZINIT_ICES[configure]}"
     (( $+ZINIT_ICES[make] )) && ZINIT_ICES[make]="${ZINIT_ICES[make]:-install}"
+    .zinit-validate-ice
     return retval
+} # ]]]
+# FUNCTION: .zinit-validate-ice [[[
+# Validates ice values at parse time.
+# Warns (not errors) about invalid values — behavior is unchanged.
+.zinit-validate-ice() {
+    builtin setopt localoptions noksharrays extendedglob warncreateglobal typesetsilent noshortloops
+    if (( $+ZINIT_ICES[as] )) && [[ -n ${ZINIT_ICES[as]} ]]; then
+        case ${ZINIT_ICES[as]} in
+            (command|program|null|completion) ;;
+            (*)
+                +zi-log "{warn}Warning{b-warn}:{rst} {ice}as{rst} ice received invalid" \
+                    "value {apo}\`{data}${ZINIT_ICES[as]}{apo}\`{rst}." \
+                    "Expected one of: {data2}null{rst}, {data2}command{rst}," \
+                    "{data2}program{rst}, {data2}completion{rst}."
+                ;;
+        esac
+    fi
+    if (( $+ZINIT_ICES[wait] )) && [[ -n ${ZINIT_ICES[wait]} ]]; then
+        local w="${ZINIT_ICES[wait]#\!}"
+        w="${w%%.[0-9]##}"
+        if [[ ${w%%[^0-9]*} = <-> && -n ${w##[0-9]##} && ${w##[0-9]##} != [abc] ]]; then
+            +zi-log "{warn}Warning{b-warn}:{rst} {ice}wait{rst} ice received invalid" \
+                "suffix letter {apo}\`{data}${w##[0-9]##}{apo}\`{rst}." \
+                "Expected one of: {data2}a{rst}, {data2}b{rst}, {data2}c{rst}, or none."
+        fi
+    fi
+    if (( $+ZINIT_ICES[depth] )) && [[ -n ${ZINIT_ICES[depth]} ]]; then
+        if [[ ${ZINIT_ICES[depth]} != <-> ]]; then
+            +zi-log "{warn}Warning{b-warn}:{rst} {ice}depth{rst} ice received invalid" \
+                "value {apo}\`{data}${ZINIT_ICES[depth]}{apo}\`{rst}." \
+                "Expected a positive integer."
+        fi
+    fi
 } # ]]]
 # FUNCTION: .zinit-pack-ice [[[
 # Remembers all ice-mods, assigns them to concrete plugin. Ice spec


### PR DESCRIPTION
# feat: validate ice arguments

## Summary

- Validate ice **values** at parse time (one-time check when `zinit ice` or inline ices are set)
- Invalid values produce a **warning** (not an error) so shells still load
- Catches common typos like `as'none'` instead of `as'null'`
- Works with both quote syntax (`as'null'`) and colon syntax (`as:null`)
- Improves the existing `proto` error message to list valid protocols

## Motivation

Ice **names** are validated — unknown ice names like `foo` produce an error. But ice
**values** are silently accepted regardless of validity. This leads to confusing
failures:

- `as'none'` silently falls through to default sourcing behavior instead of `as'null'`
- `%at-clone` in `atpull` runs as a literal command instead of substituting `atclone`

Fixes #766.

## Design Decisions

### Validate at ice-set time, not at shell load time

Validation happens in `.zinit-ice()`, which only runs when the user explicitly sets
ices (via `zinit ice ...` or inline with `zinit light`/`zinit load`). It does NOT run
on subsequent shell loads when ices are read from the `._zinit/` disk cache. This
means:

- **One-time cost**: The check runs once when ices are set, not on every shell startup
- **No startup breakage**: Cached ices from older zinit versions continue to work
- **Self-correcting**: Next time the user re-ices a plugin, validation runs

### Warning, not error

Invalid values produce a `{warn}Warning{b-warn}:` message via `+zi-log` but do NOT
abort. The plugin continues to load with the invalid value (which falls through to
default behavior, same as before). This avoids breaking existing configurations.

### Validated ices

| Ice | Valid values | Rationale |
|-----|-------------|-----------|
| `as` | `command`, `program`, `null`, `completion` | Finite, well-defined set. Common typo: `as'none'` instead of `as'null'` |
| `wait` | suffix letter `a`, `b`, `c`, or none | `wait'3d'` silently drops `d`; now warns |
| `depth` | positive integer | `depth'abc'` would fail at git clone time; now warns earlier |

**`proto`**: Already has an error guard in `zinit-install.zsh:423-460` that catches
ALL invalid protocols with `return 1`. Instead of adding a duplicate warning, the
error message was improved to list valid protocols: `"Expected one of: git, http, https, ssh, ftp, ftps, rsync."`

**Not validated:**

- `from` — intentionally accepts arbitrary hostnames as fallback
- `atpull` — complex syntax (`%atclone`, `!` prefix, raw commands) makes reliable validation impractical
- Condition strings in `wait` (e.g., `wait'[[ -n $commands[fzf] ]]'`) — arbitrary shell expressions, not possible to validate at parse time

## Out of Scope

- **Annex ice extensions**: Custom ices from zinit annexes (e.g., `zinit-annex-bin-gem-node`, `zinit-annex-binary-symlink`) are not validated. These are third-party extensions with their own value semantics. Adding validation for annex ices would require each annex to declare its valid values, which is a separate feature.

## Testing

41 tests covering:
- Valid and invalid `as` values (including `as:` colon syntax)
- Valid `wait` numeric formats, condition strings, and invalid suffix letters
- Valid and invalid `depth` values
- Combined ice validation, `--` prefix regression, and `for` syntax integration
