### PR TITLE
fix(install): prefer host-libc matching asset in gh-r selection

### DIFF
--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -67,6 +67,18 @@
   local bazel="$ZBIN/bazel"; assert "$bazel" is_executable
   run "$bazel" --version; assert $state equals 0
 }
+@test 'bicep' { # Domain-specific language (DSL) for deploying Azure resources declaratively
+  run zinit lbin'!bicep* -> bicep' for @Azure/bicep; assert $state equals 0
+  local bicep="$ZBIN/bicep"; assert "$bicep" is_executable
+  run "$bicep" --version; assert $state equals 0
+  # regression: the asset must match the host libc — musl only on musl systems
+  run ls "${ZINIT[PLUGINS_DIR]}/Azure---bicep"
+  if [[ $OSTYPE == *musl* || "$(command ldd --version 2>&1)" == *musl* ]]; then
+    assert "$output" matches 'musl'
+  else
+    assert "$output" does_not_match 'musl'
+  fi
+}
 @test 'blast' { # Blast is a simple tool for API load testing and batch jobs
   [[ $OSTYPE =~ 'darwin*' ]] && skip "on $os_type"
   run zinit for @dave/blast; assert $state equals 0

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1408,12 +1408,8 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
       fi
       ;;
     (Linux)
+      _sys='linux'
       [[ $OSTYPE == *musl* || "$(command ldd --version 2>&1)" == *musl* ]] && _clib="musl"
-      if [[ $_clib == musl ]]; then
-        _sys='musl*~^*linux*'
-      else
-        _sys='linux*~*musl'
-      fi
       ;;
     (MINGW* | MSYS* | CYGWIN* | Windows_NT)
       _sys='pc-windows-gnu'
@@ -1439,7 +1435,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
       +zi-log "{e} {b}gh-r{rst}Unsupported CPU: {obj}$_cpu{rst}"
       ;;
   esac
-  echo "${_sys};${_cpu};${_os}"
+  echo "${_sys};${_cpu};${_os};${_clib}"
 } # ]]]
 # FUNCTION: .zinit-get-latest-gh-r-url-part [[[
 # Gets version string of latest release of given Github
@@ -1506,6 +1502,17 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
         break
       fi
     done
+
+    # A musl asset is correct only when the host libc is musl — but runs after
+    # the CPU filter so a musl-only arch (e.g. only x86_64 build is musl) still resolves.
+    if (( $#list > 1 )); then
+      if [[ $parts[4] == musl ]]; then
+        filtered=( ${(M)list[@]:#(#i)*musl*} )
+      else
+        filtered=( ${list[@]:#(#i)*musl*} )
+      fi
+      (( $#filtered > 0 )) && list=( ${filtered[@]} )
+    fi
 
     if (( $#list > 1 )) { filtered=( ${list[@]:#(#i)*.(sha[[:digit:]]#|asc)} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} ); }
 

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1408,7 +1408,12 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
       fi
       ;;
     (Linux)
-      _sys='(musl|gnu)*~^*(unknown|)linux*'
+      [[ $OSTYPE == *musl* || "$(command ldd --version 2>&1)" == *musl* ]] && _clib="musl"
+      if [[ $_clib == musl ]]; then
+        _sys='musl*~^*linux*'
+      else
+        _sys='linux*~*musl'
+      fi
       ;;
     (MINGW* | MSYS* | CYGWIN* | Windows_NT)
       _sys='pc-windows-gnu'


### PR DESCRIPTION
## Problem

`zinit from'gh-r' for @Azure/bicep` on a glibc Linux host downloads `bicep-linux-musl-x64` instead of `bicep-linux-x64`.

The Linux pattern in `.zi::get-architecture` — `(musl|gnu)*~^*(unknown|)linux*` — *requires* a `musl` or `gnu` token in the asset name. Repos like Azure/bicep ship their glibc binary untagged (`bicep-linux-x64`), so the narrowing loop in `.zinit-get-latest-gh-r-url-part` discards it and the musl asset is the only survivor.

## Design

The libc preference must run **after** CPU narrowing, not before: many Rust tools (dua-cli, git-absorb, mcfly, navi, ripgrep, tre, xh, zoxide) ship their x86_64 Linux build *only* as musl while providing non-musl Linux builds solely for ARM. Filtering musl out at the OS stage strands selection on a wrong-architecture asset — or nothing.

Final shape (second commit):

- `.zi::get-architecture` uses a libc-neutral `linux` OS pattern and emits the detected host libc as a new fourth field — `gnu`, or `musl` when `OSTYPE` contains `musl` (Alpine zsh reports `linux-musl`) or `ldd --version` mentions musl.
- `.zinit-get-latest-gh-r-url-part` narrows by OS → CPU → uname → libc token (lowest priority), then an explicit post-CPU step drops musl assets on glibc hosts — or requires them on musl hosts — **only when alternatives survive**, so a musl-only architecture still resolves.

Selection outcomes on a glibc x86_64 host:

| Repo ships | Selected |
|---|---|
| untagged glibc + musl (bicep) | `bicep-linux-x64` |
| gnu + musl variants (tokei) | `tokei-x86_64-unknown-linux-gnu.tar.gz` |
| musl-only for x86_64 (ripgrep, dua, …) | the musl asset (only runnable build) |

On musl hosts the preference inverts, with the same fallback to whatever exists.

## Testing

- Full `tests/gh-r.zunit` suite: **151 passed / 0 failed / 7 skipped** (the 9 tests broken by the first-commit approach — dua, git-absorb, mcfly, navi, ripgrep, tokei, tre, xh, zoxide — all pass with the final design).
- Musl-host behavior verified on a real Alpine container: libc detected as `musl`, musl assets preferred, glibc-only repos still fall back.
- New `bicep` test installs end-to-end via gh-r and asserts the chosen asset matches the host libc on both glibc and musl systems.