### PR TITLE
fix(install): retry and authenticate github api downloads

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -99,4 +99,6 @@ jobs:
           make all install
 
       - name: "run ${{ matrix.zunit_test }} tests"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: zunit run ${{ matrix.zunit_flag }} tests/${{ matrix.zunit_test }}.zunit

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -666,6 +666,16 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     builtin emulate -LR zsh ${=${options[xtrace]:#off}:+-o xtrace}
     setopt localtraps extendedglob
 
+    # Authenticate GitHub API requests when a token is available — the anonymous
+    # limit of 60 requests/hour/IP is too low for e.g. CI runners. Restricted to
+    # api.github.com so the token is never sent to any other host.
+    local -a curl_auth wget_auth
+    local gh_token=${GITHUB_TOKEN:-$GH_TOKEN}
+    if [[ $url == https://api.github.com/* && -n $gh_token ]] {
+        curl_auth=( -H "Authorization: Bearer $gh_token" )
+        wget_auth=( --header="Authorization: Bearer $gh_token" )
+    }
+
     # Return file directly for file:// urls, wget doesn't support this schema
     if [[ "$url" =~ ^file:// ]] {
         local filepath=${url##file://}
@@ -682,12 +692,12 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
 
         if (( ${+commands[curl]} )); then
             if [[ -n $progress ]]; then
-                command curl --progress-bar -fSL "$url" 2> >(.zinit-single-line >&2) || return 1
+                command curl --retry 2 --retry-delay 1 "${curl_auth[@]}" --progress-bar -fSL "$url" 2> >(.zinit-single-line >&2) || return 1
             else
-                command curl -fsSL "$url" || return 1
+                command curl --retry 2 --retry-delay 1 "${curl_auth[@]}" -fsSL "$url" || return 1
             fi
         elif (( ${+commands[wget]} )); then
-            command wget ${${progress:--q}:#1} "$url" -O - || return 1
+            command wget --tries=3 "${wget_auth[@]}" ${${progress:--q}:#1} "$url" -O - || return 1
         elif (( ${+commands[lftp]} )); then
             command lftp -c "cat $url" || return 1
         elif (( ${+commands[lynx]} )); then
@@ -701,12 +711,12 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
     } else {
         if type curl 2>/dev/null 1>&2; then
             if [[ -n $progress ]]; then
-                command curl --progress-bar -fSL "$url" 2> >(.zinit-single-line >&2) || return 1
+                command curl --retry 2 --retry-delay 1 "${curl_auth[@]}" --progress-bar -fSL "$url" 2> >(.zinit-single-line >&2) || return 1
             else
-                command curl -fsSL "$url" || return 1
+                command curl --retry 2 --retry-delay 1 "${curl_auth[@]}" -fsSL "$url" || return 1
             fi
         elif type wget 2>/dev/null 1>&2; then
-            command wget ${${progress:--q}:#1} "$url" -O - || return 1
+            command wget --tries=3 "${wget_auth[@]}" ${${progress:--q}:#1} "$url" -O - || return 1
         elif type lftp 2>/dev/null 1>&2; then
             command lftp -c "cat $url" || return 1
         else


### PR DESCRIPTION
## Why

`gh-r | ubuntu` failed in run [33138613456](https://github.com/zdharma-continuum/zinit/actions/runs/33138613456/job/98744180297).

The failures don't track the code. Identical code failed and passed within one minute, the set of failing tests drifted from run to run, and `gh-r | macos` passed every time. Failing runs also finished in 49s instead of ~1m50s, which means downloads were erroring instantly rather than doing work. The failures cluster in contiguous alphabetical blocks because `zunit run --slice` slices deterministically, so a throttled worker takes out a whole block.

What actually happens: each gh-r test makes up to 3 unauthenticated requests (`api.github.com/.../releases/latest`, the HTML fallback pages, the asset itself). The suite alone blows through the anonymous API limit of 60 requests/hour/IP, so it chronically leans on HTML scraping. When a PR run races its merge push run, and both failure windows were exactly such pairs, per-IP abuse throttling kills whole slices.

## What

- `.zinit-download-file-stdout` now sends `Authorization: Bearer` from `GITHUB_TOKEN`/`GH_TOKEN`, but only for `https://api.github.com/` URLs, so tokens never reach asset CDNs, mirrors, or snippet hosts. It also retries transient HTTP errors: `curl --retry 2 --retry-delay 1`, `wget --tries=3`.
- `tests.yaml` exports `GITHUB_TOKEN` to the zunit step, raising the budget to 1,000 requests/hour per repo.

## Verification

- `zsh -n` and `zcompile` pass on `zinit-install.zsh`.
- `tests/gh-r.zunit@'jq'` and `@'dua'` pass with and without a token.
- With `GITHUB_TOKEN=dummy`, `api.github.com/rate_limit` fails with 401, which proves the header is sent. The `raw.githubusercontent.com` fetch and the snippet tests still pass under the dummy token, so the header doesn't leak to other hosts. With a real token the downloader reports `"limit": 5000`.
