### PR TITLE
## Fix `extract` ice not working during `zinit update` for `from'gh-r'`

### DIFF
--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -842,6 +842,34 @@
   local hub="$ZBIN/hub"; assert "$hub" is_executable
   run "$hub" --version; assert $state equals 0
 }
+@test 'extract-bang update with gh-r' { # extract hook must run after download, not before
+  # Install bat with extract'!'
+  run zinit from'gh-r' extract'!' id-as'bat/extract-update' for @sharkdp/bat
+  assert $state equals 0
+  assert $output does_not_contain 'ERROR'
+  assert $output does_not_contain "doesn't exist"
+  local bat="$ZBIN/bat"; assert "$bat" is_executable
+
+  # Tamper with stored release info so zinit sees a "new" version
+  local plugin_dir="${ZINIT[PLUGINS_DIR]}/bat---extract-update"
+  echo "/fake/old/release" >! "$plugin_dir/._zinit/is_release"
+
+  # Remove extracted contents (keep ._zinit) to verify re-extraction
+  local f
+  for f in "$plugin_dir"/*(N); do
+    [[ "${f:t}" != "._zinit" ]] && command rm -rf "$f"
+  done
+
+  # Update — should re-download and extract the archive
+  run zinit update bat/extract-update
+  assert $state equals 0
+  assert $output does_not_contain 'ERROR'
+  assert $output does_not_contain "doesn't exist"
+
+  # Verify the binary was re-extracted and linked
+  assert "$bat" is_executable
+  run "$bat" --version; assert $state equals 0
+}
 
 #=============
 # Flaky Tests

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -3334,7 +3334,7 @@ if [[ -e ${${ZINIT[BIN_DIR]}}/zmodules/Src/zdharma/zplugin.so ]] {
 
 # e-!atpull-pre.
 @zinit-register-hook "make'!!'" hook:no-e-\!atpull-pre ∞zinit-make-ee-hook
-@zinit-register-hook "extract" hook:e-\!atpull-pre ∞zinit-extract-hook
+@zinit-register-hook "extract" hook:no-e-\!atpull-pre ∞zinit-extract-hook
 @zinit-register-hook "mv''" hook:no-e-\!atpull-pre ∞zinit-mv-hook
 @zinit-register-hook "cp''" hook:no-e-\!atpull-pre ∞zinit-cp-hook
 @zinit-register-hook "compile-plugin" hook:no-e-\!atpull-pre ∞zinit-compile-plugin-hook


### PR DESCRIPTION

### Problem

When using the `extract` ice (e.g. `extract'!'`) together with `from'gh-r'`, running `zinit update` downloads the new release archive but **never extracts it**. The destination directory ends up with a raw `.tar.gz` or `.zip` file instead of the extracted binary.

This means that after updating, the install appears broken: the expected executable is missing, replaced by an unextracted archive.

### Background — what PR #761 changed

PR #761 was about preventing **double extraction during installs**. Before that PR, two pieces of code were extracting the archive: an inline extraction call that ran right after the download, and a dedicated extraction hook that ran shortly afterward. The fix in PR #761 was to remove the inline call when the `extract` ice is set and let the hook handle extraction exclusively.

That assumption held for the install path, where the extraction hook is correctly wired to run *after* the archive is on disk.

### Why updates broke

During an update of a `from'gh-r'` release, the extraction hook was wired to a slightly different stage -- one that runs *before* the new archive is downloaded. So this hook would fire on stale state, with the old extracted files still sitting in the destination directory and no archive present. That was already buggy in its own right: with no archive to find, the hook didn't do anything useful. But the end result was still correct, because the inline extraction call that ran after the download would then extract the new archive properly.

PR #761 removed that inline extraction call (correctly, for the install path). On the update path, that didn't just remove redundant work: it removed the *only* thing that was actually producing a working extracted binary. The misplaced pre-download hook is still firing and spitting errors, but now nothing else runs to extract the freshly downloaded archive.

In short, the misplaced hook registration had always been there, but the inline call compensated for it. Removing the inline call exposed the pre-existing ordering bug on the update path.

### Fix

A one-line change in `zinit.zsh`: move the extraction hook's registration from the "before download" stage to the "after download" stage of the update flow. This restores the post-download ordering that the inline call used to provide, and keeps it consistent with PR #761's "the hook handles extraction exclusively" design.

### Test

Added a test in `tests/gh-r.zunit` that:

1. Installs a `from'gh-r'` release with `extract'!'`
2. Simulates a version change to trigger a re-download on update
3. Runs `zinit update`
4. Verifies the binary is properly extracted and executable after the update
