### PR TITLE
ci(style): Add commit convention job to linting workflow

### DIFF
--- a/.github/workflows/linting.yaml
+++ b/.github/workflows/linting.yaml
@@ -10,6 +10,10 @@ on:
   workflow_dispatch:
 
 jobs:
+  commit:
+    name: "commit convention"
+    uses: zdharma-continuum/.github/.github/workflows/commit-job.yml@main
+    
   mdlint:
     name: markdown
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Description

This pull request adds a new workflow job to the GitHub Actions configuration to enforce commit message conventions.

**CI/CD improvements:**

* Added a `commit` job to `.github/workflows/linting.yaml` that uses the shared workflow `commit-job.yml` from `zdharma-continuum/.github` to check commit message conventions.

## Related Issue(s)

N/A

## Motivation and Context <!--- What problem does it solve? -->

N/A

## Usage examples

N/A

## How Has This Been Tested?

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [ ] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [ ] All new and existing tests passed.
- [ ] I have added tests to cover my changes.
- [ ] I have updated the documentation accordingly.
