### PR TITLE
fix(completion): add missing _zinit_* handlers, drop orphans, fix labels

### DIFF
--- a/_zinit
+++ b/_zinit
@@ -18,6 +18,7 @@ __zinit_commands(){
     'cd:Go to a plugin or snippet direcorty'
     'cdclear:Clear the compdef replay list'
     'cdisable:Disable completions'
+    'cdlist:Show compdef replay list'
     'cdreplay:Replay compdef list'
     'cenable:Enable completions'
     'changes:View plugins git log'
@@ -143,6 +144,10 @@ _zinit_cdclear(){
 # FUNCTION: _zinit_cdisable [[[
 _zinit_cdisable(){
   _message 'Press enter to disable completions' && ret=0
+} # ]]]
+# FUNCTION: _zinit_cdlist [[[
+_zinit_cdlist(){
+  _message 'List of compdef replays' && ret=0
 } # ]]]
 # FUNCTION: _zinit_cdreplay [[[
 _zinit_cdreplay(){

--- a/_zinit
+++ b/_zinit
@@ -144,10 +144,6 @@ _zinit_cdclear(){
 _zinit_cdisable(){
   _message 'Press enter to disable completions' && ret=0
 } # ]]]
-# FUNCTION: _zinit_cdlist [[[
-_zinit_cdlist(){
-  _message 'List of compdef replays' && ret=0
-} # ]]]
 # FUNCTION: _zinit_cdreplay [[[
 _zinit_cdreplay(){
   _arguments -A \
@@ -175,7 +171,7 @@ _zinit_compinit(){
 _zinit_completions(){
   _message "Display a list of completions" && ret=0
 } # ]]]
-# FUNCTION: _zinit_create [[[
+# FUNCTION: _zinit_compile [[[
 _zinit_compile(){
   _arguments \
     '(-h --help)'{-h,--help}'[Show this help message]' \
@@ -198,8 +194,8 @@ _zinit_creinstall(){
 _zinit_csearch(){
   ret=0
 } # ]]]
-# FUNCTION: _zinit_cunistall [[[
-_zinit_cunistall(){
+# FUNCTION: _zinit_cuninstall [[[
+_zinit_cuninstall(){
   _arguments - installed '*::installed:__zinit_installed' && ret=0
 } # ]]]
 # FUNCTION: _zinit_delete [[[
@@ -236,13 +232,9 @@ _zinit_env_whitelist(){
 _zinit_glance(){
   _arguments - installed '1:installed:__zinit_installed' && ret=0
 } # ]]]
-# FUNCTION: _zinit_list [[[
-_zinit_list(){
-  _message 'Hit enter to list the defined key bindings replay' && ret=0
-} # ]]]
-# FUNCTION: _zinit_loaded [[[
-_zinit_loaded(){
-  _message 'Hit enter to list the defined key bindings replay' && ret=0
+# FUNCTION: _zinit_help [[[
+_zinit_help(){
+  _message 'Hit enter for usage information' && ret=0
 } # ]]]
 # FUNCTION: _zinit_man [[[
 _zinit_man(){
@@ -252,6 +244,10 @@ _zinit_man(){
 _zinit_module(){
   _arguments \
     - subcommand '*::subcommand:(build help info)' && ret=0
+} # ]]]
+# FUNCTION: _zinit_plugins [[[
+_zinit_plugins(){
+  _message 'Hit enter to list the status of all installed plugins' && ret=0
 } # ]]]
 # FUNCTION: _zinit_recall [[[
 _zinit_recall(){
@@ -287,6 +283,14 @@ _zinit_snippet(){
     '(-h --help)'{-h,--help}'[Show this help message]'
   _arguments - snippet '*::snippet:__zinit_installed_snippets' && ret=0
 } # ]]]
+# FUNCTION: _zinit_snippets [[[
+_zinit_snippets(){
+  _message 'Hit enter to list the status of all installed snippets' && ret=0
+} # ]]]
+# FUNCTION: _zinit_srv [[[
+_zinit_srv(){
+  _message 'Hit enter to control a service' && ret=0
+} # ]]]
 # FUNCTION: _zinit_status [[[
 _zinit_status(){
   _message 'Display current status of Zinit' && ret=0
@@ -315,6 +319,10 @@ _zinit_uncompile(){
       '*::installed:__zinit_installed' \
     && ret=0
 } # ]]]
+# FUNCTION: _zinit_uninstall [[[
+_zinit_uninstall(){
+  _message 'Hit enter to uninstall a formula or cask' && ret=0
+} # ]]]
 # FUNCTION: _zinit_unload [[[
 _zinit_unload(){
   _arguments -A \
@@ -338,7 +346,15 @@ _zinit_update(){
   - set2 \
       '1:installed:__zinit_installed'
 } # ]]]
-# FUNCTION: _zunit_load [[[
+# FUNCTION: _zinit_version [[[
+_zinit_version(){
+  _message 'Hit enter to print the version numbers of Zinit' && ret=0
+} # ]]]
+# FUNCTION: _zinit_zstatus [[[
+_zinit_zstatus(){
+  _message 'Hit enter to show the overall Zinit status' && ret=0
+} # ]]]
+# FUNCTION: _zinit_load [[[
 _zinit_load() {
   _message 'Hit enter to list the defined key bindings replay' && ret=0
 } # ]]]


### PR DESCRIPTION
### Issue for this PR

Related to #820 (same file, adjacent defect — no separate issue filed: the repo has no CONTRIBUTING.md, no contributing guide, and no PR template mandating issue-first).

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Completes the `_zinit_*` handler coverage in the shipped `_zinit` completion. The dispatcher maps each subcommand to `_zinit_${cmd//-/_}` via `_call_function`, but 7 listed subcommands had no handler, so `zinit help<TAB>`, `zinit version<TAB>`, etc. fell through to `a completion function is not defined for command or alias`:

- New handlers: `_zinit_help`, `_zinit_plugins`, `_zinit_snippets`, `_zinit_srv`, `_zinit_uninstall`, `_zinit_version`, `_zinit_zstatus` (minimal `_message` stubs matching neighbours like `_zinit_compiled`).
- Rename `_zinit_cunistall` → `_zinit_cuninstall`: the command is `cuninstall`, which the dispatcher maps to `_zinit_cuninstall`; the old typo'd name was unreachable. Body unchanged (it already completes installed plugins/snippets — correct for "Uninstall completions").
- Delete 2 orphan helpers no command maps to: `_zinit_list`, `_zinit_loaded` (dead copy-paste stubs carrying bindkeys text; bare `list`/`loaded` are not runtime commands — the real ones are `list-plugins`/`list-snippets` — and nothing references these functions).
- Restore `_zinit_cdlist` (verbatim) and add the missing `'cdlist:Show compdef replay list'` command-table entry: `cdlist` IS a real runtime command (zinit.zsh, README, man page) whose handler is reachable by typing the full word, so deleting it regressed `zinit cdlist <TAB>` to the not-defined error (caught in review).
- Fix 2 mislabeled `# FUNCTION:` comments: `_zinit_create` above `_zinit_compile()`, `_zunit_load` above `_zinit_load()`.

No overlapping open PRs (searched: completion handler not defined).

### How did you verify your code works?

- Programmatic audit of the patched file: all 43 subcommands in `__zinit_commands` (42 + restored `cdlist`) resolve to a defined `_zinit_*` function; zero orphans remain.
- `zsh -n _zinit` syntax check passes.
- All 11 new/restored/renamed/relabeled handlers executed in `zsh -f` with the completion builtins stubbed: every one returns 0, zero stderr.
- Branch diff against upstream `main`: only `_zinit`, single concern.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR