### PR TITLE
feat(self-update): support -n/--no-pager

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,9 @@ Zinit can be updated to `self-update` and plugins to `update`.
 # Self update
 zinit self-update
 
+# Self update, without paging the changelog
+zinit self-update --no-pager
+
 # Plugin update
 zinit update
 
@@ -909,7 +912,7 @@ zinit [options] uncompile PLUGIN
 | Command                                                          | Description                                                                                                                                                                                                                                                                                                                           |
 | ---------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `module`                                                         | Manage binary Zsh module shipped with Zinit, see `zinit module help`.                                                                                                                                                                                                                                                                 |
-| `self-update`                                                    | Updates and compiles Zinit.                                                                                                                                                                                                                                                                                                           |
+| `self-update [-q] [-n]`                                          | Updates and compiles Zinit.<br> `-q` \| `--quiet` – turn off messages from the operation.<br> `-n` \| `--no-pager` – disable the use of the pager for the changelog.                                                                                                                                                                   |
 | `cd {plg-spec}`                                                  | Cd into plugin's directory. Also support snippets if fed with URL.                                                                                                                                                                                                                                                                    |
 | `edit {plg-spec}`                                                | Edit plugin's file with $EDITOR.                                                                                                                                                                                                                                                                                                      |
 | `changes {plg-spec}`                                             | View plugin's git log.                                                                                                                                                                                                                                                                                                                |
@@ -927,7 +930,7 @@ zinit [options] uncompile PLUGIN
 
 ## Updating Zinit and Plugins<a name="updating-zinit-and-plugins"></a>
 
-To update Zinit issue `zinit self-update` in the command line.
+To update Zinit issue `zinit self-update` in the command line. The changelog is shown in a pager – pass `-n`/`--no-pager` to print it to the terminal instead, or `-q`/`--quiet` to skip it.
 
 To update all plugins and snippets, issue `zinit update`. If you wish to update only a single plugin/snippet instead
 issue `zinit update NAME_OF_PLUGIN`. A list of commits will be shown:

