### PR TITLE
Document the `e-` / `no-e-` prefix on atpull hook-group names, and fix a mislabeled section header

### DIFF
--- a/zinit.zsh
+++ b/zinit.zsh
@@ -3326,13 +3326,21 @@ if [[ -e ${${ZINIT[BIN_DIR]}}/zmodules/Src/zdharma/zplugin.so ]] {
     }
 } # ]]]
 
-# !atpull-pre
+# Hook-group naming convention for atpull:
+#   hook:e-!atpull-*    — fires alongside the user's atpull'!...' ice
+#                          (runs before the pull)
+#   hook:no-e-!atpull-* — fires alongside the user's plain atpull'...' ice
+#                          (runs after the pull)
+# The 'e' stands for "exclamation" (the ! prefix on the user's atpull ice),
+# not "early".
+
+# e-!atpull-pre.
 @zinit-register-hook "-r/--reset" hook:e-\!atpull-pre ∞zinit-reset-hook
-# !atpull-post
+# e-!atpull-post.
 @zinit-register-hook "ICE[reset]" hook:e-\!atpull-post ∞zinit-reset-hook
 @zinit-register-hook "atpull'!'" hook:e-\!atpull-post ∞zinit-atpull-e-hook
 
-# e-!atpull-pre.
+# no-e-!atpull-pre.
 @zinit-register-hook "make'!!'" hook:no-e-\!atpull-pre ∞zinit-make-ee-hook
 @zinit-register-hook "extract" hook:e-\!atpull-pre ∞zinit-extract-hook
 @zinit-register-hook "mv''" hook:no-e-\!atpull-pre ∞zinit-mv-hook


### PR DESCRIPTION
### Background

In `zinit.zsh`, the section that registers the built-in `atpull` hooks uses a `hook:e-!atpull-*` / `hook:no-e-!atpull-*` naming scheme:

```zsh
@zinit-register-hook "-r/--reset" hook:e-\!atpull-pre  ∞zinit-reset-hook
@zinit-register-hook "extract"    hook:no-e-\!atpull-pre  ∞zinit-extract-hook
...
```

The meaning of the `e-` / `no-e-` prefixes is not documented anywhere — not in the README, not in `doc/HACKING.md`, not in the man page, and not in any comment. A reasonable reader confronted with `e-` will guess "early"; that guess is wrong.

The actual meaning is **exclamation**: the prefix indicates which "flavor" of the user-facing `atpull` ice the hook group is paired with.

- `hook:e-!atpull-*`  ↔ the user's `atpull'!...'` ice (the **with-exclamation** form, which runs *before* the pull).
- `hook:no-e-!atpull-*` ↔ the user's plain `atpull'...'` ice (the **no-exclamation** form, which runs *after* the pull).

The "before vs after the pull" timing isn't the meaning of the prefix; it's a *consequence* of the pairing, since `!` on the user's atpull ice is what selects the before-pull timing in the first place.

### Changes in this PR

1. **Add an explanatory comment block** at the top of the atpull hook registrations in `zinit.zsh`, recording the convention so the next reader doesn't have to reverse-engineer it from the dispatch logic.

2. **Fix a pre-existing mislabeled section header**: the line `# e-!atpull-pre.` sat directly above hooks that are registered at `hook:no-e-!atpull-pre` (not `hook:e-!atpull-pre`). Corrected to `# no-e-!atpull-pre.`. The previous siblings (`# !atpull-pre`, `# !atpull-post`) are also normalized to `# e-!atpull-pre.` and `# e-!atpull-post.` for consistency with the rest of the section labeling.

### Scope

Documentation/comment only; no behavior change.

---

### Appendix — speculative mental model (out of scope, not part of the PR)

While working on this PR, I have given some thought about how the hook-group names are organized. It's mostly speculation from my side and not part of this PR (this is why it is only included in the appendix).

The hook-group names related to atpull and atclone seem to use three prefixes:

| Prefix                  | Stage                                                                  |
|-------------------------|------------------------------------------------------------------------|
| `!<lifecycle>-pre/post` | Main action (extract, mv/cp, make, configure, user's atclone/atpull)   |
| `<lifecycle>-pre/post`  | Finalize (e.g. `compile-plugin`)                                       |
| `%<lifecycle>-pre/post` | Always — atpull only                                                   |

Inside atpull's main-action stage there's a further split: `e-!atpull-*` pairs with the user's `atpull'!'` ice, and `no-e-!atpull-*` pairs with plain `atpull`. atclone has no such split: there's just a single `!atclone-*` main-action group, since cloning has no pull-analogue with multiple phases.

If you have some more pieces of information, other interpretations, or corrections, please let me know. In any case, this appendix is not part of the PR. If we can gather more information on the naming conventions, I will be happy to include them in some compact code-comments in a future follow-up.


