### PR TITLE
fix(completion): balance paren and escape $PATH in snippet --command spec

### DIFF
--- a/_zinit
+++ b/_zinit
@@ -282,7 +282,7 @@ _zinit_self_update(){
 # FUNCTION: _zinit_snippet [[[
 _zinit_snippet(){
   _arguments -A \
-    '(-c --command)'{-c,--command}'[Load the snippet as a command (i.e., make executable and apend to $PATH])' \
+    '(-c --command)'{-c,--command}'[Load the snippet as a command (i.e., make executable and apend to \$PATH)]' \
     '(-f --force)'{-f,--force}'[Force new download of the snippet file]' \
     '(-h --help)'{-h,--help}'[Show this help message]'
   _arguments - snippet '*::snippet:__zinit_installed_snippets' && ret=0


### PR DESCRIPTION
### Issue for this PR

Closes #820

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Fixes the `_zinit_snippet --command` option spec in the shipped `_zinit`
completion:

```
-    '(-c --command)'{-c,--command}'[Load the snippet as a command (i.e., make executable and apend to $PATH])' \
+    '(-c --command)'{-c,--command}'[Load the snippet as a command (i.e., make executable and apend to \$PATH)]' \
```

Two defects on one line, one fix:

1. The `(i.e., ...` parenthesis was closed only *after* the description's
   `]`. comparguments rejects `]` at paren-depth 1, so the spec failed to
   parse on **every** `zinit <TAB>` with
   `_arguments:comparguments:327: invalid option definition`, leaving
   zinit with no completion at all. Closing the paren before the bracket
   (`)]`) repairs parsing.
2. The bare `$PATH` would expand to the user's colon-laden PATH value at
   match time; escaping it (`\$PATH`, same convention as the existing
   `\$EDITOR`/`\$FPATH` specs in this file) keeps the help text literal.

Related issue #820 has the full spec matrix: `$PATH])` errors,
`\$PATH))` errors, `\$PATH])` errors, `\$PATH)]` completes cleanly.

No overlapping open PRs found (searched: snippet completion _arguments
spec). The `apend` typo on the same line is deliberately left untouched to
keep this change minimal.

### How did you verify your code works?

- `zsh -n _zinit` syntax check passes.
- The exact repaired spec text was exercised through real `compinit` +
  TAB completion in isolated shells: completing `zinit rec` with the
  repaired line offers completions with zero `comparguments` diagnostics,
  while the as-shipped line reproduces the reported error in the same
  vehicle.
- Cross-checked the branch diff against upstream `main`: exactly this one
  hunk, no unrelated changes.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR
