### PR TITLE
docs: document compile execution order

### DIFF
--- a/README.md
+++ b/README.md
@@ -793,8 +793,18 @@ You may safely assume a given ice works with both plugins and snippets unless ex
 
 ### Order of Execution<a name="order-of-execution"></a>
 
-Order of execution of related Ice-mods: `atinit` -> `atpull!` -> `make'!!'` -> `mv` -> `cp` -> `make!` ->
-`atclone`/`atpull` -> `make` -> `(plugin script loading)` -> `src` -> `multisrc` -> `atload`.
+Order of execution of related Ice-mods: `atinit` -> `atpull!` -> `make'!!'` -> `mv` -> `cp` ->
+`[compile, unless nocompile is set]` -> `make!` -> `atclone`/`atpull` -> `make` -> `cmake` ->
+`[compile when nocompile'!']` -> `(plugin script loading)` -> `src` -> `multisrc` -> `atload`.
+
+Compilation runs in one of two phases. **By default** the `pick`-pointed files are compiled early –
+right after `cp`, and **before** the `atclone`/`atpull` hooks run – so files already present in the
+repository (or moved into place by `mv`/`cp`) are compiled automatically. A file that is **created by an
+`atclone` or `atpull` hook does not yet exist** at that point, so the default compile skips it. Passing
+the bang form `nocompile'!'` disables the early compile and **defers** compilation to a second phase that
+runs **after** `make''` and `atclone''`/`atpull''`, once the generated file exists (see the `nocompile`
+ice). Bare `nocompile` disables compilation entirely. `make'!!'` is the extra-early make phase before
+`mv`/`cp`/`extract` and the default compile phase.
 
 ## Zinit Commands<a name="zinit-commands"></a>
 

--- a/doc/zinit.1
+++ b/doc/zinit.1
@@ -1174,9 +1174,30 @@ T}
 .PP
 Order of execution of related Ice-mods: \f[C]atinit\f[R] ->
 \f[C]atpull!\f[R] -> \f[C]make\[aq]!!\[aq]\f[R] -> \f[C]mv\f[R] ->
-\f[C]cp\f[R] -> \f[C]make!\f[R] -> \f[C]atclone\f[R]/\f[C]atpull\f[R] ->
-\f[C]make\f[R] -> \f[C](plugin script loading)\f[R] -> \f[C]src\f[R] ->
+\f[C]cp\f[R] -> \f[C][compile, unless nocompile is set]\f[R] ->
+\f[C]make!\f[R] -> \f[C]atclone\f[R]/\f[C]atpull\f[R] ->
+\f[C]make\f[R] -> \f[C]cmake\f[R] ->
+\f[C][compile when nocompile\[aq]!\[aq]]\f[R] ->
+\f[C](plugin script loading)\f[R] -> \f[C]src\f[R] ->
 \f[C]multisrc\f[R] -> \f[C]atload\f[R].
+.PP
+Compilation runs in one of two phases. \f[B]By default\f[R] the
+\f[C]pick\f[R]-pointed files are compiled early - right after
+\f[C]cp\f[R], and \f[B]before\f[R] the
+\f[C]atclone\f[R]/\f[C]atpull\f[R] hooks run - so files already present
+in the repository (or moved into place by \f[C]mv\f[R]/\f[C]cp\f[R])
+are compiled automatically. A file that is \f[B]created by an
+\f[C]atclone\f[R] or \f[C]atpull\f[R] hook does not yet exist\f[R] at
+that point, so the default compile skips it. Passing the bang form
+\f[C]nocompile\[aq]!\[aq]\f[R] disables the early compile and
+\f[B]defers\f[R] compilation to a second phase that runs \f[B]after\f[R]
+\f[C]make\[aq]\[aq]\f[R] and
+\f[C]atclone\[aq]\[aq]\f[R]/\f[C]atpull\[aq]\[aq]\f[R], once the
+generated file exists (see the \f[C]nocompile\f[R] ice). Bare
+\f[C]nocompile\f[R] disables compilation entirely.
+\f[C]make\[aq]!!\[aq]\f[R] is the extra-early make phase before
+\f[C]mv\f[R]/\f[C]cp\f[R]/\f[C]extract\f[R] and the default compile
+phase.
 .SS Zinit Commands
 .PP
 Following commands are passed to \f[C]zinit ...\f[R] to obtain described


### PR DESCRIPTION
## Description

- add the default and deferred compile phases to the Ice-mod execution order
- explain when the bang form of nocompile is needed for files created by clone or pull hooks
- keep the generated man page in sync with the README

Closes #777

## Verification

- confirmed the documented order against the current hook registrations and compile conditions
- generated a temporary man page with Pandoc and rendered the tracked man page with mandoc
- parsed the README as GFM HTML
- ran `git diff --check`
