### PR TITLE
feat(ziextract): support zst archive format

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -73,12 +73,13 @@ jobs:
             ninja-build \
             pkg-config \
             xz-utils \
-            zsh
+            zsh \
+            zstd
 
       - name: "install dependencies via brew"
         id: install-deps
         run: |
-          brew install --quiet --force --overwrite autoconf automake binutils byacc coreutils curl gettext gnu-sed jemalloc libevent libtool libuv lua lua@5.4 make ninja parallel pkg-config texinfo unzip xz zsh
+          brew install --quiet --force --overwrite autoconf automake binutils byacc coreutils curl gettext gnu-sed jemalloc libevent libtool libuv lua lua@5.4 make ninja parallel pkg-config texinfo unzip xz zsh zstd
           brew unlink ncurses && brew link --force ncurses
 
       - name: "checkout zdharma-continuum/zunit"

--- a/tests/gh-r.zunit
+++ b/tests/gh-r.zunit
@@ -593,6 +593,18 @@
   local onefetch="$ZBIN/onefetch"; assert "$onefetch" is_executable
   run $onefetch --version; assert $state equals 0
 }
+@test 'ollama' { # Get up and running with large language models
+  # The suite's only `.tar.zst' release asset. darwin ships a `.tgz', so the
+  # zstd extraction path is reachable on Linux only. bpick drops the
+  # accelerator builds (mlx/rocm/jetpack), which sort ahead of the plain one.
+  [[ $OSTYPE =~ 'darwin*' ]] && skip "no .tar.zst asset on $os_type"
+  (( ${+commands[zstd]} )) || skip 'zstd not installed'
+  run zinit id-as lbin'!ollama' bpick'^*(mlx|rocm|jetpack)*' for @ollama/ollama; assert $state equals 0
+  assert $output does_not_contain 'ERROR'
+  assert $output does_not_contain "didn't recognize archive type"
+  local ollama="$ZBIN/ollama"; assert "$ollama" is_executable
+  run "$ollama" --version; assert $state equals 0
+}
 @test 'ouch' { # Painless compression and decompression for your terminal
   run zinit for @ouch-org/ouch; assert $state equals 0
   local ouch="$ZBIN/ouch"; assert "$ouch" is_executable

--- a/zinit-install.zsh
+++ b/zinit-install.zsh
@@ -1496,7 +1496,7 @@ builtin source "${ZINIT[BIN_DIR]}/zinit-side.zsh" || {
         +zi-log "{e} {b}gh-r{rst}: {ice}bpick{rst} ice found no release assets To fix, modify the {ice}bpick{rst} glob pattern {glob}$bpick{rst}"
       fi
     else
-      local junk='*((s(ha256|ig|um)|386|asc|md5|txt|vsix)*|(apk|b3|deb|json|pkg|rpm|sh|zst)(#e))';
+      local junk='*((s(ha256|ig|um)|386|asc|md5|txt|vsix)*|(apk|b3|deb|json|pkg|rpm|sh)(#e))|*.pkg.tar.zst|(*.zst~*.tar.zst)';
       # print -l ${${(m@)list:#${~junk}}:t}
       filtered=( ${(m@)list:#(#i)${~junk}} ) && (( $#filtered > 0 )) && list=( ${filtered[@]} )
     fi
@@ -1553,7 +1553,7 @@ ziextract() {
         # First try known file extensions
         local -aU files
         integer ret_val
-        files=( (#i)**/*.(zip|rar|7z|tgz|tbz|tbz2|tar.gz|tar.bz2|tar.7z|txz|tar.xz|gz|xz|tar|dmg|exe)~(*/*|.(_backup|git))/*(-.DN) )
+        files=( (#i)**/*.(zip|rar|7z|tgz|tbz|tbz2|tar.gz|tar.bz2|tar.7z|txz|tar.xz|tar.zst|gz|xz|tar|dmg|exe)~(*/*|.(_backup|git))/*(-.DN) )
         for file ( $files ) {
             ziextract "$file" $opt_move $opt_move2 $opt_norm $opt_nobkp ${${${#files}:#1}:+--nobkp}
             ret_val+=$?
@@ -1663,6 +1663,9 @@ ziextract() {
             ;;
         ((#i)*.tar.7z|(#i)*.t7z)
             →zinit-extract() { →zinit-check 7z "$file" || return 1; command 7z x -so "$file" | command tar --no-same-owner -xf -; }
+            ;;
+        ((#i)*.tar.zst)
+            →zinit-extract() { →zinit-check zstd "$file" || return 1; command zstd -dc "$file" | command tar --no-same-owner -xf -; }
             ;;
         ((#i)*.tar)
             →zinit-extract() { →zinit-check tar "$file" || return 1; command tar --no-same-owner -xf "$file"; }


### PR DESCRIPTION
## Description

Support extraction of `zst` archive format 

## Related Issue(s)

Closes #817

## Motivation and Context <!--- What problem does it solve? -->

[Initial discussion](https://github.com/zdharma-continuum/zinit/discussions/784)

## Usage examples

```zsh
# macOS
zinit from"gh-r" id-as lbin'!ollama' for @ollama/ollama
# linux
zinit id-as lbin'!ollama' bpick'^*(mlx|rocm|jetpack)*' for @ollama/ollama
```

## How Has This Been Tested?

Zunit tests added

## Types of changes <!--- Put an `x` in all the boxes that apply. -->

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Documentation change
- [X] New feature (non-breaking change which adds functionality)

## Checklist: <!--- Add an `x` in all the boxes that apply. -->

- [X] All new and existing tests passed.
- [X] I have added tests to cover my changes.
- [X] I have updated the documentation accordingly.
