### PR TITLE
fix: avoid apostrophe that breaks typeset -f round-trip of :zinit-tmp-subst-autoload

### DIFF
--- a/zinit.zsh
+++ b/zinit.zsh
@@ -397,7 +397,7 @@ builtin setopt noaliases
                         [[ -f $pth/$func ]] && { sel=$pth; break; }
                     }
                     if [[ -z $sel ]] {
-                        +zi-log '{u-warn}zinit{b-warn}:{error} Couldn''t find autoload function{ehi}:' \
+                        +zi-log '{u-warn}zinit{b-warn}:{error} Could not find autoload function{ehi}:' \
                             "{apo}\`{file}${func}{apo}\`{error} anywhere in {var}\$fpath{error}."
                             retval=1
                     } else {


### PR DESCRIPTION
## Summary

`:zinit-tmp-subst-autoload` contains an apostrophe written as a doubled quote inside a single-quoted string:

```zsh
+zi-log '{u-warn}zinit{b-warn}:{error} Couldn''t find autoload function{ehi}:' \
```

This parses fine when zinit is sourced, but the function does not survive a `typeset -f` round-trip. When zsh prints the loaded function back, the apostrophe in `Couldn't` is emitted unescaped inside a single-quoted string:

```zsh
+zi-log '{u-warn}zinit{b-warn}:{error} Couldn't find autoload function{ehi}:' "..."
```

Re-evaluating that output fails with unmatched-quote parse errors.

## Impact

Shell integrations that snapshot shell state with `typeset -f` and later `eval` it — for example Cursor and VS Code terminal state restore — fail when zinit is loaded. Because the quote parity goes odd at this line, the parse error is reported at whatever unrelated function happens to come later in the dump, producing confusing errors such as:

- `(eval):2480: parse error near `.join('\n')'`
- `command not found: dump_zsh_state`

This is painful to track down because the error never points at zinit itself.

## Fix

Reword the message to avoid the apostrophe entirely (`Couldn't` → `Could not`). One-line change, no behavior change.

This is the only in-string occurrence of the pattern in `zinit.zsh`; the other `''` matches are comments or genuine empty strings, which round-trip fine.

## Test plan

- [x] `zsh -n zinit.zsh` passes
- [x] Loaded zinit in an interactive shell, dumped all functions with `typeset -f`, and verified the dump now passes `zsh -n` and re-`eval`s cleanly (previously failed with an unmatched quote in `:zinit-tmp-subst-autoload`)