--- a/_zinit
+++ b/_zinit
@@ -275,6 +275,7 @@ _zinit_run(){
 _zinit_self_update(){
   _arguments -A \
     '(-h --help)'{-h,--help}'[Show this help message]' \
+    '(-n --no-pager)'{-n,--no-pager}'[Disable the use of the pager]' \
     '(-q --quiet)'{-q,--quiet}'[Turn off messages from the operation]' \
     && ret=0
 } # ]]]

--- a/tests/_support/self_update_fixtures
+++ b/tests/_support/self_update_fixtures
@@ -1,0 +1,66 @@
+#!/usr/bin/env zsh
+
+# Fixtures for the `zinit self-update` pager regression tests (issue #632).
+#
+# make_self_update_behind_upstream leaves the sandbox clone exactly one
+# commit behind a scratch bare upstream. The fixture commit reuses HEAD's
+# tree, so the fast-forward pull done by `zinit self-update` moves only the
+# branch pointer: the unstaged diff the bootstrap applies stays intact and
+# no working-tree restore is needed, even when an assertion aborts the
+# test. Everything is offline and also works when the bootstrap clone is a
+# detached HEAD (CI pull_request checkouts), because the `main` branch and
+# its upstream are created here.
+
+typeset -g SU_FIXTURE_SUBJECT='chore: self-update pager regression fixture'
+
+make_self_update_behind_upstream() {
+  local bin="${ZINIT[BIN_DIR]}" up="${ZINIT[HOME_DIR]}/self-update-upstream.git"
+  local fixture_sha
+
+  # The bootstrap clone is depth=1. Complete it (origin is the local repo,
+  # so this is offline) to lift the shallow-repo restrictions from the
+  # local-path push below. From the second call on, the repo is already
+  # complete and this fails harmlessly.
+  command git -C "$bin" fetch --quiet --unshallow 2>/dev/null || true
+
+  # The sandbox tree is dirty (the bootstrap applies the unstaged diff), so
+  # ambient pull.rebase/autostash settings change what `git pull` does and
+  # prints: rebase mode refuses the dirty tree, autostash prints notices
+  # even under --quiet. Pin all three off in the clone so the pull is a
+  # silent fast-forward everywhere. --local keeps the writes inside the
+  # sandbox even where GIT_CONFIG points elsewhere.
+  command git -C "$bin" config --local pull.rebase false 2>/dev/null || true
+  command git -C "$bin" config --local merge.autostash false 2>/dev/null || true
+  command git -C "$bin" config --local rebase.autoStash false 2>/dev/null || true
+
+  fixture_sha=$(command git -C "$bin" -c user.name=zunit -c user.email=zunit@localhost \
+    commit-tree 'HEAD^{tree}' -p HEAD -m "$SU_FIXTURE_SUBJECT") || true
+  [[ -n $fixture_sha ]] || fail 'fixture: commit-tree failed'
+
+  command rm -rf -- "$up"
+  command git -c init.defaultBranch=main init --quiet --bare "$up" 2>/dev/null \
+    || fail 'fixture: git init failed'
+  command git -C "$bin" push --quiet "$up" "${fixture_sha}:refs/heads/main" \
+    || fail 'fixture: git push failed'
+
+  # remove+add also replaces the narrowed single-branch fetch refspec of
+  # the depth=1 bootstrap clone with the wildcard one that the `git pull`
+  # inside self-update relies on.
+  command git -C "$bin" remote remove origin 2>/dev/null || true
+  command git -C "$bin" remote add origin "$up" || fail 'fixture: remote add failed'
+  command git -C "$bin" fetch --quiet origin || fail 'fixture: fetch failed'
+
+  # Covers detached-HEAD sandboxes and avoids the non-main-branch warning
+  # that self-update prints even under --quiet.
+  command git -C "$bin" checkout --quiet -B main || fail 'fixture: checkout failed'
+  command git -C "$bin" branch --quiet --set-upstream-to=origin/main main \
+    || fail 'fixture: set-upstream failed'
+}
+
+restore_self_update_origin() {
+  local bin="${ZINIT[BIN_DIR]}"
+  [[ -n $GIT_REPO ]] || return 0
+  command git -C "$bin" remote remove origin 2>/dev/null || true
+  command git -C "$bin" remote add origin "file://${GIT_REPO:A}" 2>/dev/null || true
+  command rm -rf -- "${ZINIT[HOME_DIR]}/self-update-upstream.git"
+}

--- a/tests/commands.zunit
+++ b/tests/commands.zunit
@@ -11,6 +11,7 @@
 @setup {
   typeset -gx HOME="$zi_test_dir"
   typeset -gx ZBIN="$zi_test_dir/polaris/bin"
+  load "${PWD}/tests/_support/self_update_fixtures"
 }
 
 @test 'help' {
@@ -77,6 +78,7 @@
     run zinit self-update $flag
     assert $output contains 'self-update'
     assert $output contains '--quiet'
+    assert $output contains '--no-pager'
     assert $state equals 1
   done
 }
@@ -92,6 +94,41 @@
   assert $output contains 'Incorrect options given'
   assert $output contains '--foo'
   assert $state equals 1
+}
+@test 'self-update --no-pager / -n accepted when up to date' {
+  for flag in '--no-pager' '-n'; do
+    run zinit self-update $flag
+    assert $output contains 'Already up to date'
+    assert $state equals 0
+  done
+}
+@test 'self-update pages the commit list through less by default' {
+  less() { command cat > /dev/null; builtin print -- 'PAGER-INVOKED'; }
+  make_self_update_behind_upstream
+  run zinit self-update
+  assert $output contains 'PAGER-INVOKED'
+  assert $output does_not_contain $SU_FIXTURE_SUBJECT
+  assert $state equals 0
+}
+@test 'self-update --no-pager / -n prints the commit list without the pager' {
+  less() { command cat > /dev/null; builtin print -- 'PAGER-INVOKED'; }
+  for flag in '--no-pager' '-n'; do
+    make_self_update_behind_upstream
+    run zinit self-update $flag
+    assert $output contains $SU_FIXTURE_SUBJECT
+    assert $output does_not_contain 'PAGER-INVOKED'
+    assert $state equals 0
+  done
+}
+@test 'self-update --quiet / -q skips the pager when behind upstream' {
+  less() { command cat > /dev/null; builtin print -- 'PAGER-INVOKED'; }
+  for flag in '--quiet' '-q'; do
+    make_self_update_behind_upstream
+    run zinit self-update $flag
+    assert $output is_empty
+    assert $state equals 0
+  done
+  restore_self_update_origin
 }
 @test 'set-debug' {
   ZINIT+=(DEBUG 'true')

--- a/zinit-autoload.zsh
+++ b/zinit-autoload.zsh
@@ -2005,7 +2005,7 @@ print -- "\nAvailable ice-modifiers:\n\n${ice_order[*]}"
             builtin cd -q "$ZINIT[BIN_DIR]" \
             && lines=( ${(f)"$(command git log --color --date=short --pretty=format:'%Cgreen%cd %h %Creset%s %Cred%d%Creset || %b' ..@\{u\})"} )
             # Use '..@{u}' which refers to the configured upstream branch, instead of '..origin/HEAD'
-            if (( ${#lines} > 0 )); then
+            if (( ${#lines} > 0 && ! OPTS[opt_-q,--quiet] )); then
                 # Remove the (origin/main ...) segments, to expect only tags to appear
                 lines=( "${(S)lines[@]//\(([,[:blank:]]#(origin|HEAD|master|main)[^a-zA-Z]##(HEAD|origin|master|main)[,[:blank:]]#)#\)/}" )
                 # Remove " ||" if it ends the line (i.e. no additional text from the body)

--- a/zinit.zsh
+++ b/zinit.zsh
@@ -2713,7 +2713,7 @@ zinit() {
         light         "--help|-b|-h"
         snippet       "--command|--force|--help|-f|-h|-x"
         times         "--help|-h|-m|-s"
-        self-update   "--help|--quiet|-h|-q"
+        self-update   "--help|--no-pager|--quiet|-h|-n|-q"
         unload        "--help|--quiet|-h|-q"
         update        "--all|--help|--no-pager|--parallel|--plugins|--quiet|--reset|--snippets|--urge|--verbose|-L|-a|-h|-n|-p|-q|-r|-s|-u|-v"
         version       ""


### PR DESCRIPTION
## Description

Re-add the `-n`/`--no-pager` flag to `zinit self-update` and honor `--quiet` in the changelog display.

- `zinit.zsh`: add `--no-pager`/`-n` to self-update's allowed-flag list. The option map already defines the flag globally and `.zinit-pager` already honors `OPTS[opt_-n,--no-pager]`, so parsing, the `-h` help listing, and the incorrect-options error all pick it up from this one line.
- `zinit-autoload.zsh`: skip the commit-list display (line munging + the `.zinit-pager` pipe) under `--quiet`. `self-update -q` — and the quiet `.zinit-self-update` call made by `update --all` — can no longer hang in `less`. As a deliberate consequence, those quiet paths no longer print zinit's own commit list; that display was the hang.
- `_zinit`: offer `-n`/`--no-pager` in the `self-update` completion.
- `tests/commands.zunit` + new `tests/_support/self_update_fixtures`: regression coverage (see below).
- `README.md`: document the flag.

## Related Issue(s)

Closes #632. History: #633 was the first attempt at this flag; #762 later added the option-parsing plumbing for `self-update` (`-q`, `-h`, unknown-flag rejection) but not `--no-pager`, and left the changelog display un-quieted.

## Motivation and Context <!--- What problem does it solve? -->

When the checkout is behind upstream, `zinit self-update` pipes the commit list into `less` unconditionally and `-q` does not prevent it, so scripted/CI/bulk updates block until `q` is pressed (#632).

## Usage examples

```zsh
zinit self-update --no-pager   # print the changelog to the terminal instead of paging it
zinit self-update -q           # fully silent, never pages
```

```console
$ zinit self-update -h
HELP FOR `self-update` subcommand – the available options:
-h,--help       →  Show this help message.
-n,--no-pager   →  Disable the use of the pager.
-q,--quiet      →  Turn off any (or: almost-any) messages from the operation.
```

## How Has This Been Tested?

- Four new zunit tests in `tests/commands.zunit` (file passes 18/18 locally, macOS): the flag is accepted when up to date; the default behind-upstream path still pages (a one-line `less()` shadow detects pager invocation); `--no-pager`/`-n` prints the commit list with no pager; `--quiet`/`-q` produces no output at all when behind upstream.
- The behind-upstream state comes from the new `tests/_support/self_update_fixtures`: a scratch bare upstream one commit ahead, built with `git commit-tree` from HEAD's own tree, so the fast-forward pull moves only the branch pointer and the sandbox working tree (including the bootstrap-applied unstaged diff) is never touched — no restore needed even when an assertion aborts. Fully offline, and works on detached-HEAD checkouts (CI `pull_request`) because the fixture creates the `main` branch and its upstream itself. Ambient `pull.rebase`/autostash settings are pinned off `--local` in the sandbox clone so the pull's behavior and output are stable across machines.
- `zsh -n` over every `*.zsh` and `_zinit`; `zcompile` on the touched sources.
- Manual: `self-update -h` lists the flag, `self-update --bogus` lists it as allowed, and tab completion offers it (verified with a `zsh/zpty` harness).

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation change
- [x] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [x] All new and existing tests passed.
- [x] I have added tests to cover my changes.
- [x] I have updated the documentation accordingly.
